### PR TITLE
Fix ZenProvider URL and ModelId propagation

### DIFF
--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -284,7 +284,8 @@ public class DictationWorker : BackgroundService, IDictationControl
             correctionResult = new LlmCorrectionResult(
                 CorrectedText: correctedText,
                 PromptId: result.PromptId,  // PromptId from TranscriptionService (context-aware prompt selection)
-                DurationMs: result.LlmDurationMs.Value
+                DurationMs: result.LlmDurationMs.Value,
+                ModelId: result.ModelId  // ModelId from LLM provider
             );
         }
 

--- a/src/VirtualAssistant.Voice/Services/ZenProvider.cs
+++ b/src/VirtualAssistant.Voice/Services/ZenProvider.cs
@@ -185,14 +185,10 @@ public class ZenProvider : ILlmProvider
 
         try
         {
-            // Get context-aware prompt and model ID in parallel
-            var promptTask = GetSystemPromptAsync(cancellationToken);
-            var modelIdTask = GetModelIdAsync(cancellationToken);
-
-            await Task.WhenAll(promptTask, modelIdTask);
-
-            var (promptText, promptId) = promptTask.Result;
-            var modelId = modelIdTask.Result;
+            // Get context-aware prompt and model ID sequentially
+            // (cannot run in parallel - DbContext is not thread-safe)
+            var (promptText, promptId) = await GetSystemPromptAsync(cancellationToken);
+            var modelId = await GetModelIdAsync(cancellationToken);
 
             var request = new
             {
@@ -206,7 +202,7 @@ public class ZenProvider : ILlmProvider
                 max_tokens = _options.MaxTokens
             };
 
-            var response = await _httpClient.PostAsJsonAsync("/chat/completions", request, cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync("chat/completions", request, cancellationToken);
 
             // Capture rate limit headers
             _lastRateLimitHeaders = new Dictionary<string, string>();


### PR DESCRIPTION
## Summary
- Fix ZenProvider API endpoint URL (remove leading slash for proper HttpClient BaseAddress combination)
- Fix DbContext race condition by using sequential DB calls instead of Task.WhenAll (same fix as MistralProvider)
- Pass ModelId from TranscriptionResult to LlmCorrectionResult in DictationWorker to enable proper correction tracking

## Changes
- `ZenProvider.cs`: Changed `/chat/completions` to `chat/completions` for correct URL resolution
- `ZenProvider.cs`: Changed parallel `Task.WhenAll` to sequential awaits to avoid DbContext thread-safety issues
- `DictationWorker.cs`: Added `ModelId: result.ModelId` when constructing LlmCorrectionResult

## Testing
- Verified Zen API calls succeed (was returning 404 before URL fix)
- Verified corrections are saved with `model_id = 2` (Alpha GLM 4.7)
- Verified faster response times (~800ms vs ~2500ms with Mistral)

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)