### PR TITLE
feat: add failed step identification to deploy notifications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,7 @@ jobs:
           REPO_FILE=$(echo "$GITHUB_REPOSITORY" | tr '/' '-')
 
           # Determine which step failed (if any)
+          # Note: bracket notation required for hyphenated step IDs
           FAILED_STEP=""
           if [ "${{ steps.restore.outcome }}" = "failure" ]; then
             FAILED_STEP="restore"
@@ -132,12 +133,12 @@ jobs:
             FAILED_STEP="test"
           elif [ "${{ steps.publish.outcome }}" = "failure" ]; then
             FAILED_STEP="publish"
-          elif [ "${{ steps.copy-assets.outcome }}" = "failure" ]; then
+          elif [ "${{ steps['copy-assets'].outcome }}" = "failure" ]; then
             FAILED_STEP="copy-assets"
           elif [ "${{ steps.restart.outcome }}" = "failure" ]; then
             FAILED_STEP="restart"
           elif [ "${{ steps.health.outcome }}" = "failure" ]; then
-            FAILED_STEP="health-check"
+            FAILED_STEP="health"
           fi
 
           jq -n \


### PR DESCRIPTION
## Summary
- Added `id` to all deploy workflow steps (restore, build, test, publish, copy-assets, restart, health)
- Notify Claude Code step now detects which specific step failed using `steps.<id>.outcome`
- Event JSON includes `failedStep` field so Claude Code knows exactly what broke

**Note:** Hook scripts (`check-deploy-status.sh`, `watch-deploy-events.sh`) live in `~/.claude/hooks/` (global, outside this repo) and were updated separately to handle the new `failedStep` field.

## Test plan
- [ ] Push a commit that compiles successfully → event should have `failedStep: ""`
- [ ] Introduce a build error → event should have `failedStep: "build"`
- [ ] Introduce a test failure → event should have `failedStep: "test"`
- [ ] Verify asyncRewake watcher shows failed step in stderr output

🤖 Generated with [Claude Code](https://claude.com/claude-code)