### PR TITLE
Fix flaky EmergencyStopAsync test in Release builds

### DIFF
--- a/tests/VirtualAssistant.Voice.Tests/Services/AudioRecordingCoordinatorTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/AudioRecordingCoordinatorTests.cs
@@ -164,8 +164,14 @@ public class AudioRecordingCoordinatorTests
     {
         // Arrange
         var chunk = new byte[] { 1, 2, 3 };
+        var callCount = 0;
         _audioCaptureMock.Setup(x => x.ReadChunkAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(chunk);
+            .ReturnsAsync(() =>
+            {
+                // Return chunk for first recording, null for second recording (after emergency stop)
+                callCount++;
+                return callCount <= 2 ? chunk : null;
+            });
 
         await _sut.StartRecordingAsync();
         await Task.Delay(100); // Allow chunk to be captured


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes timing-dependent test failure in Release builds that was causing CI deployment failures.

## Problem

Test `EmergencyStopAsync_StopsRecordingAndDiscardsData` in `AudioRecordingCoordinatorTests.cs` was failing in Release configuration with:
```
Assert.Empty() Failure: Collection was not empty
Collection: [1, 2, 3]
```

**Root cause:** Mock setup returned the same chunk data on consecutive recording sessions, but the second recording session (after emergency stop) should have an empty buffer.

## Solution

Modified mock setup to use a closure that tracks call count:
```csharp
var callCount = 0;
_audioCaptureMock.Setup(x => x.ReadChunkAsync(It.IsAny<CancellationToken>()))
    .ReturnsAsync(() =>
    {
        callCount++;
        return callCount <= 2 ? chunk : null;
    });
```

This ensures:
- First recording session gets chunks (calls 1-2)
- Second recording session (after emergency stop) gets null (call 3+)
- Deterministic behavior across Debug and Release builds

## Test Results

✅ All 201 Voice tests pass in Release configuration
✅ Specific test now passes consistently

## Related

Fixes deployment failure in GitHub Actions run #20618072995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)