### PR TITLE
fix: Recording overlay positioning and focus behavior (#679, #680)

### DIFF
--- a/src/VirtualAssistant.Desktop/UI/RecordingOverlayWindow.cs
+++ b/src/VirtualAssistant.Desktop/UI/RecordingOverlayWindow.cs
@@ -113,10 +113,11 @@ public class RecordingOverlayWindow : IRecordingOverlayWindow
             LayerShell.SetLayer(_window, Layer.Overlay); // Always on top
             LayerShell.SetKeyboardMode(_window, KeyboardMode.None); // Don't grab keyboard
 
-            // Don't anchor - we'll position manually
-            LayerShell.SetAnchor(_window, Edge.Top, false);
+            // Anchor to top-left - margins work relative to anchor edges
+            // Without anchors, window is centered; with Top+Left anchors, margins position from top-left corner
+            LayerShell.SetAnchor(_window, Edge.Top, true);
+            LayerShell.SetAnchor(_window, Edge.Left, true);
             LayerShell.SetAnchor(_window, Edge.Bottom, false);
-            LayerShell.SetAnchor(_window, Edge.Left, false);
             LayerShell.SetAnchor(_window, Edge.Right, false);
 
             // Set exclusive zone to -1 to not reserve space
@@ -126,6 +127,8 @@ public class RecordingOverlayWindow : IRecordingOverlayWindow
         // Window properties
         _window.SetDecorated(false);
         _window.SetDefaultSize(OverlayWidth, OverlayHeight);
+        _window.SetFocusOnClick(false); // Don't steal focus when clicked
+        _window.SetCanFocus(false); // Window cannot receive keyboard focus
 
         // Create UI
         _container = Box.New(Orientation.Horizontal, 8);


### PR DESCRIPTION
## Summary

- **Fixes cursor-relative positioning**: Overlay now appears near cursor instead of center/fallback position
- **Prevents focus stealing**: Overlay no longer takes focus from target application during dictation

## Changes

### LayerShell Anchor Configuration (#679)
- Changed `SetAnchor(Edge.Top, false)` → `SetAnchor(Edge.Top, true)`
- Changed `SetAnchor(Edge.Left, false)` → `SetAnchor(Edge.Left, true)`
- LayerShell margins only work relative to anchored edges
- Without anchors, window is centered ignoring margin values

### Focus Prevention (#680)
- Added `_window.SetFocusOnClick(false)` - prevents focus on mouse click
- Added `_window.SetCanFocus(false)` - prevents keyboard focus
- Combined with existing `KeyboardMode.None` for complete focus prevention

## Test plan

- [ ] Start dictation and verify overlay appears near cursor position
- [ ] Verify overlay follows cursor movement during dictation
- [ ] Click on overlay and verify target app keeps focus
- [ ] Type while overlay is visible and verify text goes to target app
- [ ] Test on both X11 and Wayland sessions

Closes #679, Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)