### PR TITLE
Fix tray menu handler not being passed to TrayIconManager

### DIFF
--- a/src/VirtualAssistant.Service/Infrastructure/SystemTrayIconManagerAdapter.cs
+++ b/src/VirtualAssistant.Service/Infrastructure/SystemTrayIconManagerAdapter.cs
@@ -28,7 +28,7 @@ public class SystemTrayIconManagerAdapter : Core.Services.ITrayIconManager
             linuxMenuHandler = handler;
         }
 
-        var icon = await _manager.CreateIconAsync(id, iconPath, tooltip, null);
+        var icon = await _manager.CreateIconAsync(id, iconPath, tooltip, linuxMenuHandler);
         return icon != null ? new TrayIconAdapter(icon) : null;
     }
 


### PR DESCRIPTION
## Problem

After merging PR #577, the VirtualAssistant tray icon stopped showing its context menu when clicked. Users could not access menu items like:
- Quit
- Mute/Unmute Toggle
- LLM Correction Toggle
- Show Logs
- Dictation Toggle
- TTS Mute Toggle

## Root Cause

In `SystemTrayIconManagerAdapter.CreateIconAsync()` (line 31), the code was converting `menuHandler` to `linuxMenuHandler` but then passing `null` to `_manager.CreateIconAsync()` instead of the converted handler:

```csharp
// Convert ITrayMenuHandler to Olbrasoft.SystemTray.Linux.ITrayMenuHandler
ITrayMenuHandler? linuxMenuHandler = null;
if (menuHandler is ITrayMenuHandler handler)
{
    linuxMenuHandler = handler;
}

var icon = await _manager.CreateIconAsync(id, iconPath, tooltip, null); // ❌ BUG: passing null
```

This caused the tray icon to be created without a menu handler, making the context menu inaccessible.

## Fix

Changed line 31 to pass `linuxMenuHandler` instead of `null`:

```csharp
var icon = await _manager.CreateIconAsync(id, iconPath, tooltip, linuxMenuHandler); // ✅ FIX
```

## Verification

- [x] Build successful
- [x] All tests pass (366 tests)
- [x] Deployed to production and verified menu appears
- [x] Menu items work correctly

## Impact

**Files changed:** 1 file  
**Lines changed:** 1 line (1 insertion, 1 deletion)

This is a critical hotfix that restores tray menu functionality broken by PR #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>