### PR TITLE
Remove ContextPromptSelector registration and configuration

### DIFF
--- a/src/VirtualAssistant.Desktop/Extensions/DesktopServiceExtensions.cs
+++ b/src/VirtualAssistant.Desktop/Extensions/DesktopServiceExtensions.cs
@@ -73,13 +73,6 @@ public static class DesktopServiceExtensions
             return new Services.DesktopContextService(monitor, logger);
         });
 
-        // Configure context mapping
-        services.Configure<ContextMappingOptions>(
-            configuration.GetSection(Configuration.ContextMappingOptions.SectionName));
-
-        // Register ContextPromptSelector
-        services.AddSingleton<Core.Services.IContextPromptSelector, Services.ContextPromptSelector>();
-
         // Configure notification filtering
         services.Configure<NotificationFilteringOptions>(
             configuration.GetSection(Configuration.NotificationFilteringOptions.SectionName));

--- a/src/VirtualAssistant.Service/appsettings.json
+++ b/src/VirtualAssistant.Service/appsettings.json
@@ -11,37 +11,6 @@
     "GracefulDegradation": true,
     "LogContextChanges": true
   },
-  "ContextMapping": {
-    "Programming": [
-      "code",
-      "cursor",
-      "rider",
-      "pycharm",
-      "idea",
-      "eclipse",
-      "vim",
-      "emacs",
-      "sublime_text",
-      "atom",
-      "vscode"
-    ],
-    "Chat": [
-      "whatsapp-for-linux",
-      "telegram",
-      "slack",
-      "discord",
-      "teams",
-      "signal",
-      "element"
-    ],
-    "Browsing": [
-      "chrome",
-      "firefox",
-      "chromium",
-      "brave",
-      "edge"
-    ]
-  },
   "NotificationFiltering": {
     "Enabled": true,
     "AppNameMapping": {


### PR DESCRIPTION
## Summary

Removes DI registration and configuration for the deprecated ContextPromptSelector system.

**Changes:**
- Removed `services.Configure<ContextMappingOptions>` from `DesktopServiceExtensions.cs`
- Removed `services.AddSingleton<IContextPromptSelector, ContextPromptSelector>` from `DesktopServiceExtensions.cs`
- Removed entire `ContextMapping` section from `appsettings.json` (Programming/Chat/Browsing arrays)

**This fixes build errors from PR #574** where the ContextPromptSelector classes were deleted.

## Test Plan

- [x] Build succeeds
- [x] All tests pass (553/555, 2 integration test failures are unrelated - missing API keys)

Fixes #571
Part of #568