### PR TITLE
Fix TTS profiles configuration

### DIFF
--- a/src/VirtualAssistant.Service/appsettings.json
+++ b/src/VirtualAssistant.Service/appsettings.json
@@ -115,9 +115,6 @@
   "OpenCode": {
     "Url": "http://localhost:4096"
   },
-  "EdgeTtsServer": {
-    "BaseUrl": "http://localhost:5555"
-  },
   "ClaudeDispatch": {
     "NotifyUrl": "http://localhost:5055/api/notifications",
     "DefaultWorkingDirectory": "~/Olbrasoft/VirtualAssistant",
@@ -152,7 +149,6 @@
       ]
     },
     "EdgeTTS": {
-      "BaseUrl": "http://localhost:5555",
       "Voice": "cs-CZ-AntoninNeural",
       "Rate": "+10%",
       "Volume": "+0%",
@@ -269,7 +265,7 @@
   "TtsProfiles": {
     "Profiles": {
       "opencode": {
-        "Provider": "Azure",
+        "Provider": "EdgeTTS-WebSocket",
         "Voice": "cs-CZ-AntoninNeural",
         "Rate": "+10%",
         "Volume": "+0%",
@@ -279,13 +275,13 @@
       "claude-code": {
         "Provider": "GoogleCloudMultiKey",
         "Voice": "cs-CZ-Chirp3-HD-Charon",
-        "Rate": "+0%",
+        "Rate": "+10%",
         "Volume": "+0%",
         "Pitch": "+0Hz",
         "Priority": 10
       },
       "gemini": {
-        "Provider": "Azure",
+        "Provider": "EdgeTTS-WebSocket",
         "Voice": "cs-CZ-VlastaNeural",
         "Rate": "+10%",
         "Volume": "+0%",
@@ -293,7 +289,7 @@
         "Priority": 10
       },
       "desktop-monitor": {
-        "Provider": "EdgeTTS",
+        "Provider": "EdgeTTS-WebSocket",
         "Voice": "cs-CZ-VlastaNeural",
         "Rate": "+0%",
         "Volume": "+0%",


### PR DESCRIPTION
## Summary
- Remove unused `EdgeTtsServer` section (HTTP server not used)
- Remove `BaseUrl` from `TTS:EdgeTTS` (WebSocket provider doesn't use it)
- Change `opencode` profile: Azure → EdgeTTS-WebSocket
- Change `gemini` profile: Azure → EdgeTTS-WebSocket
- Change `desktop-monitor` profile: EdgeTTS → EdgeTTS-WebSocket
- Change `claude-code` rate: +0% → +10%

## Problem
The Azure provider was causing circuit breaker issues when it failed - fallback tried GoogleCloudMultiKey with Azure voices (VlastaNeural), which Google Cloud doesn't recognize. This broke GoogleCloudMultiKey's circuit breaker, causing Claude Code to fall back to GoogleTTS (gTTS) with a female voice instead of using Charon.

## Solution
Each profile now uses the correct provider with compatible voices:

| Profile | Provider | Voice |
|---------|----------|-------|
| opencode | EdgeTTS-WebSocket | AntoninNeural |
| gemini | EdgeTTS-WebSocket | VlastaNeural |
| claude-code | GoogleCloudMultiKey | Charon (+10% rate) |
| desktop-monitor | EdgeTTS-WebSocket | VlastaNeural |

## Test plan
- [x] JSON syntax valid
- [x] Build passes
- [ ] Deploy via GitHub Actions (automatic after merge)
- [ ] Verify TTS works for all profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)