### PR TITLE
feat(voice): Implement automatic fallback from Google STT to Whisper

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -123,7 +123,11 @@ public static class VoiceServicesExtensions
         // Register STT provider factory
         services.AddSingleton<ISpeechTranscriberFactory, SpeechTranscriberFactory>();
 
-        // Register FallbackSpeechTranscriber or single provider based on settings
+        // Register FallbackSpeechTranscriber or single provider based on settings.
+        // Note: When FallbackSpeechTranscriber is used, LastUsedProviderId tracks which provider
+        // was actually used. This is a singleton, so LastUsedProviderId access is thread-safe
+        // via Volatile/Interlocked. Alternative approach would be to add ProviderId to
+        // TranscriptionResult, but that would require changes to the interface contract.
         services.AddSingleton<ISpeechTranscriber>(sp =>
         {
             var factory = sp.GetRequiredService<ISpeechTranscriberFactory>();
@@ -133,7 +137,8 @@ public static class VoiceServicesExtensions
             var primary = factory.GetProvider(settings.PrimaryProvider);
             var fallback = factory.GetProvider(settings.FallbackProvider);
 
-            // If fallback is disabled or not available, return primary provider
+            // If fallback is disabled or not available, return primary provider directly.
+            // In this case, caller should use factory.GetProviderId() for provider tracking.
             if (!settings.EnableFallback || primary == null || fallback == null)
             {
                 return primary ?? fallback ?? throw new InvalidOperationException("No STT provider available");

--- a/src/VirtualAssistant.Voice/Services/FallbackSpeechTranscriber.cs
+++ b/src/VirtualAssistant.Voice/Services/FallbackSpeechTranscriber.cs
@@ -16,12 +16,18 @@ public sealed class FallbackSpeechTranscriber : ISpeechTranscriber
     private readonly ILogger<FallbackSpeechTranscriber> _logger;
     private readonly SpeechProviderSettings _settings;
     private bool _disposed;
+    private int _lastUsedProviderId;
 
     /// <summary>
     /// Gets the provider ID of the last used transcriber.
     /// Used for tracking which provider was actually used in database.
+    /// Thread-safe via Volatile/Interlocked for concurrent access.
     /// </summary>
-    public int LastUsedProviderId { get; private set; }
+    public int LastUsedProviderId
+    {
+        get => System.Threading.Volatile.Read(ref _lastUsedProviderId);
+        private set => System.Threading.Interlocked.Exchange(ref _lastUsedProviderId, value);
+    }
 
     /// <summary>
     /// Gets the language code from the primary provider.
@@ -53,6 +59,12 @@ public sealed class FallbackSpeechTranscriber : ISpeechTranscriber
         if (_disposed)
             throw new ObjectDisposedException(nameof(FallbackSpeechTranscriber));
 
+        if (audioData is null)
+            throw new ArgumentNullException(nameof(audioData));
+
+        if (audioData.Length == 0)
+            throw new ArgumentException("Audio data cannot be empty.", nameof(audioData));
+
         if (!_settings.EnableFallback)
         {
             LastUsedProviderId = _factory.GetProviderId(_settings.PrimaryProvider);
@@ -71,11 +83,36 @@ public sealed class FallbackSpeechTranscriber : ISpeechTranscriber
                 return result;
             }
 
+            // Short-circuit non-provider failures (e.g., input validation, cancellation)
+            var errorMessage = result.ErrorMessage ?? string.Empty;
+            var loweredError = errorMessage.ToLowerInvariant();
+
+            var isInputValidationError =
+                loweredError.Contains("audio data cannot be empty") ||
+                loweredError.Contains("audio data is empty") ||
+                loweredError.Contains("no audio data");
+
+            var isCancellationError =
+                cancellationToken.IsCancellationRequested ||
+                loweredError.Contains("transcription cancelled") ||
+                loweredError.Contains("transcription canceled") ||
+                loweredError.Contains("operation cancelled") ||
+                loweredError.Contains("operation canceled");
+
+            if (isInputValidationError || isCancellationError)
+            {
+                LastUsedProviderId = _factory.GetProviderId(_settings.PrimaryProvider);
+                _logger.LogWarning(
+                    "Primary provider {Provider} returned non-transient error: {Error}, not falling back",
+                    _settings.PrimaryProvider, result.ErrorMessage);
+                return result;
+            }
+
             _logger.LogWarning(
                 "Primary provider {Provider} returned error: {Error}, falling back to {Fallback}",
                 _settings.PrimaryProvider, result.ErrorMessage, _settings.FallbackProvider);
         }
-        catch (Exception ex) when (ShouldFallback(ex))
+        catch (Exception ex) when (ShouldFallback(ex, cancellationToken))
         {
             _logger.LogWarning(
                 ex,
@@ -97,6 +134,9 @@ public sealed class FallbackSpeechTranscriber : ISpeechTranscriber
         if (_disposed)
             throw new ObjectDisposedException(nameof(FallbackSpeechTranscriber));
 
+        if (audioStream is null)
+            throw new ArgumentNullException(nameof(audioStream));
+
         // Read stream to memory for potential retry
         using var memoryStream = new MemoryStream();
         await audioStream.CopyToAsync(memoryStream, cancellationToken);
@@ -107,12 +147,22 @@ public sealed class FallbackSpeechTranscriber : ISpeechTranscriber
 
     /// <summary>
     /// Determines if an exception should trigger fallback.
+    /// User-requested cancellations (via CancellationToken) are propagated, not retried.
     /// </summary>
-    private static bool ShouldFallback(Exception ex)
+    private static bool ShouldFallback(Exception ex, CancellationToken cancellationToken)
     {
+        // Genuine user cancellation - propagate, don't fallback
+        // Check both: the token must be cancelled AND the exception must be from that token
+        if (cancellationToken.IsCancellationRequested &&
+            ex is OperationCanceledException oce &&
+            oce.CancellationToken == cancellationToken)
+        {
+            return false;
+        }
+
         return ex is HttpRequestException        // Network error
-            || ex is TaskCanceledException       // Timeout (when not user-requested cancellation)
-            || ex is OperationCanceledException  // Operation cancelled
+            || ex is TaskCanceledException       // Timeout (internal, not user cancellation)
+            || ex is OperationCanceledException  // Timeout from HttpClient
             || ex is TimeoutException;           // Explicit timeout
     }
 

--- a/tests/VirtualAssistant.Voice.Tests/Services/FallbackSpeechTranscriberTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/FallbackSpeechTranscriberTests.cs
@@ -175,6 +175,27 @@ public class FallbackSpeechTranscriberTests
     }
 
     [Fact]
+    public async Task TranscribeAsync_UserCancellation_DoesNotTriggerFallback()
+    {
+        // Arrange - True user cancellation via CancellationToken
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _primaryMock
+            .Setup(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var transcriber = CreateTranscriber();
+        var audioData = new byte[] { 1, 2, 3 };
+
+        // Act & Assert - Cancellation should propagate, not trigger fallback
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            transcriber.TranscribeAsync(audioData, cts.Token));
+
+        _fallbackMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task TranscribeAsync_FallbackDisabled_NeverCallsFallback()
     {
         // Arrange
@@ -362,8 +383,11 @@ public class FallbackSpeechTranscriberTests
         transcriber.Dispose();
 
         // Act & Assert
-        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            transcriber.TranscribeAsync(new MemoryStream()));
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+        {
+            using var stream = new MemoryStream();
+            await transcriber.TranscribeAsync(stream);
+        });
     }
 
     [Fact]
@@ -391,6 +415,72 @@ public class FallbackSpeechTranscriberTests
         // Act & Assert - Exception should propagate, not trigger fallback
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             transcriber.TranscribeAsync(audioData));
+
+        _fallbackMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_NullAudioData_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var transcriber = CreateTranscriber();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            transcriber.TranscribeAsync((byte[])null!));
+
+        _primaryMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _fallbackMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_EmptyAudioData_ThrowsArgumentException()
+    {
+        // Arrange
+        var transcriber = CreateTranscriber();
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            transcriber.TranscribeAsync(Array.Empty<byte>()));
+
+        Assert.Equal("audioData", ex.ParamName);
+        _primaryMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _fallbackMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_NullStream_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var transcriber = CreateTranscriber();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            transcriber.TranscribeAsync((Stream)null!));
+
+        _primaryMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _fallbackMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_PrimaryReturnsValidationError_DoesNotFallback()
+    {
+        // Arrange - Non-transient validation error should not trigger fallback
+        var validationError = new TranscriptionResult("Audio data cannot be empty");
+        _primaryMock
+            .Setup(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validationError);
+
+        var transcriber = CreateTranscriber();
+        var audioData = new byte[] { 1, 2, 3 };
+
+        // Act
+        var result = await transcriber.TranscribeAsync(audioData);
+
+        // Assert - Should return primary error, not fallback
+        Assert.False(result.Success);
+        Assert.Contains("Audio data cannot be empty", result.ErrorMessage);
+        Assert.Equal(PrimaryProviderId, transcriber.LastUsedProviderId);
 
         _fallbackMock.Verify(p => p.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
     }


### PR DESCRIPTION
## Summary

- Implement FallbackSpeechTranscriber decorator for automatic provider failover
- Falls back from Google STT to Whisper on network errors, timeouts, or API errors
- Track which provider was actually used via LastUsedProviderId for database recording

## Changes

- **FallbackSpeechTranscriber.cs** - Decorator that wraps primary and fallback providers
- **VoiceServicesExtensions.cs** - Updated DI registration to use FallbackSpeechTranscriber
- **FallbackSpeechTranscriberTests.cs** - 19 unit tests covering all scenarios

## Fallback Scenarios

| Scenario | Action |
|----------|--------|
| Google success | Return Google result, ProviderId = Google |
| Google error result | Fall back to Whisper |
| Network error (HttpRequestException) | Fall back to Whisper |
| Timeout (TaskCanceledException) | Fall back to Whisper |
| Other exceptions | Propagate (no fallback) |

## Test plan

- [x] 19 unit tests passing
- [x] All 734 existing tests passing
- [ ] Integration test with real providers (skipped in CI)

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)