### PR TITLE
fix: use jq for safe JSON in deploy notification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,17 +114,16 @@ jobs:
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           REPO_FILE=$(echo "$GITHUB_REPOSITORY" | tr '/' '-')
 
-          cat > "$EVENTS_DIR/${REPO_FILE}.json" << DEPLOY_EOF
-          {
-            "event": "deploy-complete",
-            "status": "${{ job.status }}",
-            "repository": "${GITHUB_REPOSITORY}",
-            "commit": "${COMMIT_SHA}",
-            "commitMessage": $(echo "${COMMIT_MSG}" | jq -Rs .),
-            "runUrl": "${RUN_URL}",
-            "environment": "production",
-            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          }
-          DEPLOY_EOF
+          jq -n \
+            --arg event "deploy-complete" \
+            --arg status "${{ job.status }}" \
+            --arg repository "${GITHUB_REPOSITORY}" \
+            --arg commit "${COMMIT_SHA}" \
+            --arg commitMessage "${COMMIT_MSG}" \
+            --arg runUrl "${RUN_URL}" \
+            --arg environment "production" \
+            --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{event: $event, status: $status, repository: $repository, commit: $commit, commitMessage: $commitMessage, runUrl: $runUrl, environment: $environment, timestamp: $timestamp}' \
+            > "$EVENTS_DIR/${REPO_FILE}.json"
 
           echo "Deploy notification written for Claude Code"


### PR DESCRIPTION
## Summary

- Replace heredoc string interpolation with `jq -n --arg` for deploy event file
- Prevents JSON injection from commit messages with quotes/special chars

## Test plan

- [ ] Copilot reviews → code-review notification arrives via webhook
- [ ] After merge → deploy notification arrives via inotifywait
- [ ] Full end-to-end push-based workflow verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)