### PR TITLE
Add: TTS profile for Antigravity agent

### DIFF
--- a/src/VirtualAssistant.Service/appsettings.json
+++ b/src/VirtualAssistant.Service/appsettings.json
@@ -292,6 +292,14 @@
         "Pitch": "+0Hz",
         "Priority": 10
       },
+      "antigravity": {
+        "Provider": "EdgeTTS-WebSocket",
+        "Voice": "cs-CZ-VlastaNeural",
+        "Rate": "+10%",
+        "Volume": "+0%",
+        "Pitch": "+0Hz",
+        "Priority": 10
+      },
       "desktop-monitor": {
         "Provider": "EdgeTTS-WebSocket",
         "Voice": "cs-CZ-VlastaNeural",


### PR DESCRIPTION
## Summary
- Add TTS profile configuration for Antigravity agent
- Use `cs-CZ-VlastaNeural` female voice via EdgeTTS-WebSocket provider
- Consistent with Gemini agent voice configuration

Closes #731

## Test plan
- [ ] Configuration is valid JSON
- [ ] TTS service recognizes "antigravity" profile
- [ ] Notifications from Antigravity play with female voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)