### PR TITLE
Add dictation toggle menu item

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/ServiceCollectionExtensions.cs
@@ -409,6 +409,7 @@ public static class ServiceCollectionExtensions
             var sttServiceManager = sp.GetRequiredService<SpeechToTextServiceManager>();
             var mistralProvider = sp.GetService<Olbrasoft.VirtualAssistant.Voice.Services.ILlmProvider>() as Olbrasoft.VirtualAssistant.Voice.Services.MistralProvider;
             var dictationStateMachine = sp.GetRequiredService<Olbrasoft.VirtualAssistant.Voice.StateMachine.IDictationStateMachine>();
+            var dictationWorker = sp.GetRequiredService<DictationWorker>();
             var options = sp.GetRequiredService<IOptions<ContinuousListenerOptions>>();
             var iconsPath = Path.Combine(AppContext.BaseDirectory, "icons");
 
@@ -422,7 +423,8 @@ public static class ServiceCollectionExtensions
                 menuHandler,
                 sttServiceManager,
                 mistralProvider,
-                dictationStateMachine);
+                dictationStateMachine,
+                dictationWorker);
         });
 
         return services;
@@ -444,7 +446,8 @@ public static class ServiceCollectionExtensions
 
         // Dictation worker (Phase 5 - keyboard-triggered dictation)
         // Uses dedicated AudioCaptureService and TranscriptionService instances (not shared with continuous listening)
-        services.AddHostedService(sp =>
+        // Register as singleton first so it can be injected into TrayService
+        services.AddSingleton(sp =>
         {
             var logger = sp.GetRequiredService<ILogger<DictationWorker>>();
             var keyboardMonitor = sp.GetRequiredService<IKeyboardMonitor>();
@@ -489,6 +492,9 @@ public static class ServiceCollectionExtensions
                 typingSound,
                 scopeFactory);
         });
+
+        // Register the same singleton instance as hosted service
+        services.AddHostedService(sp => sp.GetRequiredService<DictationWorker>());
 
         // TODO: Remove after testing new workers
         // services.AddHostedService<ContinuousListenerWorker>();

--- a/src/VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs
@@ -31,6 +31,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
     private const int Separator4Id = 11;
     private const int QuitId = 12;
     private const int LogViewerId = 13;
+    private const int DictationToggleId = 14;
 
     /// <summary>
     /// Event fired when user selects Quit from the menu.
@@ -87,12 +88,18 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
     /// </summary>
     public event Action? OnReloadPromptRequested;
 
+    /// <summary>
+    /// Event fired when user toggles dictation on/off.
+    /// </summary>
+    public event Action<bool>? OnDictationToggleRequested;
+
     private bool _isMuted;
     private bool _isTextToSpeechServiceRunning;
     private string _sttServiceStatus = "Checking...";
     private string _sttServiceVersion = "Unknown";
     private string _logViewerStatus = "Checking...";
     private bool _llmCorrectionEnabled = true;
+    private bool _dictationEnabled = true;
 
     public VirtualAssistantDBusMenuHandler(ILogger logger) : base(emitOnCapturedContext: false)
     {
@@ -210,6 +217,18 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
     }
 
     /// <summary>
+    /// Updates dictation enabled status in menu.
+    /// </summary>
+    public void UpdateDictationStatus(bool enabled)
+    {
+        _dictationEnabled = enabled;
+        _revision++;
+
+        // Emit LayoutUpdated signal to notify menu changed
+        EmitLayoutUpdated(_revision, RootId);
+    }
+
+    /// <summary>
     /// Returns the menu layout starting from the specified parent ID.
     /// </summary>
     protected override ValueTask<(uint Revision, (int, Dictionary<string, VariantValue>, VariantValue[]) Layout)> OnGetLayoutAsync(
@@ -246,6 +265,9 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
                 var sttServiceLabel = _sttServiceStatus == "Running"
                     ? "✅ STT Service - Vypnout"
                     : "❌ STT Service - Zapnout";
+                var dictationLabel = _dictationEnabled
+                    ? "✅ Diktace - Vypnout"
+                    : "❌ Diktace - Zapnout";
                 var logViewerLabel = _logViewerStatus == "Running"
                     ? "✅ Log Viewer - Vypnout"
                     : "❌ Log Viewer - Zapnout";
@@ -256,6 +278,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
                     CreateChildVariant(TextToSpeechToggleId, ttsToggleLabel, false),
                     CreateChildVariant(Separator1Id, "", true),
                     CreateChildVariant(SpeechToTextServiceId, sttServiceLabel, false),
+                    CreateChildVariant(DictationToggleId, dictationLabel, false),
                     CreateChildVariant(Separator2Id, "", true),
                     CreateChildVariant(LlmCorrectionId, llmCorrectionLabel, false),
                     CreateChildVariant(ReloadPromptId, "🔄 Reload LLM Prompt", false),
@@ -331,6 +354,14 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
                 props["enabled"] = VariantValue.Bool(true);
                 props["visible"] = VariantValue.Bool(true);
                 break;
+            case DictationToggleId:
+                var dictationLabel = _dictationEnabled
+                    ? "✅ Diktace - Vypnout"
+                    : "❌ Diktace - Zapnout";
+                props["label"] = VariantValue.String(dictationLabel);
+                props["enabled"] = VariantValue.Bool(true);
+                props["visible"] = VariantValue.Bool(true);
+                break;
             case LogViewerId:
                 var logViewerLabel = _logViewerStatus == "Running"
                     ? "✅ Log Viewer - Vypnout"
@@ -399,6 +430,9 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
         var sttServiceLabel = _sttServiceStatus == "Running"
             ? "✅ STT Service - Vypnout"
             : "❌ STT Service - Zapnout";
+        var dictationLabel = _dictationEnabled
+            ? "✅ Diktace - Vypnout"
+            : "❌ Diktace - Zapnout";
         var logViewerLabel = _logViewerStatus == "Running"
             ? "✅ Log Viewer - Vypnout"
             : "❌ Log Viewer - Zapnout";
@@ -424,6 +458,12 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
             SpeechToTextServiceId => (id, new Dictionary<string, VariantValue>
             {
                 ["label"] = VariantValue.String(sttServiceLabel),
+                ["enabled"] = VariantValue.Bool(true),
+                ["visible"] = VariantValue.Bool(true)
+            }),
+            DictationToggleId => (id, new Dictionary<string, VariantValue>
+            {
+                ["label"] = VariantValue.String(dictationLabel),
                 ["enabled"] = VariantValue.Bool(true),
                 ["visible"] = VariantValue.Bool(true)
             }),
@@ -551,6 +591,14 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
                 case ReloadPromptId:
                     _logger.LogInformation("Reload LLM Prompt menu item clicked");
                     OnReloadPromptRequested?.Invoke();
+                    break;
+                case DictationToggleId:
+                    _logger.LogInformation("Dictation toggle clicked (current: {Enabled})", _dictationEnabled);
+                    // Toggle dictation
+                    _dictationEnabled = !_dictationEnabled;
+                    OnDictationToggleRequested?.Invoke(_dictationEnabled);
+                    // Update menu to reflect new state
+                    UpdateDictationStatus(_dictationEnabled);
                     break;
                 default:
                     _logger.LogWarning("Unknown menu item clicked: id={Id}", id);

--- a/src/VirtualAssistant.Service/Tray/VirtualAssistantTrayService.cs
+++ b/src/VirtualAssistant.Service/Tray/VirtualAssistantTrayService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Olbrasoft.SystemTray.Linux;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Service.Services;
+using Olbrasoft.VirtualAssistant.Service.Workers;
 using Olbrasoft.VirtualAssistant.Voice.Services;
 using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 
@@ -23,6 +24,7 @@ public class VirtualAssistantTrayService : IDisposable
     private readonly SpeechToTextServiceManager? _sttServiceManager;
     private readonly MistralProvider? _mistralProvider;
     private readonly IDictationStateMachine? _dictationStateMachine;
+    private readonly DictationWorker? _dictationWorker;
     private ITrayIcon? _trayIcon;
     private ITrayIcon? _sttIcon;
     private bool _disposed;
@@ -46,7 +48,8 @@ public class VirtualAssistantTrayService : IDisposable
         ITrayMenuHandler? menuHandler = null,
         SpeechToTextServiceManager? sttServiceManager = null,
         MistralProvider? mistralProvider = null,
-        IDictationStateMachine? dictationStateMachine = null)
+        IDictationStateMachine? dictationStateMachine = null,
+        DictationWorker? dictationWorker = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _manager = manager ?? throw new ArgumentNullException(nameof(manager));
@@ -58,6 +61,7 @@ public class VirtualAssistantTrayService : IDisposable
         _sttServiceManager = sttServiceManager;
         _mistralProvider = mistralProvider;
         _dictationStateMachine = dictationStateMachine;
+        _dictationWorker = dictationWorker;
 
         // Subscribe to mute state changes
         _muteService.MuteStateChanged += OnMuteStateChanged;
@@ -85,6 +89,7 @@ public class VirtualAssistantTrayService : IDisposable
             handler.OnStopLogViewerRequested += HandleStopLogViewerService;
             handler.OnLlmCorrectionToggled += HandleLlmCorrectionToggle;
             handler.OnReloadPromptRequested += HandleReloadPrompt;
+            handler.OnDictationToggleRequested += HandleDictationToggle;
             _logger.LogDebug("Menu handler events wired up successfully");
         }
         else
@@ -532,6 +537,25 @@ public class VirtualAssistantTrayService : IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to reload Mistral prompt");
+        }
+    }
+
+    private void HandleDictationToggle(bool enabled)
+    {
+        try
+        {
+            if (_dictationWorker == null)
+            {
+                _logger.LogWarning("DictationWorker not available");
+                return;
+            }
+
+            _logger.LogInformation("Setting dictation enabled: {Enabled}", enabled);
+            _dictationWorker.SetDictationEnabled(enabled);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to toggle dictation");
         }
     }
 

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -32,6 +32,7 @@ public class DictationWorker : BackgroundService
     private List<byte> _audioBuffer = new();
     private readonly object _bufferLock = new();
     private Task? _recordingTask;
+    private bool _dictationEnabled = true;
 
     public DictationWorker(
         ILogger<DictationWorker> logger,
@@ -51,6 +52,24 @@ public class DictationWorker : BackgroundService
         _keyboardSimulation = keyboardSimulation ?? throw new ArgumentNullException(nameof(keyboardSimulation));
         _typingSound = typingSound ?? throw new ArgumentNullException(nameof(typingSound));
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+    }
+
+    /// <summary>
+    /// Enables or disables dictation functionality.
+    /// When disabled, CapsLock key events are ignored.
+    /// If currently recording/transcribing, performs emergency stop.
+    /// </summary>
+    public void SetDictationEnabled(bool enabled)
+    {
+        _dictationEnabled = enabled;
+        _logger.LogInformation("Dictation {Status}", enabled ? "enabled" : "disabled");
+
+        // If disabling and currently recording/transcribing, emergency stop
+        if (!enabled && _stateMachine.CurrentState != DictationState.Idle)
+        {
+            _logger.LogInformation("Dictation disabled while active - performing emergency stop");
+            Task.Run(async () => await EmergencyStopAsync());
+        }
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -90,6 +109,10 @@ public class DictationWorker : BackgroundService
     {
         try
         {
+            // Ignore all keys when dictation is disabled
+            if (!_dictationEnabled)
+                return;
+
             // Escape - cancel transcription
             if (e.Key == KeyCode.Escape && _stateMachine.CurrentState == DictationState.Transcribing)
             {


### PR DESCRIPTION
## Summary

Implements toggle menu item to enable/disable dictation functionality (Caps Lock response). Resolves #356.

## Changes

### Menu Item
- **Position**: Below "STT Service - Vypnout" in System Tray menu
- **Label**: 
  - `✅ Diktace - Vypnout` (when enabled)
  - `❌ Diktace - Zapnout` (when disabled)
- **Default state**: Enabled (dictation active)

### Implementation

**1. VirtualAssistantDBusMenuHandler.cs**
- Added `DictationToggleId = 14` constant
- Added `_dictationEnabled` state field (default: true)
- Added `OnDictationToggleRequested` event
- Added `UpdateDictationStatus(bool enabled)` method
- Updated menu layout generation to include dictation toggle
- Added event handler for menu item clicks

**2. VirtualAssistantTrayService.cs**
- Injected `DictationWorker` dependency
- Wired up `OnDictationToggleRequested` event
- Added `HandleDictationToggle(bool enabled)` handler method

**3. DictationWorker.cs**
- Added `_dictationEnabled` field
- Added public `SetDictationEnabled(bool enabled)` method
- Updated `OnKeyReleased()` to ignore all keys when dictation is disabled
- Performs emergency stop if disabling while recording/transcribing

**4. ServiceCollectionExtensions.cs**
- Registered `DictationWorker` as singleton (for injection into TrayService)
- Maintained hosted service registration using the singleton instance

## Behavior

| State | Display | Caps Lock | Notes |
|-------|---------|-----------|-------|
| Enabled | ✅ Diktace - Vypnout | Active | Normal dictation workflow |
| Disabled | ❌ Diktace - Zapnout | Ignored | Caps Lock events not processed |

**Toggle behavior:**
- Click toggles between enabled/disabled
- If recording/transcribing when disabled → emergency stop
- Menu refreshes automatically to show new state

## Testing

### Build & Tests
✅ Build: Successful (0 errors)  
✅ Tests: All passing (297/297)

### Manual Testing Checklist
- [ ] Menu item appears below "STT Service - Vypnout"
- [ ] Default state shows ✅ Diktace - Vypnout
- [ ] Clicking toggles label to ❌ Diktace - Zapnut
- [ ] Clicking again toggles back to ✅ Diktace - Vypnout
- [ ] When enabled, Caps Lock starts/stops recording
- [ ] When disabled, Caps Lock does nothing
- [ ] Emergency stop works when disabling during recording
- [ ] Menu refreshes correctly after toggle

## Architecture

Follows existing pattern used by other toggle items:
- TextToSpeech toggle (TextToSpeechToggleId)
- STT Service toggle (SpeechToTextServiceId)
- LLM Correction toggle (LlmCorrectionId)
- Mute toggle (MuteToggleId)

Event flow:
```
User clicks menu → OnEventAsync(DictationToggleId) 
                 → OnDictationToggleRequested?.Invoke(enabled)
                 → HandleDictationToggle(enabled)
                 → DictationWorker.SetDictationEnabled(enabled)
                 → UpdateDictationStatus(enabled) 
                 → EmitLayoutUpdated() 
                 → Menu refreshes
```

## Related Issues

Closes #356