### PR TITLE
Fix: Return to paste simulation with timeout (issue #398)

### DIFF
--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -55,21 +55,17 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             // Small delay to ensure clipboard is ready
             await Task.Delay(50, cancellationToken);
 
-            // Step 3: Type text directly using dotool (faster and more reliable than paste simulation)
-            _logger.LogInformation("Typing text directly using dotool type command");
-
-            // Escape text for dotool: newlines become literal \n, backslashes need escaping
-            var escapedText = textToType
-                .Replace("\\", "\\\\")  // Escape backslashes first
-                .Replace("\n", "\\n")   // Convert newlines to \n
-                .Replace("\r", "");     // Remove carriage returns
+            // Step 3: Simulate paste using dotool (clipboard already contains our text)
+            // Note: dotool type doesn't support Czech diacritics properly, so we use paste simulation
+            var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
+            _logger.LogInformation("Simulating paste with shortcut: {Shortcut}", pasteShortcut);
 
             var dotoolProcess = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "/bin/bash",
-                    Arguments = $"-c \"echo 'type {escapedText.Replace("'", "'\\''")}' | dotool\"",
+                    Arguments = $"-c \"echo 'key {pasteShortcut}' | dotool\"",
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
@@ -79,14 +75,14 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
 
             dotoolProcess.Start();
 
-            // Add timeout to prevent hanging (max 5 seconds for typing)
+            // Add timeout to prevent hanging (max 5 seconds for paste)
             var dotoolTask = dotoolProcess.WaitForExitAsync(cancellationToken);
             var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
             var completedTask = await Task.WhenAny(dotoolTask, timeoutTask);
 
             if (completedTask == timeoutTask)
             {
-                _logger.LogError("dotool type timeout after 5 seconds, killing process");
+                _logger.LogError("dotool paste timeout after 5 seconds, killing process");
                 try
                 {
                     dotoolProcess.Kill();
@@ -104,6 +100,9 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
                 _logger.LogError("dotool failed with exit code {ExitCode}: {Error}", dotoolProcess.ExitCode, error);
                 return false;
             }
+
+            // Small delay to ensure paste completed
+            await Task.Delay(100, cancellationToken);
 
             // Step 4: Restore original clipboard content
             if (!string.IsNullOrEmpty(originalClipboard))
@@ -134,4 +133,18 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
         }
     }
 
+    /// <summary>
+    /// Gets the appropriate paste shortcut based on the active window type.
+    /// Terminals use Ctrl+Shift+V, other applications use Ctrl+V.
+    /// </summary>
+    private async Task<string> GetPasteShortcutAsync(CancellationToken cancellationToken)
+    {
+        var isTerminal = await _terminalDetector.IsTerminalActiveAsync(cancellationToken);
+        var pasteShortcut = isTerminal ? "ctrl+shift+v" : "ctrl+v";
+
+        _logger.LogInformation("Using paste shortcut: {Shortcut} (terminal: {IsTerminal})",
+            pasteShortcut, isTerminal);
+
+        return pasteShortcut;
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #398 - Returns to paste simulation approach with timeout protection. dotool type command doesn't support Czech diacritics properly.

## Problem

After trying `dotool type` approach:
- ✅ Text in clipboard (CopyQ) is **CORRECT** (Whisper + Mistral work perfectly)
- ❌ What `dotool type` writes is **WRONG** (missing háčky, čárky)
- `dotool type` has only heuristic support for dead keys and fails with Czech

## Solution

Return to paste simulation but with critical improvement:
- Use `dotool key ctrl+v` (paste from clipboard which has correct text)
- Add **5-second timeout** to prevent infinite hangs
- Kill process if timeout occurs

## Changes

1. **Reverted to paste approach** - clipboard has correct Czech text
2. **Added timeout protection** - max 5 seconds, then kill process
3. **Terminal detection** - ctrl+shift+v for terminals, ctrl+v for other apps
4. **Maintains CopyQ backup** - text still in clipboard for safety

## Benefits vs Original

**Original problem:**
- dotool paste hangs for 60+ seconds ❌
- No timeout protection ❌

**This fix:**
- dotool paste with 5-second timeout ✅
- Czech characters work correctly ✅
- Worst case: 5-second delay instead of 60+ seconds ✅
- Text always available in CopyQ ✅

## Testing Needed

Please test dictation with Czech text:
1. Dictate: "Žluťoučký kůň pěl ódy"
2. Verify háčky and čárky display correctly
3. Check CopyQ has text in position #2
4. Confirm no 60+ second hangs (max 5 seconds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)