### PR TITLE
fix: Play tear paper sound when transcription is cancelled

### DIFF
--- a/src/VirtualAssistant.PushToTalk.Service/DictationWorker.cs
+++ b/src/VirtualAssistant.PushToTalk.Service/DictationWorker.cs
@@ -351,6 +351,10 @@ public class DictationWorker : BackgroundService
                 catch (OperationCanceledException)
                 {
                     _logger.LogInformation("Transcription cancelled by user (Escape key pressed)");
+
+                    // Play tear paper sound to indicate cancellation
+                    _ = Task.Run(async () => await _typingSoundPlayer.PlayTearPaperAsync());
+
                     await _pttNotifier.NotifyTranscriptionFailedAsync("Transcription cancelled");
                 }
                 finally
@@ -363,6 +367,10 @@ public class DictationWorker : BackgroundService
             else
             {
                 _logger.LogWarning("No audio data recorded");
+
+                // Play tear paper sound to indicate nothing was recorded
+                _ = Task.Run(async () => await _typingSoundPlayer.PlayTearPaperAsync());
+
                 await _pttNotifier.NotifyTranscriptionFailedAsync("No audio data recorded");
             }
         }


### PR DESCRIPTION
## Summary

Added paper tearing sound feedback when transcription is cancelled or discarded.

## Changes

`src/VirtualAssistant.PushToTalk.Service/DictationWorker.cs`:
- Added `PlayTearPaperAsync()` call when Escape key cancels transcription
- Added `PlayTearPaperAsync()` call when CapsLock was pressed too briefly (no audio recorded)

## Test Plan

- [x] Unit tests pass (53 tests)
- [ ] Manual test: Press Escape during transcription → hear tear paper sound
- [ ] Manual test: Quick CapsLock press (no audio) → hear tear paper sound

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)