### PR TITLE
fix: Use Google STT as primary provider for DictationWorker

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -71,22 +71,32 @@ public static class WorkerServicesExtensions
                 whisperLogger,
                 Microsoft.Extensions.Options.Options.Create(continuousOptions));
 
-            // Create transcriber: FallbackSpeechTranscriber with Google primary + Whisper fallback
-            // or just Whisper if Google is not available
+            // Create transcriber:
+            // - If Google is available and fallback is enabled: FallbackSpeechTranscriber (Google primary + Whisper fallback)
+            // - If Google is available and fallback is disabled: use Google directly
+            // - If Google is not available: use Whisper directly
             ISpeechTranscriber dictationTranscriber;
-            if (speechSettings.EnableFallback && googleTranscriber != null)
+            if (googleTranscriber != null)
             {
-                var fallbackLogger = sp.GetRequiredService<ILogger<FallbackSpeechTranscriber>>();
-                dictationTranscriber = new FallbackSpeechTranscriber(
-                    googleTranscriber,
-                    dictationWhisperTranscriber,
-                    factory,
-                    fallbackLogger,
-                    speechSettings);
+                if (speechSettings.EnableFallback)
+                {
+                    var fallbackLogger = sp.GetRequiredService<ILogger<FallbackSpeechTranscriber>>();
+                    dictationTranscriber = new FallbackSpeechTranscriber(
+                        googleTranscriber,
+                        dictationWhisperTranscriber,
+                        factory,
+                        fallbackLogger,
+                        speechSettings);
+                }
+                else
+                {
+                    // Fallback disabled and Google available - use Google directly
+                    dictationTranscriber = googleTranscriber;
+                }
             }
             else
             {
-                // Fallback disabled or Google not available - use Whisper directly
+                // Google not available - use Whisper directly
                 dictationTranscriber = dictationWhisperTranscriber;
             }
 


### PR DESCRIPTION
## Summary
Fixes DictationWorker to use Google STT as primary provider with Whisper fallback, instead of using Whisper directly.

Part of #819

## Problem
DictationWorker was creating its own `WhisperSpeechTranscriber` directly in `WorkerServicesExtensions.cs`, which bypassed the `FallbackSpeechTranscriber` and Google STT configuration.

## Solution
- Get Google STT from keyed services as primary provider
- Create dedicated Whisper transcriber for dictation (using large-v3-turbo model)
- Wrap both in `FallbackSpeechTranscriber` for automatic failover
- Falls back to Whisper-only if Google is not available

## Test plan
- [x] Build succeeds
- [x] All unit tests pass
- [ ] Manual test: dictation should use Google STT and show provider_id=14 in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)