### PR TITLE
Change default dictation state to disabled on startup

### DIFF
--- a/src/VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs
@@ -99,7 +99,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, IT
     private string _sttServiceVersion = "Unknown";
     private string _logViewerStatus = "Checking...";
     private bool _llmCorrectionEnabled = true;
-    private bool _dictationEnabled = true;
+    private bool _dictationEnabled = false;
 
     public VirtualAssistantDBusMenuHandler(ILogger logger) : base(emitOnCapturedContext: false)
     {

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -32,7 +32,7 @@ public class DictationWorker : BackgroundService
     private List<byte> _audioBuffer = new();
     private readonly object _bufferLock = new();
     private Task? _recordingTask;
-    private bool _dictationEnabled = true;
+    private bool _dictationEnabled = false;
 
     public DictationWorker(
         ILogger<DictationWorker> logger,


### PR DESCRIPTION
## Summary

Implements #360 - Changes default dictation state to **disabled** on application startup.

### Changes:
- ✅ Changed `DictationWorker._dictationEnabled` from `true` → `false`
- ✅ Changed `VirtualAssistantDBusMenuHandler._dictationEnabled` from `true` → `false`

### Behavior After This Fix:

**Before (current):**
- App starts → Diktace **ENABLED** ✅
- Menu shows: "✅ Diktace - Vypnout"
- CapsLock triggers recording immediately

**After (this PR):**
- App starts → Diktace **DISABLED** ❌
- Menu shows: "❌ Diktace - Zapnout"
- CapsLock does nothing until user enables dictation
- User must click "Zapnout" to activate dictation

### Benefits:

1. **Prevents accidental triggering** - User won't accidentally start recording
2. **Explicit control** - User must consciously enable dictation when needed
3. **Visual clarity** - Red ❌ clearly indicates dictation is OFF
4. **Resource efficiency** - Keyboard monitoring active only when needed

### Visual Indication (Already Working ✅):

The menu already has emoji indicators:
- ❌ **Red X** = Dictation disabled (can be enabled)
- ✅ **Green checkmark** = Dictation enabled (can be disabled)

## Test Plan

- [x] Build successful (0 errors)
- [x] All tests passing (297/297)
- [x] Changed 2 lines in 2 files
- [x] Both components (Worker + MenuHandler) in sync

### Manual Testing Required:

1. ✅ **Startup check**:
   - Deploy and restart VirtualAssistant
   - Verify menu shows: "❌ Diktace - Zapnout"
   - Press CapsLock → verify nothing happens (dictation disabled)

2. ✅ **Enable dictation**:
   - Click menu: "❌ Diktace - Zapnout"
   - Verify menu changes to: "✅ Diktace - Vypnout"
   - Press CapsLock → verify recording starts

3. ✅ **Disable dictation**:
   - Click menu: "✅ Diktace - Vypnout"
   - Verify menu changes to: "❌ Diktace - Zapnout"
   - Press CapsLock → verify nothing happens

4. ✅ **Restart persistence**:
   - Enable dictation via menu
   - Restart VirtualAssistant
   - Verify menu shows: "❌ Diktace - Zapnout" (state NOT persisted - expected)

## Files Modified

| File | Line | Change |
|------|------|--------|
| `VirtualAssistant.Service/Workers/DictationWorker.cs` | 35 | `true` → `false` |
| `VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs` | 102 | `true` → `false` |

**Total:** 2 lines changed in 2 files

## Notes

- **State is NOT persisted** across restarts (no database/config save)
- Each restart = fresh state (disabled by default after this fix)
- User must manually enable dictation after each restart
- This is **intended behavior** per user request

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)