### PR TITLE
feat: Add TTS fallback mechanism for VPN scenarios

### DIFF
--- a/src/VirtualAssistant.Voice/Configuration/PiperOptions.cs
+++ b/src/VirtualAssistant.Voice/Configuration/PiperOptions.cs
@@ -1,0 +1,33 @@
+namespace Olbrasoft.VirtualAssistant.Voice.Configuration;
+
+/// <summary>
+/// Configuration options for Piper TTS provider.
+/// </summary>
+public sealed class PiperOptions
+{
+    public const string SectionName = "Piper";
+
+    /// <summary>
+    /// Path to the piper binary. If not set, assumes 'piper' is in PATH.
+    /// </summary>
+    public string PiperPath { get; set; } = "piper";
+
+    /// <summary>
+    /// Path to the ONNX model file.
+    /// Default: ~/virtual-assistant/piper-voices/cs/cs_CZ-jirka-medium.onnx
+    /// </summary>
+    public string ModelPath { get; set; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        "virtual-assistant", "piper-voices", "cs", "cs_CZ-jirka-medium.onnx");
+
+    /// <summary>
+    /// Path to the model config file (.json). Optional.
+    /// </summary>
+    public string? ConfigPath { get; set; }
+
+    /// <summary>
+    /// Length scale for speech rate. Lower = faster, higher = slower.
+    /// Default: 1.0 (normal speed)
+    /// </summary>
+    public float? LengthScale { get; set; }
+}

--- a/src/VirtualAssistant.Voice/Configuration/TtsFallbackOptions.cs
+++ b/src/VirtualAssistant.Voice/Configuration/TtsFallbackOptions.cs
@@ -1,0 +1,30 @@
+namespace Olbrasoft.VirtualAssistant.Voice.Configuration;
+
+/// <summary>
+/// Configuration options for TTS fallback behavior.
+/// </summary>
+public sealed class TtsFallbackOptions
+{
+    public const string SectionName = "TtsFallback";
+
+    /// <summary>
+    /// Enable automatic fallback to Piper when Edge TTS is unavailable.
+    /// </summary>
+    public bool EnableFallback { get; set; } = true;
+
+    /// <summary>
+    /// Check location/VPN status to proactively switch to fallback.
+    /// </summary>
+    public bool CheckLocation { get; set; } = true;
+
+    /// <summary>
+    /// If true, silently skip TTS when all providers fail instead of throwing.
+    /// </summary>
+    public bool SilentOnFailure { get; set; } = true;
+
+    /// <summary>
+    /// Check Edge TTS availability before each request.
+    /// If false, only checks on startup or after failures.
+    /// </summary>
+    public bool AlwaysCheckAvailability { get; set; } = false;
+}

--- a/src/VirtualAssistant.Voice/Services/EdgeTtsProvider.cs
+++ b/src/VirtualAssistant.Voice/Services/EdgeTtsProvider.cs
@@ -1,0 +1,189 @@
+using System.Net.WebSockets;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Services;
+
+/// <summary>
+/// TTS provider using Microsoft Edge TTS WebSocket API.
+/// Requires internet connection to Microsoft services.
+/// </summary>
+public sealed class EdgeTtsProvider : ITtsProvider
+{
+    private const string WSS_URL = "wss://api.msedgeservices.com/tts/cognitiveservices/websocket/v1";
+    private const string API_KEY = "6A5AA1D4EAFF4E9FB37E23D68491D6F4";
+    private const string CHROMIUM_FULL_VERSION = "140.0.3485.14";
+    private const long WIN_EPOCH = 11644473600;
+    private const double S_TO_NS = 1e9;
+    private const int CONNECTION_TIMEOUT_MS = 5000;
+
+    private readonly ILogger<EdgeTtsProvider> _logger;
+
+    public string Name => "EdgeTTS";
+
+    public EdgeTtsProvider(ILogger<EdgeTtsProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var client = new ClientWebSocket();
+            ConfigureWebSocket(client);
+
+            var connectionId = Guid.NewGuid().ToString("N");
+            var uri = BuildUri(connectionId);
+
+            using var timeoutCts = new CancellationTokenSource(CONNECTION_TIMEOUT_MS);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            await client.ConnectAsync(uri, linkedCts.Token);
+            await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Availability check", CancellationToken.None);
+
+            _logger.LogDebug("EdgeTTS availability check: OK");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "EdgeTTS availability check failed");
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<byte[]?> GenerateAudioAsync(string text, VoiceConfig voiceConfig, CancellationToken cancellationToken = default)
+    {
+        using var client = new ClientWebSocket();
+        ConfigureWebSocket(client);
+
+        var connectionId = Guid.NewGuid().ToString("N");
+        var uri = BuildUri(connectionId);
+
+        try
+        {
+            await client.ConnectAsync(uri, cancellationToken);
+
+            // Send config message
+            var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffK");
+            var configMessage = $"X-Timestamp:{timestamp}\r\n" +
+                               "Content-Type:application/json; charset=utf-8\r\n" +
+                               "Path:speech.config\r\n\r\n" +
+                               "{\"context\":{\"synthesis\":{\"audio\":{\"metadataoptions\":{" +
+                               "\"sentenceBoundaryEnabled\":\"false\",\"wordBoundaryEnabled\":\"false\"}," +
+                               "\"outputFormat\":\"audio-24khz-48kbitrate-mono-mp3\"}}}}";
+
+            await client.SendAsync(
+                new ArraySegment<byte>(Encoding.UTF8.GetBytes(configMessage)),
+                WebSocketMessageType.Text,
+                true,
+                cancellationToken);
+
+            // Send SSML message
+            var ssml = GenerateSsml(text, voiceConfig);
+            var requestId = Guid.NewGuid().ToString("N");
+            var ssmlMessage = $"X-RequestId:{requestId}\r\n" +
+                             "Content-Type:application/ssml+xml\r\n" +
+                             "Path:ssml\r\n\r\n" +
+                             ssml;
+
+            await client.SendAsync(
+                new ArraySegment<byte>(Encoding.UTF8.GetBytes(ssmlMessage)),
+                WebSocketMessageType.Text,
+                true,
+                cancellationToken);
+
+            // Receive audio data
+            var audioChunks = new List<byte>();
+            var buffer = new byte[16384];
+
+            while (client.State == WebSocketState.Open)
+            {
+                var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                    break;
+
+                if (result.MessageType == WebSocketMessageType.Binary)
+                {
+                    // First 2 bytes = header length (big-endian)
+                    if (result.Count < 2) continue;
+
+                    var headerLength = (buffer[0] << 8) | buffer[1];
+                    var audioStart = 2 + headerLength;
+
+                    if (audioStart > result.Count) continue;
+
+                    // Check if this is audio data
+                    var headerBytes = buffer.Skip(2).Take(headerLength).ToArray();
+                    var headerText = Encoding.UTF8.GetString(headerBytes);
+
+                    if (headerText.Contains("Path:audio"))
+                    {
+                        audioChunks.AddRange(buffer.Skip(audioStart).Take(result.Count - audioStart));
+                    }
+                }
+                else if (result.MessageType == WebSocketMessageType.Text)
+                {
+                    var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                    if (message.Contains("Path:turn.end"))
+                        break;
+                }
+            }
+
+            await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Done", CancellationToken.None);
+
+            return audioChunks.ToArray();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "EdgeTTS WebSocket error generating audio");
+            return null;
+        }
+    }
+
+    private static void ConfigureWebSocket(ClientWebSocket client)
+    {
+        client.Options.SetRequestHeader("User-Agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0");
+        client.Options.SetRequestHeader("Origin", "chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold");
+        client.Options.SetRequestHeader("Pragma", "no-cache");
+        client.Options.SetRequestHeader("Cache-Control", "no-cache");
+        client.Options.SetRequestHeader("Accept-Encoding", "gzip, deflate, br");
+        client.Options.SetRequestHeader("Accept-Language", "en-US,en;q=0.9");
+        client.Options.AddSubProtocol("synthesize");
+    }
+
+    private static Uri BuildUri(string connectionId)
+    {
+        var secMsGec = GenerateSecMsGec();
+        var secMsGecVersion = $"1-{CHROMIUM_FULL_VERSION}";
+        return new Uri($"{WSS_URL}?Ocp-Apim-Subscription-Key={API_KEY}&ConnectionId={connectionId}&Sec-MS-GEC={secMsGec}&Sec-MS-GEC-Version={secMsGecVersion}");
+    }
+
+    private static string GenerateSecMsGec()
+    {
+        var ticks = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        ticks += WIN_EPOCH;
+        ticks -= ticks % 300;
+        var ticksInNs = (double)ticks * S_TO_NS / 100;
+        var strToHash = $"{ticksInNs:F0}{API_KEY}";
+        var hashBytes = SHA256.HashData(Encoding.ASCII.GetBytes(strToHash));
+        return Convert.ToHexString(hashBytes);
+    }
+
+    private static string GenerateSsml(string text, VoiceConfig config)
+    {
+        var escapedText = System.Security.SecurityElement.Escape(text);
+        return $@"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='cs-CZ'>
+            <voice name='{config.Voice}'>
+                <prosody rate='{config.Rate}' volume='{config.Volume}' pitch='{config.Pitch}'>
+                    {escapedText}
+                </prosody>
+            </voice>
+        </speak>";
+    }
+}

--- a/src/VirtualAssistant.Voice/Services/ILocationService.cs
+++ b/src/VirtualAssistant.Voice/Services/ILocationService.cs
@@ -1,0 +1,30 @@
+namespace Olbrasoft.VirtualAssistant.Voice.Services;
+
+/// <summary>
+/// Result of location check.
+/// </summary>
+public sealed record LocationInfo(
+    string CountryCode,
+    bool IsVpnDetected,
+    string? City = null,
+    string? Isp = null);
+
+/// <summary>
+/// Interface for detecting user's location and VPN status.
+/// </summary>
+public interface ILocationService
+{
+    /// <summary>
+    /// Gets the current location information.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Location information</returns>
+    Task<LocationInfo> GetLocationAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if VPN is currently active (location is not in Czech Republic).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if VPN is detected</returns>
+    Task<bool> IsVpnActiveAsync(CancellationToken cancellationToken = default);
+}

--- a/src/VirtualAssistant.Voice/Services/ITtsProvider.cs
+++ b/src/VirtualAssistant.Voice/Services/ITtsProvider.cs
@@ -1,0 +1,29 @@
+namespace Olbrasoft.VirtualAssistant.Voice.Services;
+
+/// <summary>
+/// Interface for Text-to-Speech providers.
+/// Allows different TTS backends (Edge TTS, Piper, etc.) to be used interchangeably.
+/// </summary>
+public interface ITtsProvider
+{
+    /// <summary>
+    /// Gets the name of the provider for logging purposes.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Checks if this provider is currently available.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if the provider can be used</returns>
+    Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates audio data from text.
+    /// </summary>
+    /// <param name="text">Text to convert to speech</param>
+    /// <param name="voiceConfig">Voice configuration</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Audio data as byte array, or null if generation failed</returns>
+    Task<byte[]?> GenerateAudioAsync(string text, VoiceConfig voiceConfig, CancellationToken cancellationToken = default);
+}

--- a/src/VirtualAssistant.Voice/Services/LocationService.cs
+++ b/src/VirtualAssistant.Voice/Services/LocationService.cs
@@ -1,0 +1,98 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Services;
+
+/// <summary>
+/// Service for detecting user's location using ip-api.com.
+/// Used to determine if VPN is active (non-CZ location).
+/// </summary>
+public sealed class LocationService : ILocationService
+{
+    private const string IP_API_URL = "http://ip-api.com/json/?fields=status,countryCode,city,isp,proxy,hosting";
+    private const string HOME_COUNTRY = "CZ";
+    private const int CACHE_DURATION_SECONDS = 300; // 5 minutes
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<LocationService> _logger;
+
+    private LocationInfo? _cachedLocation;
+    private DateTime _cacheExpiry = DateTime.MinValue;
+
+    public LocationService(HttpClient httpClient, ILogger<LocationService> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<LocationInfo> GetLocationAsync(CancellationToken cancellationToken = default)
+    {
+        // Return cached result if still valid
+        if (_cachedLocation != null && DateTime.UtcNow < _cacheExpiry)
+        {
+            return _cachedLocation;
+        }
+
+        try
+        {
+            var response = await _httpClient.GetFromJsonAsync<IpApiResponse>(IP_API_URL, cancellationToken);
+
+            if (response == null || response.Status != "success")
+            {
+                _logger.LogWarning("ip-api.com returned invalid response");
+                return new LocationInfo(HOME_COUNTRY, false);
+            }
+
+            var isVpn = response.CountryCode != HOME_COUNTRY || response.Proxy || response.Hosting;
+
+            _cachedLocation = new LocationInfo(
+                response.CountryCode ?? HOME_COUNTRY,
+                isVpn,
+                response.City,
+                response.Isp);
+
+            _cacheExpiry = DateTime.UtcNow.AddSeconds(CACHE_DURATION_SECONDS);
+
+            _logger.LogInformation("Location detected: {Country} (VPN: {IsVpn})",
+                _cachedLocation.CountryCode, isVpn);
+
+            return _cachedLocation;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get location from ip-api.com");
+            // On error, assume no VPN (fail-open)
+            return new LocationInfo(HOME_COUNTRY, false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> IsVpnActiveAsync(CancellationToken cancellationToken = default)
+    {
+        var location = await GetLocationAsync(cancellationToken);
+        return location.IsVpnDetected;
+    }
+
+    private sealed class IpApiResponse
+    {
+        [JsonPropertyName("status")]
+        public string? Status { get; set; }
+
+        [JsonPropertyName("countryCode")]
+        public string? CountryCode { get; set; }
+
+        [JsonPropertyName("city")]
+        public string? City { get; set; }
+
+        [JsonPropertyName("isp")]
+        public string? Isp { get; set; }
+
+        [JsonPropertyName("proxy")]
+        public bool Proxy { get; set; }
+
+        [JsonPropertyName("hosting")]
+        public bool Hosting { get; set; }
+    }
+}

--- a/src/VirtualAssistant.Voice/Services/PiperTtsProvider.cs
+++ b/src/VirtualAssistant.Voice/Services/PiperTtsProvider.cs
@@ -1,0 +1,199 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Olbrasoft.VirtualAssistant.Voice.Configuration;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Services;
+
+/// <summary>
+/// TTS provider using local Piper TTS.
+/// Works offline, no internet dependency.
+/// Fallback when Edge TTS is unavailable (e.g., VPN active).
+/// </summary>
+public sealed class PiperTtsProvider : ITtsProvider
+{
+    private readonly ILogger<PiperTtsProvider> _logger;
+    private readonly PiperOptions _options;
+    private readonly string _tempDirectory;
+
+    public string Name => "Piper";
+
+    public PiperTtsProvider(ILogger<PiperTtsProvider> logger, IOptions<PiperOptions> options)
+    {
+        _logger = logger;
+        _options = options.Value;
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "piper-tts");
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        // Check if piper binary exists and model file exists
+        var piperExists = File.Exists(_options.PiperPath) || IsPiperInPath();
+        var modelExists = File.Exists(_options.ModelPath);
+
+        var isAvailable = piperExists && modelExists;
+
+        if (!isAvailable)
+        {
+            _logger.LogDebug("Piper not available. Binary: {PiperExists}, Model: {ModelExists}",
+                piperExists, modelExists);
+        }
+
+        return Task.FromResult(isAvailable);
+    }
+
+    /// <inheritdoc/>
+    public async Task<byte[]?> GenerateAudioAsync(string text, VoiceConfig voiceConfig, CancellationToken cancellationToken = default)
+    {
+        var outputFile = Path.Combine(_tempDirectory, $"piper-{Guid.NewGuid():N}.wav");
+
+        try
+        {
+            var piperPath = File.Exists(_options.PiperPath) ? _options.PiperPath : "piper";
+
+            // Build piper command
+            // Note: Piper doesn't support prosody like Edge TTS, so voiceConfig is partially ignored
+            var arguments = $"--model \"{_options.ModelPath}\" --output_file \"{outputFile}\"";
+
+            if (!string.IsNullOrEmpty(_options.ConfigPath) && File.Exists(_options.ConfigPath))
+            {
+                arguments += $" --config \"{_options.ConfigPath}\"";
+            }
+
+            // Apply speech rate if supported
+            if (_options.LengthScale.HasValue)
+            {
+                arguments += $" --length-scale {_options.LengthScale.Value:F2}";
+            }
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = piperPath,
+                    Arguments = arguments,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+
+            // Write text to stdin
+            await process.StandardInput.WriteAsync(text);
+            await process.StandardInput.FlushAsync();
+            process.StandardInput.Close();
+
+            await process.WaitForExitAsync(cancellationToken);
+
+            if (process.ExitCode != 0)
+            {
+                var error = await process.StandardError.ReadToEndAsync(cancellationToken);
+                _logger.LogError("Piper failed with exit code {ExitCode}: {Error}",
+                    process.ExitCode, error);
+                return null;
+            }
+
+            if (!File.Exists(outputFile))
+            {
+                _logger.LogError("Piper did not create output file");
+                return null;
+            }
+
+            // Piper outputs WAV, but we need to return it for playback
+            // Convert to MP3 for consistency with Edge TTS cache
+            var mp3File = Path.ChangeExtension(outputFile, ".mp3");
+            if (await ConvertWavToMp3Async(outputFile, mp3File, cancellationToken))
+            {
+                var audioData = await File.ReadAllBytesAsync(mp3File, cancellationToken);
+
+                // Cleanup temp files
+                TryDeleteFile(outputFile);
+                TryDeleteFile(mp3File);
+
+                return audioData;
+            }
+            else
+            {
+                // If conversion fails, return WAV directly
+                var audioData = await File.ReadAllBytesAsync(outputFile, cancellationToken);
+                TryDeleteFile(outputFile);
+                return audioData;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Piper audio generation failed");
+            TryDeleteFile(outputFile);
+            return null;
+        }
+    }
+
+    private bool IsPiperInPath()
+    {
+        try
+        {
+            var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "which",
+                Arguments = "piper",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            });
+
+            process?.WaitForExit(1000);
+            return process?.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task<bool> ConvertWavToMp3Async(string wavFile, string mp3File, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "ffmpeg",
+                    Arguments = $"-y -i \"{wavFile}\" -codec:a libmp3lame -qscale:a 2 \"{mp3File}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            await process.WaitForExitAsync(cancellationToken);
+
+            return process.ExitCode == 0 && File.Exists(mp3File);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+}

--- a/src/VirtualAssistant.Voice/Services/TtsService.cs
+++ b/src/VirtualAssistant.Voice/Services/TtsService.cs
@@ -1,10 +1,10 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Net.WebSockets;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Olbrasoft.VirtualAssistant.Voice.Configuration;
 
 namespace Olbrasoft.VirtualAssistant.Voice.Services;
@@ -15,23 +15,22 @@ namespace Olbrasoft.VirtualAssistant.Voice.Services;
 public sealed record VoiceConfig(string Voice, string Rate, string Volume, string Pitch);
 
 /// <summary>
-/// Text-to-Speech service using direct WebSocket to Microsoft Edge TTS API.
-/// Pure C# - no external dependencies like Python edge-tts.
-/// Supports multiple voice profiles for different AI clients.
+/// Text-to-Speech service with fallback support.
+/// Primary: Microsoft Edge TTS (requires internet, may not work with VPN)
+/// Fallback: Piper TTS (local, works offline)
 /// </summary>
 public sealed class TtsService : IDisposable
 {
-    private const string WSS_URL = "wss://api.msedgeservices.com/tts/cognitiveservices/websocket/v1";
-    private const string API_KEY = "6A5AA1D4EAFF4E9FB37E23D68491D6F4";
-    private const string CHROMIUM_FULL_VERSION = "140.0.3485.14";
-    private const long WIN_EPOCH = 11644473600;
-    private const double S_TO_NS = 1e9;
-
     private readonly ILogger<TtsService> _logger;
     private readonly string _cacheDirectory;
     private readonly string _micLockFile = "/tmp/speech-lock";
     private readonly ConcurrentQueue<(string Text, string? Source)> _messageQueue = new();
     private readonly SemaphoreSlim _playbackLock = new(1, 1);
+
+    private readonly ITtsProvider _primaryProvider;
+    private readonly ITtsProvider? _fallbackProvider;
+    private readonly ILocationService? _locationService;
+    private readonly TtsFallbackOptions _fallbackOptions;
 
     /// <summary>
     /// Voice profiles for different AI clients loaded from configuration.
@@ -39,9 +38,25 @@ public sealed class TtsService : IDisposable
     /// </summary>
     private readonly Dictionary<string, VoiceConfig> _voiceProfiles;
 
-    public TtsService(ILogger<TtsService> logger, IConfiguration configuration)
+    // Track which provider is currently active
+    private bool _useFallback;
+    private DateTime _lastAvailabilityCheck = DateTime.MinValue;
+    private const int AVAILABILITY_CHECK_INTERVAL_SECONDS = 60;
+
+    public TtsService(
+        ILogger<TtsService> logger,
+        IConfiguration configuration,
+        ITtsProvider primaryProvider,
+        ITtsProvider? fallbackProvider = null,
+        ILocationService? locationService = null,
+        IOptions<TtsFallbackOptions>? fallbackOptions = null)
     {
         _logger = logger;
+        _primaryProvider = primaryProvider;
+        _fallbackProvider = fallbackProvider;
+        _locationService = locationService;
+        _fallbackOptions = fallbackOptions?.Value ?? new TtsFallbackOptions();
+
         _cacheDirectory = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".cache", "virtual-assistant-tts");
@@ -53,9 +68,17 @@ public sealed class TtsService : IDisposable
         configuration.GetSection(TtsVoiceProfilesOptions.SectionName).Bind(options);
         _voiceProfiles = options.Profiles;
 
+        _logger.LogInformation("TTS service initialized. Primary: {Primary}, Fallback: {Fallback}",
+            _primaryProvider.Name,
+            _fallbackProvider?.Name ?? "none");
         _logger.LogInformation("Loaded {Count} TTS voice profiles: {Profiles}",
             _voiceProfiles.Count, string.Join(", ", _voiceProfiles.Keys));
     }
+
+    /// <summary>
+    /// Gets the currently active provider name.
+    /// </summary>
+    public string ActiveProvider => _useFallback ? (_fallbackProvider?.Name ?? "none") : _primaryProvider.Name;
 
     /// <summary>
     /// Gets the voice configuration for a given source.
@@ -71,7 +94,7 @@ public sealed class TtsService : IDisposable
     }
 
     /// <summary>
-    /// Řekne text přes Microsoft Edge TTS API (přímé WebSocket volání).
+    /// Speaks text using the best available TTS provider.
     /// If speech lock is active, queues the message for later playback.
     /// </summary>
     /// <param name="text">Text to speak</param>
@@ -85,7 +108,7 @@ public sealed class TtsService : IDisposable
             if (File.Exists(_micLockFile))
             {
                 _messageQueue.Enqueue((text, source));
-                _logger.LogInformation("🎤 Mikrofon aktivní - text zařazen do fronty ({QueueCount}): {Text}", 
+                _logger.LogInformation("🎤 Mikrofon aktivní - text zařazen do fronty ({QueueCount}): {Text}",
                     _messageQueue.Count, text);
                 return;
             }
@@ -119,7 +142,7 @@ public sealed class TtsService : IDisposable
             {
                 // Re-queue the message and stop flushing
                 _messageQueue.Enqueue(item);
-                _logger.LogInformation("🎤 Lock re-acquired during flush - stopping. Remaining: {Count}", 
+                _logger.LogInformation("🎤 Lock re-acquired during flush - stopping. Remaining: {Count}",
                     _messageQueue.Count);
                 return;
             }
@@ -138,15 +161,16 @@ public sealed class TtsService : IDisposable
     /// <summary>
     /// Internal method to actually speak text (no queue check).
     /// Uses SemaphoreSlim to ensure only one message plays at a time.
+    /// Implements fallback logic when primary provider fails.
     /// </summary>
     private async Task SpeakDirectAsync(string text, string? source, CancellationToken cancellationToken)
     {
         var voiceConfig = GetVoiceConfig(source);
-        
+
         await _playbackLock.WaitAsync(cancellationToken);
         try
         {
-            // Check cache first
+            // Check cache first (provider-agnostic)
             var cacheFile = GetCacheFilePath(text, voiceConfig);
             if (File.Exists(cacheFile))
             {
@@ -155,14 +179,20 @@ public sealed class TtsService : IDisposable
                 return;
             }
 
-            // Generate new audio via WebSocket
-            _logger.LogDebug("Generating audio for: {Text} (source: {Source})", text, source ?? "default");
-            var audioData = await GenerateAudioAsync(text, voiceConfig, cancellationToken);
+            // Determine which provider to use
+            await UpdateProviderSelectionAsync(cancellationToken);
+
+            // Generate audio with fallback
+            var audioData = await GenerateAudioWithFallbackAsync(text, voiceConfig, cancellationToken);
 
             if (audioData == null || audioData.Length == 0)
             {
-                _logger.LogWarning("Failed to generate audio for: {Text}", text);
-                return;
+                if (_fallbackOptions.SilentOnFailure)
+                {
+                    _logger.LogWarning("All TTS providers failed for: {Text}", text);
+                    return;
+                }
+                throw new InvalidOperationException($"Failed to generate audio for: {text}");
             }
 
             // Save to cache
@@ -171,7 +201,8 @@ public sealed class TtsService : IDisposable
             // Play audio
             await PlayAudioAsync(cacheFile, cancellationToken);
 
-            _logger.LogInformation("🗣️ TTS [{Source}]: \"{Text}\"", source ?? "default", text);
+            _logger.LogInformation("🗣️ TTS [{Provider}][{Source}]: \"{Text}\"",
+                ActiveProvider, source ?? "default", text);
         }
         finally
         {
@@ -179,143 +210,101 @@ public sealed class TtsService : IDisposable
         }
     }
 
-    private async Task<byte[]?> GenerateAudioAsync(string text, VoiceConfig voiceConfig, CancellationToken cancellationToken)
+    /// <summary>
+    /// Updates provider selection based on location/VPN status.
+    /// </summary>
+    private async Task UpdateProviderSelectionAsync(CancellationToken cancellationToken)
     {
-        using var client = new ClientWebSocket();
+        if (!_fallbackOptions.EnableFallback || _fallbackProvider == null)
+            return;
 
-        // Add all required headers to match Microsoft Edge TTS requirements
-        client.Options.SetRequestHeader("User-Agent",
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0");
-        client.Options.SetRequestHeader("Origin", "chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold");
-        client.Options.SetRequestHeader("Pragma", "no-cache");
-        client.Options.SetRequestHeader("Cache-Control", "no-cache");
-        client.Options.SetRequestHeader("Accept-Encoding", "gzip, deflate, br");
-        client.Options.SetRequestHeader("Accept-Language", "en-US,en;q=0.9");
-
-        // CRITICAL: Add WebSocket subprotocol
-        client.Options.AddSubProtocol("synthesize");
-
-        // Generate connection parameters
-        var connectionId = Guid.NewGuid().ToString("N");
-        var secMsGec = GenerateSecMsGec();
-        var secMsGecVersion = $"1-{CHROMIUM_FULL_VERSION}";
-
-        var uri = new Uri($"{WSS_URL}?Ocp-Apim-Subscription-Key={API_KEY}&ConnectionId={connectionId}&Sec-MS-GEC={secMsGec}&Sec-MS-GEC-Version={secMsGecVersion}");
-
-        try
+        // Check VPN status if location service is available
+        if (_fallbackOptions.CheckLocation && _locationService != null)
         {
-            await client.ConnectAsync(uri, cancellationToken);
-
-            // Send config message
-            var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffK");
-            var configMessage = $"X-Timestamp:{timestamp}\r\n" +
-                               "Content-Type:application/json; charset=utf-8\r\n" +
-                               "Path:speech.config\r\n\r\n" +
-                               "{\"context\":{\"synthesis\":{\"audio\":{\"metadataoptions\":{" +
-                               "\"sentenceBoundaryEnabled\":\"false\",\"wordBoundaryEnabled\":\"false\"}," +
-                               "\"outputFormat\":\"audio-24khz-48kbitrate-mono-mp3\"}}}}";
-
-            await client.SendAsync(
-                new ArraySegment<byte>(Encoding.UTF8.GetBytes(configMessage)),
-                WebSocketMessageType.Text,
-                true,
-                cancellationToken);
-
-            // Send SSML message
-            var ssml = GenerateSsml(text, voiceConfig);
-            var requestId = Guid.NewGuid().ToString("N");
-            var ssmlMessage = $"X-RequestId:{requestId}\r\n" +
-                             "Content-Type:application/ssml+xml\r\n" +
-                             "Path:ssml\r\n\r\n" +
-                             ssml;
-
-            await client.SendAsync(
-                new ArraySegment<byte>(Encoding.UTF8.GetBytes(ssmlMessage)),
-                WebSocketMessageType.Text,
-                true,
-                cancellationToken);
-
-            // Receive audio data
-            var audioChunks = new List<byte>();
-            var buffer = new byte[16384];
-
-            while (client.State == WebSocketState.Open)
+            try
             {
-                var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
-
-                if (result.MessageType == WebSocketMessageType.Close)
-                    break;
-
-                if (result.MessageType == WebSocketMessageType.Binary)
+                var isVpnActive = await _locationService.IsVpnActiveAsync(cancellationToken);
+                if (isVpnActive && !_useFallback)
                 {
-                    // First 2 bytes = header length (big-endian)
-                    if (result.Count < 2) continue;
-
-                    var headerLength = (buffer[0] << 8) | buffer[1];
-                    var audioStart = 2 + headerLength;
-
-                    if (audioStart > result.Count) continue;
-
-                    // Check if this is audio data
-                    var headerBytes = buffer.Skip(2).Take(headerLength).ToArray();
-                    var headerText = Encoding.UTF8.GetString(headerBytes);
-
-                    if (headerText.Contains("Path:audio"))
-                    {
-                        audioChunks.AddRange(buffer.Skip(audioStart).Take(result.Count - audioStart));
-                    }
+                    _logger.LogInformation("VPN detected - switching to fallback provider ({Provider})",
+                        _fallbackProvider.Name);
+                    _useFallback = true;
+                    return;
                 }
-                else if (result.MessageType == WebSocketMessageType.Text)
+                else if (!isVpnActive && _useFallback)
                 {
-                    var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
-                    if (message.Contains("Path:turn.end"))
-                        break;
+                    _logger.LogInformation("VPN not detected - switching back to primary provider ({Provider})",
+                        _primaryProvider.Name);
+                    _useFallback = false;
+                    return;
                 }
             }
-
-            await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Done", CancellationToken.None);
-
-            return audioChunks.ToArray();
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Location check failed, continuing with current provider");
+            }
         }
-        catch (Exception ex)
+
+        // Periodic availability check
+        if (_fallbackOptions.AlwaysCheckAvailability &&
+            DateTime.UtcNow - _lastAvailabilityCheck > TimeSpan.FromSeconds(AVAILABILITY_CHECK_INTERVAL_SECONDS))
         {
-            _logger.LogError(ex, "WebSocket error generating audio");
+            _lastAvailabilityCheck = DateTime.UtcNow;
+
+            if (!_useFallback)
+            {
+                var isAvailable = await _primaryProvider.IsAvailableAsync(cancellationToken);
+                if (!isAvailable)
+                {
+                    _logger.LogWarning("Primary provider unavailable - switching to fallback");
+                    _useFallback = true;
+                }
+            }
+            else
+            {
+                // Check if we can switch back to primary
+                var isAvailable = await _primaryProvider.IsAvailableAsync(cancellationToken);
+                if (isAvailable)
+                {
+                    _logger.LogInformation("Primary provider available again - switching back");
+                    _useFallback = false;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generates audio with automatic fallback on failure.
+    /// </summary>
+    private async Task<byte[]?> GenerateAudioWithFallbackAsync(
+        string text,
+        VoiceConfig voiceConfig,
+        CancellationToken cancellationToken)
+    {
+        var provider = _useFallback ? _fallbackProvider : _primaryProvider;
+
+        if (provider == null)
+        {
+            _logger.LogError("No TTS provider available");
             return null;
         }
-    }
 
-    private static string GenerateSecMsGec()
-    {
-        // Get current Unix timestamp
-        var ticks = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        _logger.LogDebug("Generating audio using {Provider} for: {Text}", provider.Name, text);
+        var audioData = await provider.GenerateAudioAsync(text, voiceConfig, cancellationToken);
 
-        // Switch to Windows file time epoch (1601-01-01 00:00:00 UTC)
-        ticks += WIN_EPOCH;
+        // If primary failed and fallback is available, try fallback
+        if ((audioData == null || audioData.Length == 0) &&
+            !_useFallback &&
+            _fallbackOptions.EnableFallback &&
+            _fallbackProvider != null)
+        {
+            _logger.LogWarning("Primary provider failed, trying fallback ({Provider})", _fallbackProvider.Name);
+            _useFallback = true;
 
-        // Round down to nearest 5 minutes (300 seconds)
-        ticks -= ticks % 300;
+            audioData = await _fallbackProvider.GenerateAudioAsync(text, voiceConfig, cancellationToken);
+        }
 
-        // Convert to 100-nanosecond intervals (Windows file time format)
-        var ticksInNs = (double)ticks * S_TO_NS / 100;
-
-        // Create string to hash
-        var strToHash = $"{ticksInNs:F0}{API_KEY}";
-
-        // Compute SHA256 hash and return uppercased hex digest
-        var hashBytes = SHA256.HashData(Encoding.ASCII.GetBytes(strToHash));
-        return Convert.ToHexString(hashBytes);
-    }
-
-    private static string GenerateSsml(string text, VoiceConfig config)
-    {
-        var escapedText = System.Security.SecurityElement.Escape(text);
-        return $@"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='cs-CZ'>
-            <voice name='{config.Voice}'>
-                <prosody rate='{config.Rate}' volume='{config.Volume}' pitch='{config.Pitch}'>
-                    {escapedText}
-                </prosody>
-            </voice>
-        </speak>";
+        return audioData;
     }
 
     private async Task PlayAudioAsync(string audioFile, CancellationToken cancellationToken)
@@ -346,7 +335,9 @@ public sealed class TtsService : IDisposable
             .Trim('-')
             .ToLowerInvariant();
 
-        var parameters = $"{config.Voice}{config.Rate}{config.Volume}{config.Pitch}";
+        // Include provider in cache key to avoid mixing Edge and Piper audio
+        var providerKey = _useFallback ? "piper" : "edge";
+        var parameters = $"{providerKey}{config.Voice}{config.Rate}{config.Volume}{config.Pitch}";
         var hash = Convert.ToHexString(MD5.HashData(Encoding.UTF8.GetBytes(parameters)))[..8];
 
         return Path.Combine(_cacheDirectory, $"{safeName}-{hash}.mp3");

--- a/tests/VirtualAssistant.Voice.Tests/Services/LocationServiceTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/LocationServiceTests.cs
@@ -1,0 +1,303 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Olbrasoft.VirtualAssistant.Voice.Services;
+
+namespace VirtualAssistant.Voice.Tests.Services;
+
+/// <summary>
+/// Unit tests for LocationService VPN detection functionality.
+/// </summary>
+public class LocationServiceTests
+{
+    private readonly Mock<ILogger<LocationService>> _loggerMock;
+
+    public LocationServiceTests()
+    {
+        _loggerMock = new Mock<ILogger<LocationService>>();
+    }
+
+    private LocationService CreateService(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        return new LocationService(httpClient, _loggerMock.Object);
+    }
+
+    private static Mock<HttpMessageHandler> CreateMockHandler(HttpResponseMessage response)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+        return handlerMock;
+    }
+
+    [Fact]
+    public async Task GetLocationAsync_WhenInCzechRepublic_ReturnsNoVpn()
+    {
+        // Arrange
+        var responseContent = new
+        {
+            status = "success",
+            countryCode = "CZ",
+            city = "Prague",
+            isp = "O2",
+            proxy = false,
+            hosting = false
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(responseContent)
+        };
+
+        var handlerMock = CreateMockHandler(response);
+        var sut = CreateService(handlerMock.Object);
+
+        // Act
+        var result = await sut.GetLocationAsync();
+
+        // Assert
+        Assert.Equal("CZ", result.CountryCode);
+        Assert.False(result.IsVpnDetected);
+        Assert.Equal("Prague", result.City);
+        Assert.Equal("O2", result.Isp);
+    }
+
+    [Fact]
+    public async Task GetLocationAsync_WhenInGermany_ReturnsVpnDetected()
+    {
+        // Arrange
+        var responseContent = new
+        {
+            status = "success",
+            countryCode = "DE",
+            city = "Frankfurt",
+            isp = "Windscribe",
+            proxy = false,
+            hosting = false
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(responseContent)
+        };
+
+        var handlerMock = CreateMockHandler(response);
+        var sut = CreateService(handlerMock.Object);
+
+        // Act
+        var result = await sut.GetLocationAsync();
+
+        // Assert
+        Assert.Equal("DE", result.CountryCode);
+        Assert.True(result.IsVpnDetected);
+    }
+
+    [Fact]
+    public async Task GetLocationAsync_WhenProxyDetected_ReturnsVpnDetected()
+    {
+        // Arrange
+        var responseContent = new
+        {
+            status = "success",
+            countryCode = "CZ",
+            city = "Prague",
+            isp = "O2",
+            proxy = true,
+            hosting = false
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(responseContent)
+        };
+
+        var handlerMock = CreateMockHandler(response);
+        var sut = CreateService(handlerMock.Object);
+
+        // Act
+        var result = await sut.GetLocationAsync();
+
+        // Assert
+        Assert.True(result.IsVpnDetected);
+    }
+
+    [Fact]
+    public async Task GetLocationAsync_WhenHostingDetected_ReturnsVpnDetected()
+    {
+        // Arrange
+        var responseContent = new
+        {
+            status = "success",
+            countryCode = "CZ",
+            city = "Prague",
+            isp = "DataCenter",
+            proxy = false,
+            hosting = true
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(responseContent)
+        };
+
+        var handlerMock = CreateMockHandler(response);
+        var sut = CreateService(handlerMock.Object);
+
+        // Act
+        var result = await sut.GetLocationAsync();
+
+        // Assert
+        Assert.True(result.IsVpnDetected);
+    }
+
+    [Fact]
+    public async Task GetLocationAsync_WhenApiFails_ReturnsDefaultCzLocation()
+    {
+        // Arrange
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var handlerMock = CreateMockHandler(response);
+        var sut = CreateService(handlerMock.Object);
+
+        // Act
+        var result = await sut.GetLocationAsync();
+
+        // Assert - fail-open: assume no VPN on error
+        Assert.Equal("CZ", result.CountryCode);
+        Assert.False(result.IsVpnDetected);
+    }
+
+    [Fact]
+    public async Task GetLocationAsync_WhenApiReturnsInvalidStatus_ReturnsDefaultCzLocation()
+    {
+        // Arrange
+        var responseContent = new
+        {
+            status = "fail",
+            message = "reserved range"
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(responseContent)
+        };
+
+        var handlerMock = CreateMockHandler(response);
+        var sut = CreateService(handlerMock.Object);
+
+        // Act
+        var result = await sut.GetLocationAsync();
+
+        // Assert
+        Assert.Equal("CZ", result.CountryCode);
+        Assert.False(result.IsVpnDetected);
+    }
+
+    [Fact]
+    public async Task GetLocationAsync_CachesResult()
+    {
+        // Arrange
+        var callCount = 0;
+        var responseContent = new
+        {
+            status = "success",
+            countryCode = "CZ",
+            city = "Prague",
+            isp = "O2",
+            proxy = false,
+            hosting = false
+        };
+
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(responseContent)
+                };
+            });
+
+        var sut = CreateService(handlerMock.Object);
+
+        // Act - call multiple times
+        await sut.GetLocationAsync();
+        await sut.GetLocationAsync();
+        await sut.GetLocationAsync();
+
+        // Assert - API should only be called once (cached)
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task IsVpnActiveAsync_WhenInCzechRepublic_ReturnsFalse()
+    {
+        // Arrange
+        var responseContent = new
+        {
+            status = "success",
+            countryCode = "CZ",
+            city = "Prague",
+            isp = "O2",
+            proxy = false,
+            hosting = false
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(responseContent)
+        };
+
+        var handlerMock = CreateMockHandler(response);
+        var sut = CreateService(handlerMock.Object);
+
+        // Act
+        var result = await sut.IsVpnActiveAsync();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsVpnActiveAsync_WhenNotInCzechRepublic_ReturnsTrue()
+    {
+        // Arrange
+        var responseContent = new
+        {
+            status = "success",
+            countryCode = "DE",
+            city = "Berlin",
+            isp = "VPN Provider",
+            proxy = false,
+            hosting = false
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(responseContent)
+        };
+
+        var handlerMock = CreateMockHandler(response);
+        var sut = CreateService(handlerMock.Object);
+
+        // Act
+        var result = await sut.IsVpnActiveAsync();
+
+        // Assert
+        Assert.True(result);
+    }
+}

--- a/tests/VirtualAssistant.Voice.Tests/Services/TtsServiceTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/TtsServiceTests.cs
@@ -1,18 +1,23 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
+using Olbrasoft.VirtualAssistant.Voice.Configuration;
 using Olbrasoft.VirtualAssistant.Voice.Services;
 
 namespace VirtualAssistant.Voice.Tests.Services;
 
 /// <summary>
-/// Unit tests for TtsService message queue functionality.
+/// Unit tests for TtsService message queue and fallback functionality.
 /// Note: WebSocket/audio playback functionality requires integration tests.
 /// </summary>
 public class TtsServiceTests : IDisposable
 {
     private readonly Mock<ILogger<TtsService>> _loggerMock;
     private readonly Mock<IConfiguration> _configurationMock;
+    private readonly Mock<ITtsProvider> _primaryProviderMock;
+    private readonly Mock<ITtsProvider> _fallbackProviderMock;
+    private readonly Mock<ILocationService> _locationServiceMock;
     private readonly TtsService _sut;
     private const string SpeechLockFilePath = "/tmp/speech-lock";
 
@@ -20,12 +25,32 @@ public class TtsServiceTests : IDisposable
     {
         _loggerMock = new Mock<ILogger<TtsService>>();
         _configurationMock = new Mock<IConfiguration>();
+        _primaryProviderMock = new Mock<ITtsProvider>();
+        _fallbackProviderMock = new Mock<ITtsProvider>();
+        _locationServiceMock = new Mock<ILocationService>();
+
+        // Setup provider names
+        _primaryProviderMock.Setup(p => p.Name).Returns("EdgeTTS");
+        _fallbackProviderMock.Setup(p => p.Name).Returns("Piper");
 
         // Setup empty configuration section (will use defaults from TtsVoiceProfilesOptions)
         var sectionMock = new Mock<IConfigurationSection>();
         _configurationMock.Setup(x => x.GetSection("TtsVoiceProfiles")).Returns(sectionMock.Object);
 
-        _sut = new TtsService(_loggerMock.Object, _configurationMock.Object);
+        var fallbackOptions = Options.Create(new TtsFallbackOptions
+        {
+            EnableFallback = true,
+            CheckLocation = true,
+            SilentOnFailure = true
+        });
+
+        _sut = new TtsService(
+            _loggerMock.Object,
+            _configurationMock.Object,
+            _primaryProviderMock.Object,
+            _fallbackProviderMock.Object,
+            _locationServiceMock.Object,
+            fallbackOptions);
 
         // Ensure clean state - no lock file
         if (File.Exists(SpeechLockFilePath))
@@ -49,7 +74,7 @@ public class TtsServiceTests : IDisposable
     {
         // Act
         var result = _sut.QueueCount;
-        
+
         // Assert
         Assert.Equal(0, result);
     }
@@ -59,10 +84,10 @@ public class TtsServiceTests : IDisposable
     {
         // Arrange
         File.WriteAllText(SpeechLockFilePath, "test");
-        
+
         // Act
         await _sut.SpeakAsync("Test message");
-        
+
         // Assert
         Assert.Equal(1, _sut.QueueCount);
     }
@@ -72,32 +97,15 @@ public class TtsServiceTests : IDisposable
     {
         // Arrange
         File.WriteAllText(SpeechLockFilePath, "test");
-        
+
         // Act
         await _sut.SpeakAsync("Message 1");
         await _sut.SpeakAsync("Message 2");
         await _sut.SpeakAsync("Message 3");
-        
+
         // Assert
         Assert.Equal(3, _sut.QueueCount);
     }
-
-    // ⚠️ WARNING: DO NOT UNCOMMENT THIS TEST - IT MAY PLAY AUDIO/TTS DURING TEST EXECUTION ⚠️
-    // This test calls FlushQueueAsync without lock file, which may trigger audio playback.
-    // Keep this test commented out to prevent sound interruptions during test runs.
-    //
-    //[Fact]
-    //public async Task FlushQueueAsync_WhenQueueEmpty_DoesNothing()
-    //{
-    //    // Arrange - queue is empty
-    //    Assert.Equal(0, _sut.QueueCount);
-    //
-    //    // Act
-    //    await _sut.FlushQueueAsync();
-    //
-    //    // Assert - no errors, still empty
-    //    Assert.Equal(0, _sut.QueueCount);
-    //}
 
     [Fact]
     public async Task FlushQueueAsync_WhenLockReacquired_StopsAndRequeues()
@@ -107,13 +115,13 @@ public class TtsServiceTests : IDisposable
         await _sut.SpeakAsync("Message 1");
         await _sut.SpeakAsync("Message 2");
         Assert.Equal(2, _sut.QueueCount);
-        
+
         // Note: FlushQueueAsync will check for lock file before each message
         // Since lock still exists, messages should be re-queued
-        
+
         // Act
         await _sut.FlushQueueAsync();
-        
+
         // Assert - messages were re-queued because lock still exists
         // First message was dequeued, lock checked, re-queued
         Assert.True(_sut.QueueCount >= 1, "Messages should remain in queue when lock exists");
@@ -125,47 +133,17 @@ public class TtsServiceTests : IDisposable
         // Arrange
         File.WriteAllText(SpeechLockFilePath, "test");
         var messages = new[] { "First", "Second", "Third" };
-        
+
         // Act
         foreach (var msg in messages)
         {
             await _sut.SpeakAsync(msg);
         }
-        
+
         // Assert
         Assert.Equal(3, _sut.QueueCount);
         // Queue should preserve FIFO order (tested implicitly by queue behavior)
     }
-
-    // ⚠️ WARNING: DO NOT UNCOMMENT THIS TEST - IT PLAYS AUDIO/TTS DURING TEST EXECUTION ⚠️
-    // This test calls actual TTS service without lock file, causing audio playback.
-    // Keep this test commented out to prevent sound interruptions during test runs.
-    // The functionality is covered by integration tests.
-    //
-    //[Fact]
-    //public async Task SpeakAsync_NoLock_DoesNotQueue()
-    //{
-    //    // Arrange - ensure no lock file exists
-    //    if (File.Exists(SpeechLockFilePath))
-    //    {
-    //        File.Delete(SpeechLockFilePath);
-    //    }
-    //
-    //    // Act - try to speak without lock
-    //    // Note: This will fail because we can't actually play audio in tests,
-    //    // but the queue should remain empty since lock doesn't exist
-    //    try
-    //    {
-    //        await _sut.SpeakAsync("Test message");
-    //    }
-    //    catch
-    //    {
-    //        // Expected - can't play audio in test environment
-    //    }
-    //
-    //    // Assert - message was NOT queued (was attempted to be played directly)
-    //    Assert.Equal(0, _sut.QueueCount);
-    //}
 
     [Fact]
     public async Task SpeakAsync_ThreadSafety_MultipleEnqueues()
@@ -173,7 +151,7 @@ public class TtsServiceTests : IDisposable
         // Arrange
         File.WriteAllText(SpeechLockFilePath, "test");
         var tasks = new Task[10];
-        
+
         // Act - multiple concurrent enqueues
         for (int i = 0; i < tasks.Length; i++)
         {
@@ -183,9 +161,9 @@ public class TtsServiceTests : IDisposable
                 await _sut.SpeakAsync($"Message {index}");
             });
         }
-        
+
         await Task.WhenAll(tasks);
-        
+
         // Assert - all messages should be queued
         Assert.Equal(10, _sut.QueueCount);
     }
@@ -199,76 +177,14 @@ public class TtsServiceTests : IDisposable
         await _sut.SpeakAsync("Message 2");
         var initialCount = _sut.QueueCount;
         Assert.Equal(2, initialCount);
-        
+
         // Act - try to flush while lock still exists
         await _sut.FlushQueueAsync();
-        
+
         // Assert - queue should still have messages (lock prevents playback)
         Assert.True(_sut.QueueCount >= 1);
     }
 
-    // ⚠️ WARNING: DO NOT UNCOMMENT THIS TEST - IT PLAYS AUDIO/TTS DURING TEST EXECUTION ⚠️
-    // This test calls actual TTS service without lock file, causing audio playback of "Concurrent message 0-4".
-    // Keep this test commented out to prevent sound interruptions during test runs.
-    // The semaphore thread-safety functionality is covered by other tests that use lock files.
-    //
-    ///// <summary>
-    ///// Tests that SemaphoreSlim ensures sequential execution of SpeakDirectAsync.
-    ///// Since we can't test actual playback, this test verifies that:
-    ///// 1. Multiple concurrent calls don't throw exceptions
-    ///// 2. The service handles concurrent access gracefully
-    ///// Note: Full sequential playback is tested via integration tests.
-    ///// </summary>
-    //[Fact]
-    //public async Task SpeakAsync_MultipleConcurrentCalls_NoExceptions()
-    //{
-    //    // Arrange - ensure no lock file (messages will go to SpeakDirectAsync)
-    //    if (File.Exists(SpeechLockFilePath))
-    //    {
-    //        File.Delete(SpeechLockFilePath);
-    //    }
-    //
-    //    var tasks = new List<Task>();
-    //    var exceptions = new List<Exception>();
-    //
-    //    // Act - fire multiple concurrent calls
-    //    // These will try to play audio (which will fail in tests) but should not throw
-    //    // The semaphore should ensure they don't corrupt shared state
-    //    for (int i = 0; i < 5; i++)
-    //    {
-    //        var index = i;
-    //        tasks.Add(Task.Run(async () =>
-    //        {
-    //            try
-    //            {
-    //                await _sut.SpeakAsync($"Concurrent message {index}");
-    //            }
-    //            catch (Exception ex)
-    //            {
-    //                // WebSocket/audio errors are expected in test environment
-    //                // but ObjectDisposedException or semaphore errors would indicate a problem
-    //                if (ex is ObjectDisposedException or SemaphoreFullException)
-    //                {
-    //                    lock (exceptions)
-    //                    {
-    //                        exceptions.Add(ex);
-    //                    }
-    //                }
-    //            }
-    //        }));
-    //    }
-    //
-    //    await Task.WhenAll(tasks);
-    //
-    //    // Assert - no semaphore-related exceptions
-    //    Assert.Empty(exceptions);
-    //    // Queue should be empty (messages were attempted to be played, not queued)
-    //    Assert.Equal(0, _sut.QueueCount);
-    //}
-
-    /// <summary>
-    /// Tests that Dispose properly cleans up the semaphore without throwing.
-    /// </summary>
     [Fact]
     public void Dispose_MultipleCalls_NoExceptions()
     {
@@ -277,8 +193,10 @@ public class TtsServiceTests : IDisposable
         var configuration = new Mock<IConfiguration>();
         var sectionMock = new Mock<IConfigurationSection>();
         configuration.Setup(x => x.GetSection("TtsVoiceProfiles")).Returns(sectionMock.Object);
+        var primaryProvider = new Mock<ITtsProvider>();
+        primaryProvider.Setup(p => p.Name).Returns("EdgeTTS");
 
-        var service = new TtsService(logger.Object, configuration.Object);
+        var service = new TtsService(logger.Object, configuration.Object, primaryProvider.Object);
 
         // Act & Assert - multiple dispose calls should not throw
         service.Dispose();
@@ -286,5 +204,282 @@ public class TtsServiceTests : IDisposable
 
         // Note: Second dispose may throw ObjectDisposedException which is acceptable
         // We're mainly testing that the first dispose doesn't throw
+    }
+
+    [Fact]
+    public void ActiveProvider_Initially_ReturnsPrimaryProviderName()
+    {
+        // Act
+        var result = _sut.ActiveProvider;
+
+        // Assert
+        Assert.Equal("EdgeTTS", result);
+    }
+}
+
+/// <summary>
+/// Unit tests for TtsService fallback functionality.
+/// </summary>
+public class TtsServiceFallbackTests : IDisposable
+{
+    private readonly Mock<ILogger<TtsService>> _loggerMock;
+    private readonly Mock<IConfiguration> _configurationMock;
+    private readonly Mock<ITtsProvider> _primaryProviderMock;
+    private readonly Mock<ITtsProvider> _fallbackProviderMock;
+    private readonly Mock<ILocationService> _locationServiceMock;
+    private const string SpeechLockFilePath = "/tmp/speech-lock";
+    private static readonly string CacheDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".cache", "virtual-assistant-tts");
+
+    public TtsServiceFallbackTests()
+    {
+        _loggerMock = new Mock<ILogger<TtsService>>();
+        _configurationMock = new Mock<IConfiguration>();
+        _primaryProviderMock = new Mock<ITtsProvider>();
+        _fallbackProviderMock = new Mock<ITtsProvider>();
+        _locationServiceMock = new Mock<ILocationService>();
+
+        // Setup provider names
+        _primaryProviderMock.Setup(p => p.Name).Returns("EdgeTTS");
+        _fallbackProviderMock.Setup(p => p.Name).Returns("Piper");
+
+        // Setup empty configuration section
+        var sectionMock = new Mock<IConfigurationSection>();
+        _configurationMock.Setup(x => x.GetSection("TtsVoiceProfiles")).Returns(sectionMock.Object);
+
+        // Ensure clean state
+        if (File.Exists(SpeechLockFilePath))
+        {
+            File.Delete(SpeechLockFilePath);
+        }
+
+        // Clean cache directory to ensure tests call providers
+        CleanCacheDirectory();
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(SpeechLockFilePath))
+        {
+            File.Delete(SpeechLockFilePath);
+        }
+    }
+
+    private static void CleanCacheDirectory()
+    {
+        if (Directory.Exists(CacheDirectory))
+        {
+            foreach (var file in Directory.GetFiles(CacheDirectory, "test-*"))
+            {
+                try { File.Delete(file); } catch { }
+            }
+        }
+    }
+
+    private TtsService CreateService(TtsFallbackOptions? options = null)
+    {
+        return new TtsService(
+            _loggerMock.Object,
+            _configurationMock.Object,
+            _primaryProviderMock.Object,
+            _fallbackProviderMock.Object,
+            _locationServiceMock.Object,
+            Options.Create(options ?? new TtsFallbackOptions()));
+    }
+
+    [Fact]
+    public void Constructor_WithProviders_LogsInitialization()
+    {
+        // Act
+        using var sut = CreateService();
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("TTS service initialized")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Constructor_WithoutFallbackProvider_InitializesSuccessfully()
+    {
+        // Act
+        using var sut = new TtsService(
+            _loggerMock.Object,
+            _configurationMock.Object,
+            _primaryProviderMock.Object);
+
+        // Assert
+        Assert.Equal("EdgeTTS", sut.ActiveProvider);
+    }
+
+    [Fact]
+    public async Task SpeakAsync_WhenVpnActive_UsesFallbackProvider()
+    {
+        // Arrange
+        var uniqueText = $"test-vpn-active-{Guid.NewGuid()}";
+        _locationServiceMock.Setup(l => l.IsVpnActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _fallbackProviderMock.Setup(p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 1, 2, 3 });
+
+        using var sut = CreateService(new TtsFallbackOptions
+        {
+            EnableFallback = true,
+            CheckLocation = true,
+            SilentOnFailure = true
+        });
+
+        // Act
+        await sut.SpeakAsync(uniqueText);
+
+        // Assert - fallback provider should be used due to VPN
+        _fallbackProviderMock.Verify(
+            p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SpeakAsync_WhenVpnNotActive_UsesPrimaryProvider()
+    {
+        // Arrange
+        var uniqueText = $"test-vpn-not-active-{Guid.NewGuid()}";
+        _locationServiceMock.Setup(l => l.IsVpnActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _primaryProviderMock.Setup(p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 1, 2, 3 });
+
+        using var sut = CreateService(new TtsFallbackOptions
+        {
+            EnableFallback = true,
+            CheckLocation = true,
+            SilentOnFailure = true
+        });
+
+        // Act
+        await sut.SpeakAsync(uniqueText);
+
+        // Assert - primary provider should be used
+        _primaryProviderMock.Verify(
+            p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SpeakAsync_WhenPrimaryFails_FallsBackToSecondary()
+    {
+        // Arrange
+        var uniqueText = $"test-primary-fails-{Guid.NewGuid()}";
+        _locationServiceMock.Setup(l => l.IsVpnActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _primaryProviderMock.Setup(p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null); // Primary fails
+        _fallbackProviderMock.Setup(p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 1, 2, 3 });
+
+        using var sut = CreateService(new TtsFallbackOptions
+        {
+            EnableFallback = true,
+            CheckLocation = true,
+            SilentOnFailure = true
+        });
+
+        // Act
+        await sut.SpeakAsync(uniqueText);
+
+        // Assert - both providers should be called (primary failed, fallback used)
+        _primaryProviderMock.Verify(
+            p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _fallbackProviderMock.Verify(
+            p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SpeakAsync_WhenFallbackDisabled_DoesNotUseFallback()
+    {
+        // Arrange
+        var uniqueText = $"test-fallback-disabled-{Guid.NewGuid()}";
+        _locationServiceMock.Setup(l => l.IsVpnActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _primaryProviderMock.Setup(p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null); // Primary fails
+
+        using var sut = CreateService(new TtsFallbackOptions
+        {
+            EnableFallback = false,
+            SilentOnFailure = true
+        });
+
+        // Act
+        await sut.SpeakAsync(uniqueText);
+
+        // Assert - fallback should NOT be called
+        _fallbackProviderMock.Verify(
+            p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SpeakAsync_WhenLocationCheckDisabled_DoesNotCheckVpn()
+    {
+        // Arrange
+        var uniqueText = $"test-location-disabled-{Guid.NewGuid()}";
+        _primaryProviderMock.Setup(p => p.GenerateAudioAsync(
+                It.IsAny<string>(),
+                It.IsAny<VoiceConfig>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 1, 2, 3 });
+
+        using var sut = CreateService(new TtsFallbackOptions
+        {
+            EnableFallback = true,
+            CheckLocation = false,
+            SilentOnFailure = true
+        });
+
+        // Act
+        await sut.SpeakAsync(uniqueText);
+
+        // Assert - location service should NOT be called
+        _locationServiceMock.Verify(
+            l => l.IsVpnActiveAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
## Summary

This PR implements a TTS fallback mechanism that automatically switches to a local Piper TTS provider when Edge TTS is unavailable (e.g., when VPN is connected to a non-CZ location).

Closes #109

## Changes

### New Files
- `ITtsProvider.cs` - Interface for TTS providers
- `EdgeTtsProvider.cs` - Extracted Edge TTS logic into a separate provider
- `PiperTtsProvider.cs` - Local TTS fallback using Piper
- `ILocationService.cs` - Interface for location/VPN detection
- `LocationService.cs` - VPN detection via ip-api.com
- `TtsFallbackOptions.cs` - Configuration for fallback behavior
- `PiperOptions.cs` - Configuration for Piper TTS
- `LocationServiceTests.cs` - Unit tests for location service

### Modified Files
- `TtsService.cs` - Refactored to support multiple providers with fallback
- `TtsServiceTests.cs` - Updated tests for new architecture

## Architecture

```
TtsService (orchestrator)
├── ITtsProvider _primaryProvider (EdgeTtsProvider)
├── ITtsProvider _fallbackProvider (PiperTtsProvider)
├── ILocationService _locationService
└── TtsFallbackOptions _options
```

## Configuration Options

| Option | Default | Description |
|--------|---------|-------------|
| `EnableFallback` | `true` | Enable automatic fallback to Piper |
| `CheckLocation` | `true` | Use location service for VPN detection |
| `SilentOnFailure` | `true` | Silent mode when all providers fail |
| `AlwaysCheckAvailability` | `false` | Periodic availability checks |

## Piper Configuration

```json
{
  "Piper": {
    "PiperPath": "piper",
    "ModelPath": "~/virtual-assistant/piper-voices/cs/cs_CZ-jirka-medium.onnx",
    "LengthScale": 1.0
  }
}
```

## Test Plan

- [x] All 70 unit tests pass
- [ ] Manual test: TTS works without VPN (Edge TTS)
- [ ] Manual test: TTS works with VPN connected (Piper fallback)
- [ ] Manual test: TTS fails gracefully when both providers unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)