### PR TITLE
fix: Add D-Bus session variables for service restart in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,9 @@ jobs:
 
       - name: Restart service
         run: |
-          systemctl --user restart virtual-assistant.service || true
+          # GitHub Actions runner doesn't have D-Bus session, so we need to set it up
+          export XDG_RUNTIME_DIR=/run/user/$(id -u)
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+          systemctl --user restart virtual-assistant.service
           sleep 2
-          systemctl --user status virtual-assistant.service --no-pager || true
+          systemctl --user status virtual-assistant.service --no-pager


### PR DESCRIPTION
## Summary
- Fixes service restart in GitHub Actions deploy workflow
- GitHub Actions runner doesn't have D-Bus session access, causing `systemctl --user restart` to fail

## Problem
Deploy workflow silently failed to restart service with error:
```
Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
```

## Solution
Export required D-Bus session variables before running systemctl:
- `XDG_RUNTIME_DIR=/run/user/$(id -u)`
- `DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"`

## Test plan
- [ ] Deploy workflow succeeds on next push to main
- [ ] Service is actually restarted after deploy
- [ ] Migrations are automatically applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)