### PR TITLE
fix: pass racing dependencies to DictationWorker TranscriptionService

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.SignalR;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Infrastructure;
 using Olbrasoft.VirtualAssistant.Service.Workers;
+using Olbrasoft.VirtualAssistant.Voice.Configuration;
 using Olbrasoft.VirtualAssistant.Voice.Filters;
 using Olbrasoft.VirtualAssistant.Voice.Services;
 
@@ -105,13 +106,17 @@ public static class WorkerServicesExtensions
             var transcriptionLogger = sp.GetRequiredService<ILogger<TranscriptionService>>();
             var textFilter = sp.GetRequiredService<ITextFilter>();
             var llmProviderFactory = sp.GetRequiredService<ILlmProviderFactory>();
+            var racingLlmProvider = sp.GetRequiredService<IRacingLlmProvider>();
+            var llmProviderOptions = sp.GetRequiredService<IOptions<LlmProviderOptions>>();
 
             var dictationTranscriptionService = new TranscriptionService(
                 transcriptionLogger,
                 dictationTranscriber,
                 configuration,
                 textFilter,
-                llmProviderFactory);
+                llmProviderFactory,
+                racingLlmProvider,
+                llmProviderOptions);
 
             var hubContext = sp.GetRequiredService<IHubContext<DictationHub>>();
 

--- a/src/VirtualAssistant.Voice/Services/TranscriptionService.cs
+++ b/src/VirtualAssistant.Voice/Services/TranscriptionService.cs
@@ -43,6 +43,18 @@ public class TranscriptionService : ITranscriptionService
         _racingOptions = llmProviderOptions?.Value.Racing ?? new RacingOptions();
         _options = new ContinuousListenerOptions();
         configuration.GetSection(ContinuousListenerOptions.SectionName).Bind(_options);
+
+        _logger.LogInformation("TranscriptionService racing config: Enabled={Enabled}, Providers=[{Providers}], RacingProvider={HasRacing}, ActiveProvider={Active}",
+            _racingOptions.Enabled,
+            string.Join(", ", _racingOptions.Providers),
+            _racingLlmProvider != null,
+            llmProviderOptions?.Value.ActiveProvider ?? "null");
+
+        // Also check raw config
+        var rawEnabled = configuration["LlmProvider:Racing:Enabled"];
+        var rawProviders = configuration["LlmProvider:Racing:Providers"];
+        _logger.LogInformation("TranscriptionService racing RAW config: Enabled={RawEnabled}, Providers={RawProviders}",
+            rawEnabled ?? "null", rawProviders ?? "null");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fix missing racing dependencies in WorkerServicesExtensions - DictationWorker's TranscriptionService was created without `IRacingLlmProvider` and `IOptions<LlmProviderOptions>`, causing racing to never activate for dictation
- Add diagnostic logging for racing config at startup

## Test plan
- [x] Verified racing works: Mercury won in 1173ms, GPT-5.4 Nano finished in 1708ms
- [x] Both results saved to DB with matching `race_group_id` and correct `is_winner` flags
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)