### PR TITLE
fix: Use valid provider ID default to prevent FK constraint violation

### DIFF
--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -304,8 +304,8 @@ public class DictationWorker : BackgroundService, IDictationControl
         }
 
         // Get the STT provider ID from the transcription result (set by the active speech transcriber)
-        // If not set, fall back to 0 (unknown) instead of assuming a specific provider.
-        var sttProviderId = result.SttProviderId.GetValueOrDefault();
+        // Falls back to Whisper (13) if not set - required because provider_id has FK constraint
+        var sttProviderId = result.SttProviderId.GetValueOrDefault(13);
 
         await persistenceService.SaveTranscriptionAsync(
             audioData,


### PR DESCRIPTION
## Summary
Hotfix for critical bug introduced in PR #835.

## Problem
`GetValueOrDefault()` returns `0` when `SttProviderId` is null, but `0` is not a valid provider ID in the `providers` table. This causes FK constraint violation:

```
23503: insert or update on table "voice_transcriptions" violates foreign key constraint "FK_voice_transcriptions_providers_provider_id"
```

## Solution
Changed from `GetValueOrDefault()` to `GetValueOrDefault(13)` which falls back to Whisper (ID=13) - a valid provider in the database.

## Test plan
- [x] Build passes
- [ ] Manual test: dictate text, verify no FK constraint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)