### PR TITLE
Add Prompt entity for context-aware LLM corrections

### DIFF
--- a/src/VirtualAssistant.Data.EntityFrameworkCore/Configurations/LlmCorrectionConfiguration.cs
+++ b/src/VirtualAssistant.Data.EntityFrameworkCore/Configurations/LlmCorrectionConfiguration.cs
@@ -32,13 +32,23 @@ public class LlmCorrectionConfiguration : IEntityTypeConfiguration<LlmCorrection
             .IsRequired()
             .HasDefaultValueSql("NOW()");
 
-        // Foreign key relationship
+        builder.Property(l => l.PromptId)
+            .HasColumnName("prompt_id")
+            .IsRequired(); // NOT NULL - always has a prompt
+
+        // Foreign key relationships
         builder.HasOne(l => l.WhisperTranscription)
             .WithMany()
             .HasForeignKey(l => l.WhisperTranscriptionId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        builder.HasOne(l => l.Prompt)
+            .WithMany(p => p.LlmCorrections)
+            .HasForeignKey(l => l.PromptId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         builder.HasIndex(l => l.WhisperTranscriptionId);
+        builder.HasIndex(l => l.PromptId);
         builder.HasIndex(l => l.CreatedAt);
     }
 }

--- a/src/VirtualAssistant.Data.EntityFrameworkCore/Configurations/PromptConfiguration.cs
+++ b/src/VirtualAssistant.Data.EntityFrameworkCore/Configurations/PromptConfiguration.cs
@@ -1,0 +1,50 @@
+namespace Olbrasoft.VirtualAssistant.Data.EntityFrameworkCore.Configurations;
+
+/// <summary>
+/// EF Core configuration for Prompt entity with PostgreSQL snake_case naming.
+/// </summary>
+public class PromptConfiguration : IEntityTypeConfiguration<Prompt>
+{
+    public void Configure(EntityTypeBuilder<Prompt> builder)
+    {
+        builder.ToTable("prompts");
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.Id)
+            .HasColumnName("id");
+
+        builder.Property(p => p.Name)
+            .HasColumnName("name")
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(p => p.ApplicationName)
+            .HasColumnName("application_name")
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(p => p.AppIdPattern)
+            .HasColumnName("app_id_pattern")
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(p => p.PromptFileName)
+            .HasColumnName("prompt_file_name")
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(p => p.CreatedAt)
+            .HasColumnName("created_at")
+            .IsRequired()
+            .HasDefaultValueSql("NOW()");
+
+        // Relationship: Prompt 1:N LlmCorrections
+        builder.HasMany(p => p.LlmCorrections)
+            .WithOne(l => l.Prompt)
+            .HasForeignKey(l => l.PromptId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(p => p.AppIdPattern);
+    }
+}

--- a/src/VirtualAssistant.Data/Entities/LlmCorrection.cs
+++ b/src/VirtualAssistant.Data/Entities/LlmCorrection.cs
@@ -31,7 +31,18 @@ public class LlmCorrection
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
+    /// Foreign key to Prompt - which context-aware prompt was used for this correction.
+    /// NOT NULL - every correction always has a prompt (specific or Default with pattern "*").
+    /// </summary>
+    public int PromptId { get; set; }
+
+    /// <summary>
     /// Navigation property to the original Whisper transcription.
     /// </summary>
     public WhisperTranscription WhisperTranscription { get; set; } = null!;
+
+    /// <summary>
+    /// Navigation property to the prompt that was used for this correction.
+    /// </summary>
+    public Prompt Prompt { get; set; } = null!;
 }

--- a/src/VirtualAssistant.Data/Entities/Prompt.cs
+++ b/src/VirtualAssistant.Data/Entities/Prompt.cs
@@ -1,0 +1,42 @@
+namespace Olbrasoft.VirtualAssistant.Data.Entities;
+
+/// <summary>
+/// Represents an LLM correction prompt with application context mapping.
+/// </summary>
+public class Prompt
+{
+    /// <summary>
+    /// Unique identifier for this prompt.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Prompt display name (e.g., "OpenCode Correction", "ClaudeCode Correction").
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Application name this prompt is for (e.g., "OpenCode", "Claude Code", "Ferdium", "Default").
+    /// </summary>
+    public string ApplicationName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Pattern to match against DesktopContext.ActiveApplication (e.g., "code", "ferdium", "*" for default).
+    /// </summary>
+    public string AppIdPattern { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Filename of the prompt in Prompts/ directory (e.g., "OpenCodeCorrection.md").
+    /// </summary>
+    public string PromptFileName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When this prompt was created (UTC).
+    /// </summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Navigation property to LLM corrections that used this prompt.
+    /// </summary>
+    public ICollection<LlmCorrection> LlmCorrections { get; set; } = new List<LlmCorrection>();
+}


### PR DESCRIPTION
## Summary

Created `Prompt` entity to enable context-aware LLM corrections by mapping applications to specific correction prompts.

## Changes

- ✅ **Created `Prompt` entity** (`VirtualAssistant.Data/Entities/Prompt.cs`):
  - Properties: Id, Name, ApplicationName, AppIdPattern, PromptFileName, CreatedAt
  - PascalCase entity properties (C# conventions)
  - XML documentation for all properties
  - Navigation property to LlmCorrections (1:N relationship)

- ✅ **Created `PromptConfiguration`** (`VirtualAssistant.Data.EntityFrameworkCore/Configurations/PromptConfiguration.cs`):
  - Maps to PostgreSQL `prompts` table
  - snake_case column names (id, name, application_name, app_id_pattern, prompt_file_name, created_at)
  - Index on `app_id_pattern` for fast lookups
  - 1:N relationship with LlmCorrections (DeleteBehavior.Restrict)

- ✅ **Extended `LlmCorrection` entity**:
  - Added `PromptId` property (int, NOT NULL)
  - Added `Prompt` navigation property
  - Every correction must have a prompt (specific or Default with pattern "*")

- ✅ **Updated `LlmCorrectionConfiguration`**:
  - Added `prompt_id` column (snake_case, NOT NULL)
  - FK relationship: llm_corrections.prompt_id → prompts.id (DeleteBehavior.Restrict)
  - Index on `prompt_id`

## Database Schema

**New table: `prompts`**
```sql
CREATE TABLE prompts (
  id SERIAL PRIMARY KEY,
  name VARCHAR(200) NOT NULL,
  application_name VARCHAR(100) NOT NULL,
  app_id_pattern VARCHAR(100) NOT NULL,
  prompt_file_name VARCHAR(200) NOT NULL,
  created_at TIMESTAMP NOT NULL DEFAULT NOW()
);

CREATE INDEX idx_prompts_app_id_pattern ON prompts(app_id_pattern);
```

**Updated table: `llm_corrections`**
```sql
ALTER TABLE llm_corrections 
  ADD COLUMN prompt_id INTEGER NOT NULL REFERENCES prompts(id);

CREATE INDEX idx_llm_corrections_prompt_id ON llm_corrections(prompt_id);
```

## Initial Data (Phase 1)

Migration will seed 4 prompts:
1. **OpenCode** (pattern: "opencode") → OpenCodeCorrection.md
2. **Claude Code** (pattern: "code") → ClaudeCodeCorrection.md
3. **Ferdium** (pattern: "ferdium") → FerdiumCorrection.md
4. **Default** (pattern: "*") → DefaultCorrection.md (REQUIRED fallback)

## Build Status

✅ Build successful (0 errors, 7 warnings from Data.Cqrs dependency)

## Related Issues

- Implements #579 (Prompt entity)
- Related to #567 (context-aware prompts implementation)
- Requires #580 (EF Core migration) after merge

## Next Steps

After this PR is merged:
1. Create EF Core migration (#580)
2. Update MistralProvider for context-aware prompt selection (#582)
3. Update Desktop Monitor UI (#583)

## Test Plan

- [ ] Build succeeds without errors
- [ ] EF Core migration creates tables and relationships correctly
- [ ] Prompt selection logic works for different applications
- [ ] Default prompt is used as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)