### PR TITLE
Refactor VoiceTranscription CQRS classes to records

### DIFF
--- a/src/VirtualAssistant.Data/Commands/VoiceTranscriptionCommands/SaveVoiceTranscriptionCommand.cs
+++ b/src/VirtualAssistant.Data/Commands/VoiceTranscriptionCommands/SaveVoiceTranscriptionCommand.cs
@@ -6,23 +6,11 @@ namespace Olbrasoft.VirtualAssistant.Data.Commands.VoiceTranscriptionCommands;
 /// <summary>
 /// Command to save a new voice transcription record.
 /// </summary>
-public class SaveVoiceTranscriptionCommand : BaseCommand<VoiceTranscription>
-{
-    public SaveVoiceTranscriptionCommand(ICommandExecutor executor) : base(executor) { }
-    public SaveVoiceTranscriptionCommand(IMediator mediator) : base(mediator) { }
-
-    /// <summary>
-    /// The transcribed text. Must not be null or empty.
-    /// </summary>
-    public string Text { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The application that was focused during dictation (optional).
-    /// </summary>
-    public string? SourceApp { get; set; }
-
-    /// <summary>
-    /// The recording duration in milliseconds (optional).
-    /// </summary>
-    public int? DurationMs { get; set; }
-}
+/// <param name="Text">The transcribed text. Must not be null or empty.</param>
+/// <param name="SourceApp">The application that was focused during dictation (optional).</param>
+/// <param name="DurationMs">The recording duration in milliseconds (optional).</param>
+public record SaveVoiceTranscriptionCommand(
+    string Text,
+    string? SourceApp = null,
+    int? DurationMs = null
+) : ICommand<VoiceTranscription>;

--- a/src/VirtualAssistant.Data/Queries/VoiceTranscriptionQueries/GetRecentVoiceTranscriptionsQuery.cs
+++ b/src/VirtualAssistant.Data/Queries/VoiceTranscriptionQueries/GetRecentVoiceTranscriptionsQuery.cs
@@ -6,13 +6,6 @@ namespace Olbrasoft.VirtualAssistant.Data.Queries.VoiceTranscriptionQueries;
 /// <summary>
 /// Query to get the most recent voice transcriptions.
 /// </summary>
-public class GetRecentVoiceTranscriptionsQuery : BaseQuery<IReadOnlyList<VoiceTranscription>>
-{
-    public GetRecentVoiceTranscriptionsQuery(IQueryProcessor processor) : base(processor) { }
-    public GetRecentVoiceTranscriptionsQuery(IMediator mediator) : base(mediator) { }
-
-    /// <summary>
-    /// Maximum number of transcriptions to return (default: 50). Must be greater than 0.
-    /// </summary>
-    public int Count { get; set; } = 50;
-}
+/// <param name="Count">Maximum number of transcriptions to return (default: 50). Must be greater than 0.</param>
+public record GetRecentVoiceTranscriptionsQuery(int Count = 50)
+    : IQuery<IReadOnlyList<VoiceTranscription>>;

--- a/src/VirtualAssistant.Data/Queries/VoiceTranscriptionQueries/SearchVoiceTranscriptionsQuery.cs
+++ b/src/VirtualAssistant.Data/Queries/VoiceTranscriptionQueries/SearchVoiceTranscriptionsQuery.cs
@@ -6,13 +6,6 @@ namespace Olbrasoft.VirtualAssistant.Data.Queries.VoiceTranscriptionQueries;
 /// <summary>
 /// Query to search for voice transcriptions containing the specified text.
 /// </summary>
-public class SearchVoiceTranscriptionsQuery : BaseQuery<IReadOnlyList<VoiceTranscription>>
-{
-    public SearchVoiceTranscriptionsQuery(IQueryProcessor processor) : base(processor) { }
-    public SearchVoiceTranscriptionsQuery(IMediator mediator) : base(mediator) { }
-
-    /// <summary>
-    /// The search query. Must not be null or empty.
-    /// </summary>
-    public string SearchQuery { get; set; } = string.Empty;
-}
+/// <param name="SearchQuery">The search query. Must not be null or empty.</param>
+public record SearchVoiceTranscriptionsQuery(string SearchQuery)
+    : IQuery<IReadOnlyList<VoiceTranscription>>;


### PR DESCRIPTION
## Summary

Refactored 3 VoiceTranscription CQRS classes to immutable records with primary constructors as part of #558.

### Files Changed

- `SearchVoiceTranscriptionsQuery.cs`: 18 → 11 lines (-39%)
- `GetRecentVoiceTranscriptionsQuery.cs`: 18 → 11 lines (-39%)  
- `SaveVoiceTranscriptionCommand.cs`: 28 → 16 lines (-43%)

### Technical Changes

- Changed from `BaseQuery<T>`/`BaseCommand<T>` to `IQuery<T>`/`ICommand<T>`
- Removed constructor overloads for `IQueryProcessor`/`ICommandExecutor`/`IMediator`
- Moved property documentation to `<param>` XML tags
- Used primary constructors with optional parameters (e.g., `Count = 50`)

### Benefits

✅ Immutability by default  
✅ Value-based equality  
✅ Reduced boilerplate code  
✅ Better pattern matching support

## Test Plan

- [x] All 553 unit tests passing
- [x] Build successful with no errors
- [ ] Await GitHub Copilot code review
- [ ] Address any review comments before merge

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)