### PR TITLE
fix: Add timeout to cursor position D-Bus call (#682)

### DIFF
--- a/src/VirtualAssistant.Desktop/Services/RecordingOverlayService.cs
+++ b/src/VirtualAssistant.Desktop/Services/RecordingOverlayService.cs
@@ -22,6 +22,9 @@ public class RecordingOverlayService : IRecordingOverlayService
     private const int FallbackX = 100;
     private const int FallbackY = 100;
 
+    // Timeout for D-Bus cursor position call (500ms)
+    private static readonly TimeSpan CursorPositionTimeout = TimeSpan.FromMilliseconds(500);
+
     public RecordingOverlayService(
         ILogger<RecordingOverlayService> logger,
         ICursorPositionService cursorPositionService,
@@ -106,17 +109,27 @@ public class RecordingOverlayService : IRecordingOverlayService
     {
         try
         {
-            var position = await _cursorPositionService.GetCursorPositionAsync(cancellationToken);
+            // Create a timeout token to prevent D-Bus call from hanging forever
+            using var timeoutCts = new CancellationTokenSource(CursorPositionTimeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            var position = await _cursorPositionService.GetCursorPositionAsync(linkedCts.Token);
             if (position.HasValue)
             {
                 return (position.Value.X, position.Value.Y);
             }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning("Cursor position request timed out after {Timeout}ms, using fallback",
+                CursorPositionTimeout.TotalMilliseconds);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to get cursor position, using fallback");
         }
 
+        _logger.LogDebug("Using fallback cursor position: ({X}, {Y})", FallbackX, FallbackY);
         return (FallbackX, FallbackY);
     }
 


### PR DESCRIPTION
## Summary

- Adds 500ms timeout to cursor position D-Bus call
- Prevents recording overlay from hanging when D-Bus doesn't respond
- Falls back to position (100, 100) when timeout occurs

## Problem

When showing the recording overlay, `GetCursorPositionOrFallbackAsync` calls D-Bus `GetPointerPosition`. If the D-Bus call doesn't return (which happens on GNOME Wayland), the overlay hangs forever and never shows.

## Solution

Add a 500ms timeout using `CancellationTokenSource`. If the D-Bus call doesn't complete within 500ms, use the fallback position instead of hanging.

## Changes

- Add `CursorPositionTimeout` constant (500ms)
- Create linked CancellationTokenSource with timeout
- Catch `OperationCanceledException` separately for timeout handling
- Log warning when timeout occurs

## Test plan

- [ ] Press CapsLock to start recording
- [ ] Verify overlay appears within ~500ms (at fallback position if D-Bus times out)
- [ ] Verify no hanging even if GNOME extension D-Bus doesn't respond

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)