### PR TITLE
Create ISoundEffectPlayer interface for sound players (#436)

### DIFF
--- a/src/VirtualAssistant.Core/Audio/CancelSoundPlayer.cs
+++ b/src/VirtualAssistant.Core/Audio/CancelSoundPlayer.cs
@@ -8,7 +8,7 @@ namespace Olbrasoft.VirtualAssistant.Core.Audio;
 /// Plays a paper-rip sound effect to indicate discarding of transcribed content.
 /// Uses pw-cat (PipeWire) or paplay (PulseAudio) to play audio.
 /// </summary>
-public class CancelSoundPlayer : IDisposable
+public class CancelSoundPlayer : ISoundEffectPlayer, IDisposable
 {
     private readonly ILogger<CancelSoundPlayer> _logger;
     private readonly string? _soundFilePath;
@@ -88,6 +88,24 @@ public class CancelSoundPlayer : IDisposable
                 _logger.LogDebug(ex, "Error playing cancel sound");
             }
         });
+    }
+
+    /// <summary>
+    /// Not applicable for cancel sound - this is a one-shot sound effect.
+    /// </summary>
+    public void StartLoop()
+    {
+        // Cancel sound is not designed for looping
+        _logger.LogDebug("StartLoop called on CancelSoundPlayer (no-op)");
+    }
+
+    /// <summary>
+    /// Not applicable for cancel sound - this is a one-shot sound effect.
+    /// </summary>
+    public void StopLoop()
+    {
+        // Cancel sound is not designed for looping
+        _logger.LogDebug("StopLoop called on CancelSoundPlayer (no-op)");
     }
 
     private async Task PlayOnceAsync(CancellationToken cancellationToken)

--- a/src/VirtualAssistant.Core/Audio/ISoundEffectPlayer.cs
+++ b/src/VirtualAssistant.Core/Audio/ISoundEffectPlayer.cs
@@ -1,0 +1,23 @@
+namespace Olbrasoft.VirtualAssistant.Core.Audio;
+
+/// <summary>
+/// Interface for sound effect players.
+/// Enables dependency inversion for audio playback components.
+/// </summary>
+public interface ISoundEffectPlayer
+{
+    /// <summary>
+    /// Plays the sound effect once.
+    /// </summary>
+    void Play();
+
+    /// <summary>
+    /// Starts continuous looping playback of the sound effect.
+    /// </summary>
+    void StartLoop();
+
+    /// <summary>
+    /// Stops the continuous looping playback.
+    /// </summary>
+    void StopLoop();
+}

--- a/src/VirtualAssistant.Core/Audio/TypingSoundPlayer.cs
+++ b/src/VirtualAssistant.Core/Audio/TypingSoundPlayer.cs
@@ -7,7 +7,7 @@ namespace Olbrasoft.VirtualAssistant.Core.Audio;
 /// Service for playing typing sound during transcription.
 /// Uses pw-cat (PipeWire) or paplay (PulseAudio) to play audio.
 /// </summary>
-public class TypingSoundPlayer : IDisposable
+public class TypingSoundPlayer : ISoundEffectPlayer, IDisposable
 {
     private readonly ILogger<TypingSoundPlayer> _logger;
     private readonly string? _soundFilePath;
@@ -67,6 +67,28 @@ public class TypingSoundPlayer : IDisposable
     /// Gets whether sound playback is enabled.
     /// </summary>
     public bool IsEnabled => !string.IsNullOrWhiteSpace(_soundFilePath) && File.Exists(_soundFilePath);
+
+    /// <summary>
+    /// Plays the typing sound once.
+    /// </summary>
+    public void Play()
+    {
+        if (_disposed || !IsEnabled)
+            return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                await PlayOnceAsync(cts.Token);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Error playing typing sound");
+            }
+        });
+    }
 
     /// <summary>
     /// Starts playing the typing sound in a loop.

--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -97,8 +97,8 @@ public static class VoiceServicesExtensions
         services.AddSingleton<ITerminalDetector, WaylandTerminalDetector>();
         services.AddSingleton<IKeyboardSimulationService, XDoToolKeyboardService>();
 
-        // Typing sound player for dictation feedback
-        services.AddSingleton(sp =>
+        // Typing sound player for dictation feedback (keyed service)
+        services.AddKeyedSingleton<ISoundEffectPlayer, TypingSoundPlayer>("typing", (sp, key) =>
         {
             var logger = sp.GetRequiredService<ILogger<TypingSoundPlayer>>();
             var configuration = sp.GetRequiredService<IConfiguration>();
@@ -107,8 +107,8 @@ public static class VoiceServicesExtensions
             return TypingSoundPlayer.CreateFromDirectory(logger, soundsPath, "write.mp3", audioSink);
         });
 
-        // Cancel sound player for dictation cancel feedback (paper-rip sound)
-        services.AddSingleton(sp =>
+        // Cancel sound player for dictation cancel feedback (keyed service)
+        services.AddKeyedSingleton<ISoundEffectPlayer, CancelSoundPlayer>("cancel", (sp, key) =>
         {
             var logger = sp.GetRequiredService<ILogger<CancelSoundPlayer>>();
             var configuration = sp.GetRequiredService<IConfiguration>();

--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -36,8 +36,8 @@ public static class WorkerServicesExtensions
             var keyboardMonitor = sp.GetRequiredService<IKeyboardMonitor>();
             var stateMachine = sp.GetRequiredService<Olbrasoft.VirtualAssistant.Voice.StateMachine.IDictationStateMachine>();
             var keyboardSimulation = sp.GetRequiredService<IKeyboardSimulationService>();
-            var typingSound = sp.GetRequiredService<TypingSoundPlayer>();
-            var cancelSound = sp.GetRequiredService<CancelSoundPlayer>();
+            var typingSound = sp.GetRequiredKeyedService<ISoundEffectPlayer>("typing");
+            var cancelSound = sp.GetRequiredKeyedService<ISoundEffectPlayer>("cancel");
             var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
 
             // Create dedicated AudioCaptureService for dictation (independent from continuous listening)

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -30,8 +30,8 @@ public class DictationWorker : BackgroundService, IDictationControl
     private readonly IAudioRecordingCoordinator _recordingCoordinator;
     private readonly ITranscriptionService _transcriptionService;
     private readonly IKeyboardSimulationService _keyboardSimulation;
-    private readonly TypingSoundPlayer _typingSound;
-    private readonly CancelSoundPlayer _cancelSound;
+    private readonly ISoundEffectPlayer _typingSound;
+    private readonly ISoundEffectPlayer _cancelSound;
     private readonly IServiceScopeFactory _scopeFactory;
 
     private CancellationTokenSource? _transcriptionCts;
@@ -44,8 +44,8 @@ public class DictationWorker : BackgroundService, IDictationControl
         IAudioRecordingCoordinator recordingCoordinator,
         ITranscriptionService transcriptionService,
         IKeyboardSimulationService keyboardSimulation,
-        TypingSoundPlayer typingSound,
-        CancelSoundPlayer cancelSound,
+        ISoundEffectPlayer typingSound,
+        ISoundEffectPlayer cancelSound,
         IServiceScopeFactory scopeFactory)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Applies Dependency Inversion Principle to sound effect players by introducing `ISoundEffectPlayer` interface.

## Changes

### New Interface
- Created `ISoundEffectPlayer` with methods: `Play()`, `StartLoop()`, `StopLoop()`
- Enables dependency injection and mocking for sound players

### Updated Implementations
- `TypingSoundPlayer` now implements `ISoundEffectPlayer`
  - Added `Play()` method for one-time playback
- `CancelSoundPlayer` now implements `ISoundEffectPlayer`
  - Added `StartLoop()` and `StopLoop()` as no-ops (cancel sound is one-shot)

### Dependency Injection
- Registered sound players as keyed services ("typing", "cancel")
- Updated `DictationWorker` to depend on `ISoundEffectPlayer` interface
- Changed DI resolution to use `GetRequiredKeyedService<ISoundEffectPlayer>("typing"/"cancel")`

## Benefits

- Follows Dependency Inversion Principle (DIP)
- Enables unit testing with mocked sound players
- Reduces coupling between DictationWorker and concrete implementations

## Testing

- All 136 unit tests passing ✅
- Build successful with 0 errors ✅

Fixes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)