### PR TITLE
Add instruction to convert indicative to imperative in LLM prompts

### DIFF
--- a/src/VirtualAssistant.Voice/Prompts/ClaudeCodeCorrection.md
+++ b/src/VirtualAssistant.Voice/Prompts/ClaudeCodeCorrection.md
@@ -26,6 +26,32 @@ Příklady:
 
 **PRAVIDLO:** Příkazy jsou pro agentní program → NESMÍŠ je měnit na oznamovací věty!
 
+**⚠️ KRITICKÉ: UŽIVATEL DIKTUJE PŘÍKAZY, NE OZNAMUJE!**
+- Uživatel diktuje PŘÍKAZY pro agentní program Claude Code
+- Whisper často ŠPATNĚ interpretuje příkazy jako oznamovací věty v 1. osobě
+- **OPRAV 1. osobu oznamovací na 2. osobu rozkazovací (imperativ)!**
+
+**Typické chyby Whisper (VŽDY OPRAV na imperativ):**
+- "Prohlédím projekt" → "**Prohlédni** projekt"
+- "Prohlédnu projekt" → "**Prohlédni** projekt"
+- "Zjistím mi" → "**Zjisti** mi"
+- "Podívám se na" → "**Podívej se** na"
+- "Udělám to" → "**Udělej** to"
+- "Najdu soubor" → "**Najdi** soubor"
+- "Otevřu soubor" → "**Otevři** soubor"
+- "Spustím testy" → "**Spusť** testy"
+- "Vytvořím issue" → "**Vytvoř** issue"
+- "Přidám label" → "**Přidej** label"
+- "Smažu soubor" → "**Smaž** soubor"
+- "Upravím kód" → "**Uprav** kód"
+- "Zkontroluju" → "**Zkontroluj**"
+- "Analyzuju" → "**Analyzuj**"
+
+**Rozpoznávací znaky příkazu:**
+- Text popisuje akci, kterou má agent provést
+- Sloveso na začátku nebo blízko začátku věty
+- Kontext programování/vývoje (issues, soubory, kód, testy)
+
 ## Kontext systému
 
 ### Adresářová struktura

--- a/src/VirtualAssistant.Voice/Prompts/GeminiCorrection.md
+++ b/src/VirtualAssistant.Voice/Prompts/GeminiCorrection.md
@@ -26,6 +26,32 @@ Příklady:
 
 **PRAVIDLO:** Příkazy jsou pro agentní program → NESMÍŠ je měnit na oznamovací věty!
 
+**⚠️ KRITICKÉ: UŽIVATEL DIKTUJE PŘÍKAZY, NE OZNAMUJE!**
+- Uživatel diktuje PŘÍKAZY pro agentní program Gemini CLI
+- Whisper často ŠPATNĚ interpretuje příkazy jako oznamovací věty v 1. osobě
+- **OPRAV 1. osobu oznamovací na 2. osobu rozkazovací (imperativ)!**
+
+**Typické chyby Whisper (VŽDY OPRAV na imperativ):**
+- "Prohlédím projekt" → "**Prohlédni** projekt"
+- "Prohlédnu projekt" → "**Prohlédni** projekt"
+- "Zjistím mi" → "**Zjisti** mi"
+- "Podívám se na" → "**Podívej se** na"
+- "Udělám to" → "**Udělej** to"
+- "Najdu soubor" → "**Najdi** soubor"
+- "Otevřu soubor" → "**Otevři** soubor"
+- "Spustím testy" → "**Spusť** testy"
+- "Vytvořím issue" → "**Vytvoř** issue"
+- "Přidám label" → "**Přidej** label"
+- "Smažu soubor" → "**Smaž** soubor"
+- "Upravím kód" → "**Uprav** kód"
+- "Zkontroluju" → "**Zkontroluj**"
+- "Analyzuju" → "**Analyzuj**"
+
+**Rozpoznávací znaky příkazu:**
+- Text popisuje akci, kterou má agent provést
+- Sloveso na začátku nebo blízko začátku věty
+- Kontext programování/vývoje (issues, soubory, kód, testy)
+
 ## Kontext systému
 
 ### Adresářová struktura

--- a/src/VirtualAssistant.Voice/Prompts/OpenCodeCorrection.md
+++ b/src/VirtualAssistant.Voice/Prompts/OpenCodeCorrection.md
@@ -26,6 +26,32 @@ Příklady:
 
 **PRAVIDLO:** Příkazy jsou pro agentní program → NESMÍŠ je měnit na oznamovací věty!
 
+**⚠️ KRITICKÉ: UŽIVATEL DIKTUJE PŘÍKAZY, NE OZNAMUJE!**
+- Uživatel diktuje PŘÍKAZY pro agentní program OpenCode
+- Whisper často ŠPATNĚ interpretuje příkazy jako oznamovací věty v 1. osobě
+- **OPRAV 1. osobu oznamovací na 2. osobu rozkazovací (imperativ)!**
+
+**Typické chyby Whisper (VŽDY OPRAV na imperativ):**
+- "Prohlédím projekt" → "**Prohlédni** projekt"
+- "Prohlédnu projekt" → "**Prohlédni** projekt"
+- "Zjistím mi" → "**Zjisti** mi"
+- "Podívám se na" → "**Podívej se** na"
+- "Udělám to" → "**Udělej** to"
+- "Najdu soubor" → "**Najdi** soubor"
+- "Otevřu soubor" → "**Otevři** soubor"
+- "Spustím testy" → "**Spusť** testy"
+- "Vytvořím issue" → "**Vytvoř** issue"
+- "Přidám label" → "**Přidej** label"
+- "Smažu soubor" → "**Smaž** soubor"
+- "Upravím kód" → "**Uprav** kód"
+- "Zkontroluju" → "**Zkontroluj**"
+- "Analyzuju" → "**Analyzuj**"
+
+**Rozpoznávací znaky příkazu:**
+- Text popisuje akci, kterou má agent provést
+- Sloveso na začátku nebo blízko začátku věty
+- Kontext programování/vývoje (issues, soubory, kód, testy)
+
 ## Kontext systému
 
 ### Adresářová struktura


### PR DESCRIPTION
## Summary

- Added explicit instructions to LLM correction prompts to fix Whisper's tendency to transcribe commands as indicative sentences

## Problem

Whisper often transcribes spoken commands in 1st person indicative instead of imperative:
- ❌ "Prohlédnu projekt" (indicative - I will look at)
- ✅ "Prohlédni projekt" (imperative - look at)

## Solution

Added a new section to all three correction prompts with:
- Clear explanation that user dictates COMMANDS, not statements
- List of common Whisper mistakes and their corrections
- Recognition patterns for commands

## Changes

- `OpenCodeCorrection.md` - Added imperative conversion section
- `ClaudeCodeCorrection.md` - Added imperative conversion section
- `GeminiCorrection.md` - Added imperative conversion section

## Test plan

- [ ] Dictate a command like "Prohlédni projekt" 
- [ ] Verify LLM corrects "Prohlédnu" → "Prohlédni"

🤖 Generated with [Claude Code](https://claude.com/claude-code)