### PR TITLE
Refactor TranscriptionCorrection queries and commands to C# records (#561)

### DIFF
--- a/src/VirtualAssistant.Data/Commands/TranscriptionCorrectionCommands/AddTranscriptionCorrectionCommand.cs
+++ b/src/VirtualAssistant.Data/Commands/TranscriptionCorrectionCommands/AddTranscriptionCorrectionCommand.cs
@@ -6,13 +6,6 @@ namespace Olbrasoft.VirtualAssistant.Data.Commands.TranscriptionCorrectionComman
 /// <summary>
 /// Command to add a new correction to the database.
 /// </summary>
-public class AddTranscriptionCorrectionCommand : BaseCommand<bool>
-{
-    public AddTranscriptionCorrectionCommand(ICommandExecutor executor) : base(executor) { }
-    public AddTranscriptionCorrectionCommand(IMediator mediator) : base(mediator) { }
-
-    /// <summary>
-    /// The correction to add. Must not be null.
-    /// </summary>
-    public TranscriptionCorrection Correction { get; set; } = null!;
-}
+/// <param name="Correction">The correction to add. Must not be null.</param>
+public record AddTranscriptionCorrectionCommand(TranscriptionCorrection Correction)
+    : ICommand<bool>;

--- a/src/VirtualAssistant.Data/Commands/TranscriptionCorrectionCommands/DeleteTranscriptionCorrectionCommand.cs
+++ b/src/VirtualAssistant.Data/Commands/TranscriptionCorrectionCommands/DeleteTranscriptionCorrectionCommand.cs
@@ -5,13 +5,5 @@ namespace Olbrasoft.VirtualAssistant.Data.Commands.TranscriptionCorrectionComman
 /// <summary>
 /// Command to delete a correction from the database.
 /// </summary>
-public class DeleteTranscriptionCorrectionCommand : BaseCommand<bool>
-{
-    public DeleteTranscriptionCorrectionCommand(ICommandExecutor executor) : base(executor) { }
-    public DeleteTranscriptionCorrectionCommand(IMediator mediator) : base(mediator) { }
-
-    /// <summary>
-    /// The ID of the correction to delete. Must be greater than 0.
-    /// </summary>
-    public int Id { get; set; } = -1;
-}
+/// <param name="Id">The ID of the correction to delete. Must be greater than 0.</param>
+public record DeleteTranscriptionCorrectionCommand(int Id) : ICommand<bool>;

--- a/src/VirtualAssistant.Data/Commands/TranscriptionCorrectionCommands/TrackCorrectionUsageCommand.cs
+++ b/src/VirtualAssistant.Data/Commands/TranscriptionCorrectionCommands/TrackCorrectionUsageCommand.cs
@@ -6,18 +6,9 @@ namespace Olbrasoft.VirtualAssistant.Data.Commands.TranscriptionCorrectionComman
 /// Command to track that a correction was applied during transcription processing.
 /// Used for analytics to measure correction effectiveness.
 /// </summary>
-public class TrackCorrectionUsageCommand : BaseCommand<bool>
-{
-    public TrackCorrectionUsageCommand(ICommandExecutor executor) : base(executor) { }
-    public TrackCorrectionUsageCommand(IMediator mediator) : base(mediator) { }
-
-    /// <summary>
-    /// The ID of the applied correction. Must be greater than 0.
-    /// </summary>
-    public int CorrectionId { get; set; }
-
-    /// <summary>
-    /// Optional context about where the correction was used (e.g., "dictation", "continuous-listening").
-    /// </summary>
-    public string? Context { get; set; }
-}
+/// <param name="CorrectionId">The ID of the applied correction. Must be greater than 0.</param>
+/// <param name="Context">Optional context about where the correction was used (e.g., "dictation", "continuous-listening").</param>
+public record TrackCorrectionUsageCommand(
+    int CorrectionId,
+    string? Context = null
+) : ICommand<bool>;

--- a/src/VirtualAssistant.Data/Commands/TranscriptionCorrectionCommands/UpdateTranscriptionCorrectionCommand.cs
+++ b/src/VirtualAssistant.Data/Commands/TranscriptionCorrectionCommands/UpdateTranscriptionCorrectionCommand.cs
@@ -7,13 +7,6 @@ namespace Olbrasoft.VirtualAssistant.Data.Commands.TranscriptionCorrectionComman
 /// Command to update an existing correction in the database.
 /// Sets UpdatedAt to current time automatically.
 /// </summary>
-public class UpdateTranscriptionCorrectionCommand : BaseCommand<bool>
-{
-    public UpdateTranscriptionCorrectionCommand(ICommandExecutor executor) : base(executor) { }
-    public UpdateTranscriptionCorrectionCommand(IMediator mediator) : base(mediator) { }
-
-    /// <summary>
-    /// The correction to update. Must not be null.
-    /// </summary>
-    public TranscriptionCorrection Correction { get; set; } = null!;
-}
+/// <param name="Correction">The correction to update. Must not be null.</param>
+public record UpdateTranscriptionCorrectionCommand(TranscriptionCorrection Correction)
+    : ICommand<bool>;

--- a/src/VirtualAssistant.Data/Queries/TranscriptionCorrectionQueries/GetActiveTranscriptionCorrectionsQuery.cs
+++ b/src/VirtualAssistant.Data/Queries/TranscriptionCorrectionQueries/GetActiveTranscriptionCorrectionsQuery.cs
@@ -7,8 +7,5 @@ namespace Olbrasoft.VirtualAssistant.Data.Queries.TranscriptionCorrectionQueries
 /// Query to get all active corrections ordered by priority (highest first).
 /// Used by TextFilter for in-memory caching.
 /// </summary>
-public class GetActiveTranscriptionCorrectionsQuery : BaseQuery<IReadOnlyList<TranscriptionCorrection>>
-{
-    public GetActiveTranscriptionCorrectionsQuery(IQueryProcessor processor) : base(processor) { }
-    public GetActiveTranscriptionCorrectionsQuery(IMediator mediator) : base(mediator) { }
-}
+public record GetActiveTranscriptionCorrectionsQuery()
+    : IQuery<IReadOnlyList<TranscriptionCorrection>>;

--- a/src/VirtualAssistant.Data/Queries/TranscriptionCorrectionQueries/GetTranscriptionCorrectionByIdQuery.cs
+++ b/src/VirtualAssistant.Data/Queries/TranscriptionCorrectionQueries/GetTranscriptionCorrectionByIdQuery.cs
@@ -6,13 +6,6 @@ namespace Olbrasoft.VirtualAssistant.Data.Queries.TranscriptionCorrectionQueries
 /// <summary>
 /// Query to get a correction by its unique identifier.
 /// </summary>
-public class GetTranscriptionCorrectionByIdQuery : BaseQuery<TranscriptionCorrection?>
-{
-    public GetTranscriptionCorrectionByIdQuery(IQueryProcessor processor) : base(processor) { }
-    public GetTranscriptionCorrectionByIdQuery(IMediator mediator) : base(mediator) { }
-
-    /// <summary>
-    /// The correction ID. Must be greater than 0.
-    /// </summary>
-    public int Id { get; set; } = -1;
-}
+/// <param name="Id">The correction ID. Must be greater than 0.</param>
+public record GetTranscriptionCorrectionByIdQuery(int Id)
+    : IQuery<TranscriptionCorrection?>;

--- a/src/VirtualAssistant.Voice/Filters/DatabaseCorrectionFilterStrategy.cs
+++ b/src/VirtualAssistant.Voice/Filters/DatabaseCorrectionFilterStrategy.cs
@@ -109,8 +109,8 @@ public class DatabaseCorrectionFilterStrategy : ITextFilterStrategy
                 }
 
                 // Synchronous call is acceptable for cache refresh
-                var query = new GetActiveTranscriptionCorrectionsQuery(queryProcessor);
-                _cachedCorrections = query.ToResultAsync().GetAwaiter().GetResult();
+                var query = new GetActiveTranscriptionCorrectionsQuery();
+                _cachedCorrections = queryProcessor.ProcessAsync(query, CancellationToken.None).GetAwaiter().GetResult();
 
                 _cacheExpiry = DateTime.UtcNow.Add(CacheDuration);
 
@@ -145,11 +145,10 @@ public class DatabaseCorrectionFilterStrategy : ITextFilterStrategy
 
             if (commandExecutor != null)
             {
-                var command = new TrackCorrectionUsageCommand(commandExecutor)
-                {
-                    CorrectionId = correctionId
-                };
-                await command.ToResultAsync();
+                var command = new TrackCorrectionUsageCommand(
+                    CorrectionId: correctionId
+                );
+                await commandExecutor.ExecuteAsync(command, CancellationToken.None);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

Refactors all TranscriptionCorrection CQRS queries and commands from classes inheriting `BaseQuery<T>`/`BaseCommand<T>` to immutable records implementing `IQuery<T>`/`ICommand<T>`.

Closes #561

## Changes

### Converted to Records (6 files)

**Queries (2 files):**
1. **GetActiveTranscriptionCorrectionsQuery** - 14 → 11 lines (-21%)
2. **GetTranscriptionCorrectionByIdQuery** - 18 → 11 lines (-39%)

**Commands (4 files):**
3. **TrackCorrectionUsageCommand** - 23 → 14 lines (-39%)
4. **UpdateTranscriptionCorrectionCommand** - 19 → 12 lines (-37%)
5. **DeleteTranscriptionCorrectionCommand** - 17 → 9 lines (-47%)
6. **AddTranscriptionCorrectionCommand** - 18 → 11 lines (-39%)

### Service Updates

- **DatabaseCorrectionFilterStrategy.cs** - Updated to use `IQueryProcessor.ProcessAsync()` and `ICommandExecutor.ExecuteAsync()` instead of old command/query pattern

## Technical Benefits

✅ **37% average code reduction** (109 → 68 lines)  
✅ **Immutable value-based equality** - Records provide structural equality by default  
✅ **Primary constructors** - Simpler, more declarative syntax  
✅ **Modern C# 12+ patterns** - Aligns with current best practices  

## Testing

- ✅ All 553 unit tests passing
- ✅ Build successful
- ✅ No breaking changes to handler implementations

## Migration Pattern

**Before (class):**
```csharp
var query = new GetActiveTranscriptionCorrectionsQuery(queryProcessor);
var corrections = query.ToResultAsync().GetAwaiter().GetResult();
```

**After (record):**
```csharp
var query = new GetActiveTranscriptionCorrectionsQuery();
var corrections = queryProcessor.ProcessAsync(query, CancellationToken.None).GetAwaiter().GetResult();
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)