### PR TITLE
refactor: Apply ISP - use granular speech interfaces

### DIFF
--- a/src/VirtualAssistant.Service/Controllers/SpeechLockController.cs
+++ b/src/VirtualAssistant.Service/Controllers/SpeechLockController.cs
@@ -15,18 +15,21 @@ namespace Olbrasoft.VirtualAssistant.Service.Controllers;
 public class SpeechLockController : ControllerBase
 {
     private readonly ISpeechLockService _speechLockService;
-    private readonly IVirtualAssistantSpeaker _speaker;
+    private readonly ISpeechCancellation _speechCancellation;
+    private readonly ISpeechQueueInfo _speechQueueInfo;
     private readonly INotificationBatchingService _batchingService;
     private readonly ILogger<SpeechLockController> _logger;
 
     public SpeechLockController(
         ISpeechLockService speechLockService,
-        IVirtualAssistantSpeaker speaker,
+        ISpeechCancellation speechCancellation,
+        ISpeechQueueInfo speechQueueInfo,
         INotificationBatchingService batchingService,
         ILogger<SpeechLockController> logger)
     {
         _speechLockService = speechLockService;
-        _speaker = speaker;
+        _speechCancellation = speechCancellation;
+        _speechQueueInfo = speechQueueInfo;
         _batchingService = batchingService;
         _logger = logger;
     }
@@ -45,7 +48,7 @@ public class SpeechLockController : ControllerBase
             request?.TimeoutSeconds ?? 30);
 
         // Stop current TTS immediately
-        _speaker.CancelCurrentSpeech();
+        _speechCancellation.CancelCurrentSpeech();
 
         // Activate lock with optional custom timeout
         TimeSpan? timeout = request?.TimeoutSeconds > 0
@@ -59,9 +62,9 @@ public class SpeechLockController : ControllerBase
             Success = true,
             IsLocked = true,
             Message = "Speech lock activated",
-            QueueCount = _batchingService.PendingCount + _speaker.QueueCount,
+            QueueCount = _batchingService.PendingCount + _speechQueueInfo.QueueCount,
             BatchingQueueCount = _batchingService.PendingCount,
-            TtsQueueCount = _speaker.QueueCount
+            TtsQueueCount = _speechQueueInfo.QueueCount
         });
     }
 
@@ -87,11 +90,11 @@ public class SpeechLockController : ControllerBase
         }
 
         // Flush queued messages from TtsService (messages that arrived during lock)
-        var ttsQueueCount = _speaker.QueueCount;
+        var ttsQueueCount = _speechQueueInfo.QueueCount;
         if (ttsQueueCount > 0)
         {
             _logger.LogInformation("Flushing {Count} queued messages from TTS service", ttsQueueCount);
-            await _speaker.FlushQueueAsync();
+            await _speechCancellation.FlushQueueAsync();
         }
 
         var totalFlushed = batchPendingCount + ttsQueueCount;
@@ -102,7 +105,7 @@ public class SpeechLockController : ControllerBase
             Message = totalFlushed > 0
                 ? $"Speech lock released, playing {totalFlushed} queued message(s)"
                 : "Speech lock released",
-            QueueCount = _batchingService.PendingCount + _speaker.QueueCount
+            QueueCount = _batchingService.PendingCount + _speechQueueInfo.QueueCount
         });
     }
 
@@ -113,7 +116,7 @@ public class SpeechLockController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult GetStatus()
     {
-        var totalQueueCount = _batchingService.PendingCount + _speaker.QueueCount;
+        var totalQueueCount = _batchingService.PendingCount + _speechQueueInfo.QueueCount;
         return Ok(new SpeechLockResponse
         {
             Success = true,
@@ -122,7 +125,7 @@ public class SpeechLockController : ControllerBase
             QueueCount = totalQueueCount,
             IsProcessing = _batchingService.IsProcessing,
             BatchingQueueCount = _batchingService.PendingCount,
-            TtsQueueCount = _speaker.QueueCount
+            TtsQueueCount = _speechQueueInfo.QueueCount
         });
     }
 }

--- a/src/VirtualAssistant.Service/Infrastructure/StartupNotificationService.cs
+++ b/src/VirtualAssistant.Service/Infrastructure/StartupNotificationService.cs
@@ -1,5 +1,3 @@
-using Olbrasoft.VirtualAssistant.Core.Services;
-
 namespace Olbrasoft.VirtualAssistant.Service.Infrastructure;
 
 /// <summary>
@@ -8,12 +6,10 @@ namespace Olbrasoft.VirtualAssistant.Service.Infrastructure;
 /// </summary>
 public sealed class StartupNotificationService : IHostedService
 {
-    private readonly IVirtualAssistantSpeaker _speaker;
     private readonly ILogger<StartupNotificationService> _logger;
 
-    public StartupNotificationService(IVirtualAssistantSpeaker speaker, ILogger<StartupNotificationService> logger)
+    public StartupNotificationService(ILogger<StartupNotificationService> logger)
     {
-        _speaker = speaker;
         _logger = logger;
     }
 

--- a/src/VirtualAssistant.Voice/Services/NotificationBatchingService.cs
+++ b/src/VirtualAssistant.Voice/Services/NotificationBatchingService.cs
@@ -16,7 +16,7 @@ namespace Olbrasoft.VirtualAssistant.Voice.Services;
 public class NotificationBatchingService : INotificationBatchingService, IDisposable
 {
     private readonly ILogger<NotificationBatchingService> _logger;
-    private readonly IVirtualAssistantSpeaker _speaker;
+    private readonly ISpeechController _speechController;
     private readonly INotificationTracker _notificationTracker;
     private readonly ISpeechLockService _speechLockService;
     private readonly SpeechToTextSettings _speechToTextSettings;
@@ -27,13 +27,13 @@ public class NotificationBatchingService : INotificationBatchingService, IDispos
 
     public NotificationBatchingService(
         ILogger<NotificationBatchingService> logger,
-        IVirtualAssistantSpeaker speaker,
+        ISpeechController speechController,
         INotificationTracker notificationTracker,
         ISpeechLockService speechLockService,
         IOptions<SpeechToTextSettings> speechToTextSettings)
     {
         _logger = logger;
-        _speaker = speaker;
+        _speechController = speechController;
         _notificationTracker = notificationTracker;
         _speechLockService = speechLockService;
         _speechToTextSettings = speechToTextSettings.Value;
@@ -123,7 +123,7 @@ public class NotificationBatchingService : INotificationBatchingService, IDispos
             await WaitForSpeechUnlockAsync();
 
             // Speak the text directly - skip cache for notifications (each is unique with timestamps/dynamic content)
-            var ttsResult = await _speaker.SpeakAsync(text, notification.Agent, skipCache: true);
+            var ttsResult = await _speechController.SpeakAsync(text, notification.Agent, skipCache: true);
 
             // Record TTS tracking if we have a notification ID
             if (notification.NotificationId.HasValue)

--- a/tests/VirtualAssistant.Service.Tests/Controllers/SpeechLockControllerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Controllers/SpeechLockControllerTests.cs
@@ -10,7 +10,8 @@ namespace Olbrasoft.VirtualAssistant.Service.Tests.Controllers;
 public class SpeechLockControllerTests
 {
     private readonly Mock<ISpeechLockService> _speechLockServiceMock;
-    private readonly Mock<IVirtualAssistantSpeaker> _speakerMock;
+    private readonly Mock<ISpeechCancellation> _speechCancellationMock;
+    private readonly Mock<ISpeechQueueInfo> _speechQueueInfoMock;
     private readonly Mock<INotificationBatchingService> _batchingServiceMock;
     private readonly Mock<ILogger<SpeechLockController>> _loggerMock;
     private readonly SpeechLockController _controller;
@@ -18,13 +19,15 @@ public class SpeechLockControllerTests
     public SpeechLockControllerTests()
     {
         _speechLockServiceMock = new Mock<ISpeechLockService>();
-        _speakerMock = new Mock<IVirtualAssistantSpeaker>();
+        _speechCancellationMock = new Mock<ISpeechCancellation>();
+        _speechQueueInfoMock = new Mock<ISpeechQueueInfo>();
         _batchingServiceMock = new Mock<INotificationBatchingService>();
         _loggerMock = new Mock<ILogger<SpeechLockController>>();
 
         _controller = new SpeechLockController(
             _speechLockServiceMock.Object,
-            _speakerMock.Object,
+            _speechCancellationMock.Object,
+            _speechQueueInfoMock.Object,
             _batchingServiceMock.Object,
             _loggerMock.Object);
     }
@@ -34,7 +37,7 @@ public class SpeechLockControllerTests
     {
         // Arrange
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(0);
-        _speakerMock.Setup(x => x.QueueCount).Returns(0);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(0);
 
         // Act
         var result = _controller.Start(null);
@@ -46,7 +49,7 @@ public class SpeechLockControllerTests
         Assert.True(response.IsLocked);
         Assert.Equal("Speech lock activated", response.Message);
 
-        _speakerMock.Verify(x => x.CancelCurrentSpeech(), Times.Once);
+        _speechCancellationMock.Verify(x => x.CancelCurrentSpeech(), Times.Once);
         _speechLockServiceMock.Verify(x => x.Lock(null), Times.Once);
     }
 
@@ -56,7 +59,7 @@ public class SpeechLockControllerTests
         // Arrange
         var request = new SpeechLockStartRequest { TimeoutSeconds = 60 };
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(0);
-        _speakerMock.Setup(x => x.QueueCount).Returns(0);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(0);
 
         // Act
         var result = _controller.Start(request);
@@ -77,7 +80,7 @@ public class SpeechLockControllerTests
         // Arrange
         var request = new SpeechLockStartRequest { TimeoutSeconds = 0 };
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(0);
-        _speakerMock.Setup(x => x.QueueCount).Returns(0);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(0);
 
         // Act
         var result = _controller.Start(request);
@@ -91,7 +94,7 @@ public class SpeechLockControllerTests
     {
         // Arrange
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(3);
-        _speakerMock.Setup(x => x.QueueCount).Returns(2);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(2);
 
         // Act
         var result = _controller.Start(null);
@@ -107,7 +110,7 @@ public class SpeechLockControllerTests
     {
         // Arrange
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(2);
-        _speakerMock.Setup(x => x.QueueCount).Returns(3);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(3);
 
         // Act
         var result = await _controller.Stop();
@@ -121,7 +124,7 @@ public class SpeechLockControllerTests
 
         _speechLockServiceMock.Verify(x => x.Unlock(), Times.Once);
         _batchingServiceMock.Verify(x => x.FlushAsync(), Times.Once);
-        _speakerMock.Verify(x => x.FlushQueueAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _speechCancellationMock.Verify(x => x.FlushQueueAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -129,7 +132,7 @@ public class SpeechLockControllerTests
     {
         // Arrange
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(0);
-        _speakerMock.Setup(x => x.QueueCount).Returns(0);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(0);
 
         // Act
         var result = await _controller.Stop();
@@ -141,7 +144,7 @@ public class SpeechLockControllerTests
 
         _speechLockServiceMock.Verify(x => x.Unlock(), Times.Once);
         _batchingServiceMock.Verify(x => x.FlushAsync(), Times.Never);
-        _speakerMock.Verify(x => x.FlushQueueAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _speechCancellationMock.Verify(x => x.FlushQueueAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -149,7 +152,7 @@ public class SpeechLockControllerTests
     {
         // Arrange
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(0);
-        _speakerMock.Setup(x => x.QueueCount).Returns(2);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(2);
 
         // Act
         var result = await _controller.Stop();
@@ -160,7 +163,7 @@ public class SpeechLockControllerTests
         Assert.Contains("2", response.Message);
 
         _batchingServiceMock.Verify(x => x.FlushAsync(), Times.Never);
-        _speakerMock.Verify(x => x.FlushQueueAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _speechCancellationMock.Verify(x => x.FlushQueueAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -170,7 +173,7 @@ public class SpeechLockControllerTests
         _speechLockServiceMock.Setup(x => x.IsLocked).Returns(true);
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(5);
         _batchingServiceMock.Setup(x => x.IsProcessing).Returns(false);
-        _speakerMock.Setup(x => x.QueueCount).Returns(3);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(3);
 
         // Act
         var result = _controller.GetStatus();
@@ -194,7 +197,7 @@ public class SpeechLockControllerTests
         _speechLockServiceMock.Setup(x => x.IsLocked).Returns(false);
         _batchingServiceMock.Setup(x => x.PendingCount).Returns(0);
         _batchingServiceMock.Setup(x => x.IsProcessing).Returns(true);
-        _speakerMock.Setup(x => x.QueueCount).Returns(0);
+        _speechQueueInfoMock.Setup(x => x.QueueCount).Returns(0);
 
         // Act
         var result = _controller.GetStatus();


### PR DESCRIPTION
Fixes #690

## Summary
Refactored consumers of IVirtualAssistantSpeaker to use specific granular interfaces per Interface Segregation Principle.

## Changes
| File | Before | After |
|------|--------|-------|
| NotificationBatchingService | IVirtualAssistantSpeaker | ISpeechController |
| StartupNotificationService | IVirtualAssistantSpeaker (unused) | Removed |
| SpeechLockController | IVirtualAssistantSpeaker | ISpeechCancellation + ISpeechQueueInfo |

## Testing
- All unit tests pass (294 in Service.Tests, 148 in Voice.Tests)
- Updated SpeechLockControllerTests for new interfaces
- 2 pre-existing Desktop.Tests failures (unrelated to this change)