### PR TITLE
Auto-copy entire assets directory on deploy

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -47,11 +47,11 @@ echo
 # Step 3: Copy additional resources (preserve existing)
 echo "📦 Copying resources..."
 
-# Icons (for tray icon) - copy from assets/icons to app/icons
-if [ -d "$PROJECT_PATH/assets/icons" ]; then
-    mkdir -p "$BASE_DIR/app/icons"
-    cp -r "$PROJECT_PATH/assets/icons/"* "$BASE_DIR/app/icons/" 2>/dev/null || true
-    echo "  ✅ Icons copied (including hands/)"
+# Copy entire assets directory (icons, sounds, etc.)
+if [ -d "$PROJECT_PATH/assets" ]; then
+    mkdir -p "$BASE_DIR/app/assets"
+    cp -r "$PROJECT_PATH/assets/"* "$BASE_DIR/app/assets/" 2>/dev/null || true
+    echo "  ✅ Assets copied (icons/, sounds/)"
 fi
 
 # Models (app-specific models like silero_vad.onnx, NOT Whisper models!)

--- a/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
@@ -57,7 +57,7 @@ public static class TrayServicesExtensions
         services.AddSingleton<ITrayIconCoordinator>(sp =>
         {
             var manager = sp.GetRequiredService<Core.Services.ITrayIconManager>();
-            var iconsPath = Path.Combine(AppContext.BaseDirectory, "icons");
+            var iconsPath = Path.Combine(AppContext.BaseDirectory, "assets", "icons");
             var muteService = sp.GetRequiredService<IManualMuteService>();
             var logger = sp.GetRequiredService<ILogger<TrayIconCoordinator>>();
             var menuHandler = sp.GetRequiredService<SystemTrayMenuHandler>();


### PR DESCRIPTION
## Summary
Automatically deploys entire `assets/` directory (icons, sounds, etc.) instead of just icons, ensuring new assets are automatically available after deployment.

## Changes

### deploy.sh Updates
**Before:**
```bash
# Icons (for tray icon) - copy from assets/icons to app/icons
if [ -d "$PROJECT_PATH/assets/icons" ]; then
    mkdir -p "$BASE_DIR/app/icons"
    cp -r "$PROJECT_PATH/assets/icons/"* "$BASE_DIR/app/icons/" 2>/dev/null || true
    echo "  ✅ Icons copied (including hands/)"
fi
```

**After:**
```bash
# Copy entire assets directory (icons, sounds, etc.)
if [ -d "$PROJECT_PATH/assets" ]; then
    mkdir -p "$BASE_DIR/app/assets"
    cp -r "$PROJECT_PATH/assets/"* "$BASE_DIR/app/assets/" 2>/dev/null || true
    echo "  ✅ Assets copied (icons/, sounds/)"
fi
```

### TrayServicesExtensions.cs Updates
**Before:**
```csharp
var iconsPath = Path.Combine(AppContext.BaseDirectory, "icons");
```

**After:**
```csharp
var iconsPath = Path.Combine(AppContext.BaseDirectory, "assets", "icons");
```

## Deployed Directory Structure
```
/opt/olbrasoft/virtual-assistant/app/assets/
├── icons/
│   ├── hands/
│   │   ├── default-left-hand.svg
│   │   ├── default-right-hand.svg
│   │   └── (29 more hand icons)
│   └── heads/
│       ├── default-head.svg
│       ├── listening-dictation-head.svg
│       ├── busy-head.svg
│       └── muted-head.svg
└── sounds/
    ├── paper-rip.mp3
    └── write.mp3
```

## Benefits
✅ **Future-proof** - automatically includes new asset types (videos, fonts, etc.)  
✅ **Less maintenance** - single copy command instead of multiple  
✅ **Cleaner structure** - deployed directory matches source layout  
✅ **Automatic deployment** - new sounds and icons deployed without manual intervention

## Test Results
- ✅ All 163 tests passing in VirtualAssistant.Service.Tests
- ✅ All 211 tests passing in VirtualAssistant.Voice.Tests

## Verification
After deployment, verify with:
```bash
# Check assets directory
ls -la /opt/olbrasoft/virtual-assistant/app/assets/

# Verify icon counts (35 SVG files)
find /opt/olbrasoft/virtual-assistant/app/assets/icons/ -name "*.svg" | wc -l

# Verify sound files (2 MP3 files)
find /opt/olbrasoft/virtual-assistant/app/assets/sounds/ -name "*.mp3" | wc -l
```

## Resolves
Closes #482
Closes #483
Closes #484
Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)