### PR TITLE
[Secrets Migration] Batch 4: Update .gitignore (#638)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,9 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# SecureStore keyfiles (NEVER commit!)
+*.key
+secrets/*.key
+keys/*.key
+.config/virtual-assistant/keys/*.key


### PR DESCRIPTION
## Summary

Updates .gitignore to prevent accidental commit of SecureStore encryption keyfiles.

## Changes

Added patterns to `.gitignore`:
- `*.key` - all keyfiles
- `secrets/*.key` - keyfiles in secrets directories
- `keys/*.key` - keyfiles in keys directories
- `.config/virtual-assistant/keys/*.key` - specific config path

## Verification

- [x] No *.key files in current repository
- [x] No *.key files in Git history
- [x] Patterns cover all expected keyfile locations

## Closes

- Closes #638 (Remove Legacy Secret Files - .gitignore update part)

## Note

Issue #639 (Production Deployment & Validation) requires manual verification after deployment and should be closed by user after confirming all features work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)