### PR TITLE
fix: Preserve SttProviderId when TranscriptionService creates new result

### DIFF
--- a/src/VirtualAssistant.Voice/Services/TranscriptionService.cs
+++ b/src/VirtualAssistant.Voice/Services/TranscriptionService.cs
@@ -119,7 +119,8 @@ public class TranscriptionService : ITranscriptionService
                 FilteredText = filteredText,  // Text after filtering but before LLM (null if no filtering)
                 LlmDurationMs = llmDurationMs, // LLM correction duration in ms (null if no LLM correction)
                 PromptId = promptId,          // Prompt ID used for LLM correction (null if no LLM correction)
-                ModelId = modelId             // Model ID used for LLM correction (null if no LLM correction)
+                ModelId = modelId,            // Model ID used for LLM correction (null if no LLM correction)
+                SttProviderId = result.SttProviderId  // Preserve STT provider ID from transcriber
             };
         }
 


### PR DESCRIPTION
## Summary
Critical bug fix - TranscriptionService was losing the SttProviderId.

## Problem
When `TranscriptionService` creates a new `TranscriptionResult` (for LLM correction), it wasn't preserving `SttProviderId` from the original result. This caused all transcriptions to be saved with `provider_id=13` (Whisper default) even when Google STT was actually used.

## Fix
Added `SttProviderId = result.SttProviderId` to preserve the provider ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)