### PR TITLE
fix: Change opencode TTS voice rate from +40% to +25%

### DIFF
--- a/src/VirtualAssistant.Service/appsettings.json
+++ b/src/VirtualAssistant.Service/appsettings.json
@@ -37,7 +37,7 @@
       },
       "opencode": {
         "Voice": "cs-CZ-AntoninNeural",
-        "Rate": "+40%",
+        "Rate": "+25%",
         "Volume": "+0%",
         "Pitch": "+3st"
       },


### PR DESCRIPTION
## Summary

Sync source code with runtime configuration. The +40% rate was too fast, +25% provides better listening experience.

## Changes

- `src/VirtualAssistant.Service/appsettings.json`: Change opencode TTS voice rate from `+40%` to `+25%`

## Test Plan

- [x] Verify the change in source code matches runtime config
- [ ] Manual test: TTS playback for opencode should be at natural speed

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)