### PR TITLE
feat: extend workspace buttons to 1-8 with row wrap

### DIFF
--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -136,7 +136,8 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
     private static readonly HashSet<string> AllowedKeys = new(StringComparer.OrdinalIgnoreCase)
     {
         "enter", "ctrl+u", "ctrl+v", "ctrl+shift+v", "escape", "tab", "backspace", "delete", "alt+F4",
-        "super+kp1", "super+kp4", "super+kp5", "super+kp6",
+        "super+kp1", "super+kp2", "super+kp3", "super+kp4",
+        "super+kp5", "super+kp6", "super+kp7", "super+kp8",
         "end", "ctrl+a"
     };
 

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -260,7 +260,7 @@ public class DictationHub : Hub
         catch (Exception ex) { _logger.LogError(ex, "ClearText failed"); }
     }
 
-    private static readonly HashSet<int> AllowedWorkspaces = [1, 4, 5, 6];
+    private static readonly HashSet<int> AllowedWorkspaces = [1, 2, 3, 4, 5, 6, 7, 8];
 
     /// <summary>
     /// Gets current workspace info (1-indexed workspace number and total count).

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -343,14 +343,16 @@
         }
 
         .workspace-buttons {
+            --workspace-gap: 10px;
+            --workspace-per-row: 4;
             display: flex;
             flex-wrap: wrap;
-            gap: 10px;
+            gap: var(--workspace-gap);
         }
 
         .btn-workspace {
-            flex: 1 1 calc(25% - 8px);
-            min-width: calc(25% - 8px);
+            flex: 1 1 calc((100% - (var(--workspace-per-row) - 1) * var(--workspace-gap)) / var(--workspace-per-row));
+            min-width: calc((100% - (var(--workspace-per-row) - 1) * var(--workspace-gap)) / var(--workspace-per-row));
             height: 70px;
             font-size: 1.5rem;
             font-weight: 700;
@@ -488,7 +490,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=24"></script>
+    <script src="remote.js?v=25"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -344,11 +344,13 @@
 
         .workspace-buttons {
             display: flex;
+            flex-wrap: wrap;
             gap: 10px;
         }
 
         .btn-workspace {
-            flex: 1;
+            flex: 1 1 calc(25% - 8px);
+            min-width: calc(25% - 8px);
             height: 70px;
             font-size: 1.5rem;
             font-weight: 700;
@@ -437,9 +439,13 @@
         <div class="workspace-section" id="workspaceSection">
             <div class="workspace-buttons">
                 <button class="btn-workspace" id="btnWorkspace1" data-workspace="1" disabled>1</button>
+                <button class="btn-workspace hidden" id="btnWorkspace2" data-workspace="2" disabled>2</button>
+                <button class="btn-workspace hidden" id="btnWorkspace3" data-workspace="3" disabled>3</button>
                 <button class="btn-workspace hidden" id="btnWorkspace4" data-workspace="4" disabled>4</button>
                 <button class="btn-workspace hidden" id="btnWorkspace5" data-workspace="5" disabled>5</button>
                 <button class="btn-workspace hidden" id="btnWorkspace6" data-workspace="6" disabled>6</button>
+                <button class="btn-workspace hidden" id="btnWorkspace7" data-workspace="7" disabled>7</button>
+                <button class="btn-workspace hidden" id="btnWorkspace8" data-workspace="8" disabled>8</button>
             </div>
         </div>
 

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -26,9 +26,13 @@ const elements = {
     btnFerdium: document.getElementById('btnFerdium'),
     workspaceButtons: {
         1: document.getElementById('btnWorkspace1'),
+        2: document.getElementById('btnWorkspace2'),
+        3: document.getElementById('btnWorkspace3'),
         4: document.getElementById('btnWorkspace4'),
         5: document.getElementById('btnWorkspace5'),
-        6: document.getElementById('btnWorkspace6')
+        6: document.getElementById('btnWorkspace6'),
+        7: document.getElementById('btnWorkspace7'),
+        8: document.getElementById('btnWorkspace8')
     }
 };
 

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,7 +4,7 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v24';
+const SCRIPT_VERSION = 'v25';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v24';
+const CACHE_NAME = 'va-dictation-v25';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v25';
+const CACHE_NAME = 'va-dictation-v26';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',
@@ -50,8 +50,10 @@ self.addEventListener('fetch', event => {
                 }
                 return response;
             })
-            .catch(() =>
-                caches.match(event.request).then(cachedResponse => {
+            .catch(() => {
+                // Ignore querystring so /remote.js?v=25 matches precached /remote.js
+                const matchOptions = isSameOrigin ? { ignoreSearch: true } : undefined;
+                return caches.match(event.request, matchOptions).then(cachedResponse => {
                     if (cachedResponse) {
                         return cachedResponse;
                     }
@@ -62,8 +64,8 @@ self.addEventListener('fetch', event => {
                         status: 503,
                         statusText: 'Service Unavailable'
                     });
-                })
-            )
+                });
+            })
     );
 });
 


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
- Extend workspace buttons from 1,4,5,6 to full 1-8 range
- Max 4 buttons per row via flex-wrap; 5-8 wrap to second row
- Each button visible only when totalWorkspaces >= N
- Dynamic show/hide when workspaces are added or closed

Closes #942

## Test plan
- [ ] Verify buttons 1-N visible based on totalWorkspaces
- [ ] Verify 5-8 wrap to second row
- [ ] Verify button click switches workspace via super+kpN

🤖 Generated with [Claude Code](https://claude.com/claude-code)