### PR TITLE
feat: streaming chunked transcription for fast dictation

### DIFF
--- a/src/VirtualAssistant.Core/Audio/IAudioRecordingCoordinator.cs
+++ b/src/VirtualAssistant.Core/Audio/IAudioRecordingCoordinator.cs
@@ -1,6 +1,12 @@
 namespace Olbrasoft.VirtualAssistant.Core.Audio;
 
 /// <summary>
+/// Event args for a periodic audio chunk emitted during recording.
+/// Contains a raw PCM slice since the previous chunk boundary and its ordinal index.
+/// </summary>
+public record AudioChunkEventArgs(int Index, byte[] PcmBytes);
+
+/// <summary>
 /// Coordinates audio recording workflow including buffer management and capture task lifecycle.
 /// Separates audio recording concerns from dictation state machine orchestration.
 /// </summary>
@@ -10,6 +16,24 @@ public interface IAudioRecordingCoordinator
     /// Gets whether recording is currently in progress.
     /// </summary>
     bool IsRecording { get; }
+
+    /// <summary>
+    /// Fired periodically during recording with accumulated audio since the previous emit.
+    /// Subscribed to only when streaming transcription is enabled. Not fired outside recording.
+    /// </summary>
+    event EventHandler<AudioChunkEventArgs>? ChunkAvailable;
+
+    /// <summary>
+    /// Enables periodic chunk emission on the current (or next) recording session.
+    /// Call before <see cref="StartRecordingAsync"/> when streaming is active.
+    /// </summary>
+    /// <param name="interval">Minimum interval between chunk emits.</param>
+    void EnableChunking(TimeSpan interval);
+
+    /// <summary>
+    /// Disables chunk emission. Already-emitted chunks keep their state in subscribers.
+    /// </summary>
+    void DisableChunking();
 
     /// <summary>
     /// Starts audio recording, initializing buffer and capture task.

--- a/src/VirtualAssistant.Core/Services/IDictationControl.cs
+++ b/src/VirtualAssistant.Core/Services/IDictationControl.cs
@@ -12,4 +12,11 @@ public interface IDictationControl
     /// </summary>
     /// <param name="enabled">True to enable dictation, false to disable.</param>
     void SetDictationEnabled(bool enabled);
+
+    /// <summary>
+    /// Enables or disables streaming (chunked) transcription for the fast dictation path.
+    /// When enabled, audio is sliced and transcribed in background during recording.
+    /// Affects only fast-mode dictations started after the toggle; in-flight recordings retain their mode.
+    /// </summary>
+    void SetStreamingTranscriptionEnabled(bool enabled);
 }

--- a/src/VirtualAssistant.Core/Services/IMenuEventDispatcher.cs
+++ b/src/VirtualAssistant.Core/Services/IMenuEventDispatcher.cs
@@ -55,4 +55,9 @@ public interface IMenuEventDispatcher
     /// Opens browser to Inception Labs billing dashboard.
     /// </summary>
     void HandleMercuryBilling();
+
+    /// <summary>
+    /// Handles streaming transcription toggle from menu (fast dictation path only).
+    /// </summary>
+    void HandleStreamingTranscriptionToggle(bool enabled);
 }

--- a/src/VirtualAssistant.Service/Tray/Menu/IMenuEventRouter.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/IMenuEventRouter.cs
@@ -52,6 +52,11 @@ public interface IMenuEventRouter
     event Action<bool>? OnTtsMuteToggleRequested;
 
     /// <summary>
+    /// Event fired when user toggles streaming transcription on/off.
+    /// </summary>
+    event Action<bool>? OnStreamingTranscriptionToggled;
+
+    /// <summary>
     /// Handles a menu click event.
     /// </summary>
     /// <param name="id">Menu item ID that was clicked.</param>

--- a/src/VirtualAssistant.Service/Tray/Menu/IMenuStateManager.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/IMenuStateManager.cs
@@ -42,6 +42,11 @@ public interface IMenuStateManager
     bool IsDictationEnabled { get; }
 
     /// <summary>
+    /// Gets whether streaming (chunked) transcription is enabled for the fast dictation path.
+    /// </summary>
+    bool IsStreamingTranscriptionEnabled { get; }
+
+    /// <summary>
     /// Gets the current prompt synchronization status.
     /// </summary>
     PromptSyncStatus PromptSyncStatus { get; }
@@ -75,6 +80,11 @@ public interface IMenuStateManager
     /// Updates the dictation enabled status.
     /// </summary>
     void UpdateDictationStatus(bool enabled);
+
+    /// <summary>
+    /// Updates the streaming transcription enabled status (fast path only).
+    /// </summary>
+    void UpdateStreamingTranscriptionStatus(bool enabled);
 
     /// <summary>
     /// Updates the prompt synchronization status.

--- a/src/VirtualAssistant.Service/Tray/Menu/MenuEventRouter.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/MenuEventRouter.cs
@@ -64,6 +64,11 @@ public class MenuEventRouter : IMenuEventRouter
     public event Action<bool>? OnTtsMuteToggleRequested;
 
     /// <summary>
+    /// Event fired when user toggles streaming transcription on/off.
+    /// </summary>
+    public event Action<bool>? OnStreamingTranscriptionToggled;
+
+    /// <summary>
     /// Handles a menu click event.
     /// Routes the event to the appropriate handler based on menu item ID.
     /// </summary>
@@ -96,7 +101,8 @@ public class MenuEventRouter : IMenuEventRouter
         [MenuItemIds.MercuryBillingId] = HandleMercuryBilling,
         [MenuItemIds.LlmCorrectionId] = HandleLlmCorrection,
         [MenuItemIds.ReloadPromptId] = HandleReloadPrompt,
-        [MenuItemIds.DictationToggleId] = HandleDictationToggle
+        [MenuItemIds.DictationToggleId] = HandleDictationToggle,
+        [MenuItemIds.StreamingTranscriptionId] = HandleStreamingTranscriptionToggle
     };
 
     private void HandleQuit()
@@ -157,5 +163,13 @@ public class MenuEventRouter : IMenuEventRouter
         var newState = !_stateManager.IsDictationEnabled;
         _stateManager.UpdateDictationStatus(newState);
         OnDictationToggleRequested?.Invoke(newState);
+    }
+
+    private void HandleStreamingTranscriptionToggle()
+    {
+        _logger.LogInformation("Streaming transcription toggle clicked (current: {Enabled})", _stateManager.IsStreamingTranscriptionEnabled);
+        var newState = !_stateManager.IsStreamingTranscriptionEnabled;
+        _stateManager.UpdateStreamingTranscriptionStatus(newState);
+        OnStreamingTranscriptionToggled?.Invoke(newState);
     }
 }

--- a/src/VirtualAssistant.Service/Tray/Menu/MenuItemIds.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/MenuItemIds.cs
@@ -20,4 +20,5 @@ public static class MenuItemIds
     public const int DashboardId = 16;
     public const int AboutId = 17;
     public const int MercuryBillingId = 18;
+    public const int StreamingTranscriptionId = 19;
 }

--- a/src/VirtualAssistant.Service/Tray/Menu/MenuLayoutBuilder.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/MenuLayoutBuilder.cs
@@ -57,6 +57,12 @@ public class MenuLayoutBuilder : IMenuLayoutBuilder
                 ["enabled"] = VariantValue.Bool(true),
                 ["visible"] = VariantValue.Bool(true)
             }),
+            MenuItemIds.StreamingTranscriptionId => (id, new Dictionary<string, VariantValue>
+            {
+                ["label"] = VariantValue.String(GetStreamingTranscriptionLabel()),
+                ["enabled"] = VariantValue.Bool(true),
+                ["visible"] = VariantValue.Bool(true)
+            }),
             MenuItemIds.LlmCorrectionId => (id, new Dictionary<string, VariantValue>
             {
                 ["label"] = VariantValue.String(GetLlmCorrectionLabel()),
@@ -128,6 +134,7 @@ public class MenuLayoutBuilder : IMenuLayoutBuilder
             var muteLabel = GetMuteLabel();
             var ttsMuteLabel = GetTtsMuteLabel();
             var dictationLabel = GetDictationLabel();
+            var streamingLabel = GetStreamingTranscriptionLabel();
             var llmCorrectionLabel = GetLlmCorrectionLabel();
 
             children =
@@ -135,6 +142,7 @@ public class MenuLayoutBuilder : IMenuLayoutBuilder
                 CreateChildVariant(MenuItemIds.StatusId, "VirtualAssistant - poslouchám", false, enabled: false),
                 CreateChildVariant(MenuItemIds.Separator1Id, "", true),
                 CreateChildVariant(MenuItemIds.DictationToggleId, dictationLabel, false),
+                CreateChildVariant(MenuItemIds.StreamingTranscriptionId, streamingLabel, false),
                 CreateChildVariant(MenuItemIds.Separator2Id, "", true),
                 CreateChildVariant(MenuItemIds.LlmCorrectionId, llmCorrectionLabel, false),
                 CreateChildVariant(MenuItemIds.ReloadPromptId, GetPromptSyncLabel(), false),
@@ -208,6 +216,13 @@ public class MenuLayoutBuilder : IMenuLayoutBuilder
         return _stateManager.IsDictationEnabled
             ? "✅ Diktace - Vypnout"
             : "❌ Diktace - Zapnout";
+    }
+
+    private string GetStreamingTranscriptionLabel()
+    {
+        return _stateManager.IsStreamingTranscriptionEnabled
+            ? "✅ Streaming transkripce - Vypnout"
+            : "❌ Streaming transkripce - Zapnout";
     }
 
     private string GetLlmCorrectionLabel()

--- a/src/VirtualAssistant.Service/Tray/Menu/MenuStateManager.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/MenuStateManager.cs
@@ -12,6 +12,7 @@ public class MenuStateManager : IMenuStateManager
     private string _logViewerStatus = "Checking...";
     private bool _llmCorrectionEnabled = true;
     private bool _dictationEnabled = true;
+    private bool _streamingTranscriptionEnabled;
     private PromptSyncStatus _promptSyncStatus = PromptSyncStatus.Unknown;
     private string? _lastSyncError;
     private uint _revision;
@@ -58,6 +59,11 @@ public class MenuStateManager : IMenuStateManager
     /// Gets whether dictation is enabled.
     /// </summary>
     public bool IsDictationEnabled => _dictationEnabled;
+
+    /// <summary>
+    /// Gets whether streaming (chunked) transcription is enabled for the fast dictation path.
+    /// </summary>
+    public bool IsStreamingTranscriptionEnabled => _streamingTranscriptionEnabled;
 
     /// <summary>
     /// Gets the current prompt synchronization status.
@@ -111,6 +117,15 @@ public class MenuStateManager : IMenuStateManager
     public void UpdateDictationStatus(bool enabled)
     {
         _dictationEnabled = enabled;
+        IncrementRevisionAndNotify();
+    }
+
+    /// <summary>
+    /// Updates the streaming transcription enabled status (fast path only).
+    /// </summary>
+    public void UpdateStreamingTranscriptionStatus(bool enabled)
+    {
+        _streamingTranscriptionEnabled = enabled;
         IncrementRevisionAndNotify();
     }
 

--- a/src/VirtualAssistant.Service/Tray/MenuEventDispatcher.cs
+++ b/src/VirtualAssistant.Service/Tray/MenuEventDispatcher.cs
@@ -247,4 +247,24 @@ public class MenuEventDispatcher : IMenuEventDispatcher
             _logger.LogError(ex, "Failed to toggle dictation");
         }
     }
+
+    /// <inheritdoc/>
+    public void HandleStreamingTranscriptionToggle(bool enabled)
+    {
+        try
+        {
+            if (_dictationControl == null)
+            {
+                _logger.LogWarning("Dictation control not available");
+                return;
+            }
+
+            _logger.LogInformation("Setting streaming transcription enabled: {Enabled}", enabled);
+            _dictationControl.SetStreamingTranscriptionEnabled(enabled);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to toggle streaming transcription");
+        }
+    }
 }

--- a/src/VirtualAssistant.Service/Tray/TrayCoordinatorService.cs
+++ b/src/VirtualAssistant.Service/Tray/TrayCoordinatorService.cs
@@ -88,6 +88,7 @@ public class TrayCoordinatorService : IDisposable
             handler.OnReloadPromptRequested += _menuDispatcher.HandleReloadPrompt;
             handler.OnDictationToggleRequested += _menuDispatcher.HandleDictationToggle;
             handler.OnMercuryBillingRequested += _menuDispatcher.HandleMercuryBilling;
+            handler.OnStreamingTranscriptionToggled += _menuDispatcher.HandleStreamingTranscriptionToggle;
 
             _logger.LogDebug("Menu handler events wired up successfully");
         }

--- a/src/VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs
@@ -30,6 +30,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
     private readonly Action<bool> _dictationToggleHandler;
     private readonly Action<bool> _ttsMuteToggleHandler;
     private readonly Action _mercuryBillingHandler;
+    private readonly Action<bool> _streamingTranscriptionHandler;
 
     /// <summary>
     /// Event fired when user selects Quit from the menu.
@@ -72,6 +73,11 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
     public event Action<bool>? OnTtsMuteToggleRequested;
 
     /// <summary>
+    /// Event fired when user toggles streaming transcription on/off.
+    /// </summary>
+    public event Action<bool>? OnStreamingTranscriptionToggled;
+
+    /// <summary>
     /// Event fired when user selects Mercury Billing menu item.
     /// </summary>
     public event Action? OnMercuryBillingRequested;
@@ -103,6 +109,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
         _dictationToggleHandler = (enabled) => OnDictationToggleRequested?.Invoke(enabled);
         _ttsMuteToggleHandler = (muted) => OnTtsMuteToggleRequested?.Invoke(muted);
         _mercuryBillingHandler = () => OnMercuryBillingRequested?.Invoke();
+        _streamingTranscriptionHandler = (enabled) => OnStreamingTranscriptionToggled?.Invoke(enabled);
 
         // Subscribe to state changes to emit layout updates
         _stateManager.StateChanged += OnStateChanged;
@@ -117,6 +124,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
         _eventRouter.OnDictationToggleRequested += _dictationToggleHandler;
         _eventRouter.OnTtsMuteToggleRequested += _ttsMuteToggleHandler;
         _eventRouter.OnMercuryBillingRequested += _mercuryBillingHandler;
+        _eventRouter.OnStreamingTranscriptionToggled += _streamingTranscriptionHandler;
     }
 
     public override Connection Connection => _connection ?? throw new InvalidOperationException("Connection not set. Call RegisterWithDbus first.");
@@ -326,6 +334,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
         _eventRouter.OnDictationToggleRequested -= _dictationToggleHandler;
         _eventRouter.OnTtsMuteToggleRequested -= _ttsMuteToggleHandler;
         _eventRouter.OnMercuryBillingRequested -= _mercuryBillingHandler;
+        _eventRouter.OnStreamingTranscriptionToggled -= _streamingTranscriptionHandler;
     }
 
     protected override ValueTask<bool> OnAboutToShowAsync(Message request, int id)

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -35,6 +35,14 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private CancellationTokenSource? _transcriptionCts;
     private bool _dictationEnabled = true;
     private bool _quickDictationMode;
+    private volatile bool _streamingTranscriptionEnabled;
+
+    // Streaming chunk transcription state — populated during Recording when streaming is on.
+    // On Stop (quick mode): assembled into the final raw text. On Stop (slow mode): discarded.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<int, string> _streamChunkResults = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<int, Task> _streamChunkTasks = new();
+    private CancellationTokenSource? _streamChunksCts;
+    private bool _streamingActiveForSession;  // frozen snapshot at StartRecording time
 
     /// <inheritdoc/>
     public DictationState State => _stateMachine.CurrentState;
@@ -85,6 +93,15 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _logger.LogInformation("Dictation disabled while active - performing emergency stop");
             Task.Run(async () => await EmergencyStopAsync());
         }
+    }
+
+    /// <summary>
+    /// Enables or disables streaming (chunked) transcription for the fast dictation path.
+    /// </summary>
+    public void SetStreamingTranscriptionEnabled(bool enabled)
+    {
+        _streamingTranscriptionEnabled = enabled;
+        _logger.LogInformation("Streaming transcription {Status}", enabled ? "enabled" : "disabled");
     }
 
     /// <inheritdoc/>
@@ -169,6 +186,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             TranscriptionCompleted += OnTranscriptionCompletedBroadcast;
             _transcriptionService.RawTranscriptionReady += OnRawTranscriptionReadyBroadcast;
 
+            // Subscribe to streaming chunk emissions — transcribes each chunk in background
+            _recordingCoordinator.ChunkAvailable += OnChunkAvailable;
+
             // Wait for cancellation
             await Task.Delay(Timeout.Infinite, stoppingToken);
         }
@@ -187,6 +207,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _stateMachine.StateChanged -= OnStateChangedBroadcast;
             TranscriptionCompleted -= OnTranscriptionCompletedBroadcast;
             _transcriptionService.RawTranscriptionReady -= OnRawTranscriptionReadyBroadcast;
+            _recordingCoordinator.ChunkAvailable -= OnChunkAvailable;
 
             // Stop recording if active
             if (_stateMachine.CurrentState == DictationState.Recording)
@@ -293,6 +314,81 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _ = BroadcastDictationEventAsync(DictationEventType.RawTranscriptionCompleted, text);
     }
 
+    /// <summary>
+    /// Handles a streaming audio chunk by launching a background Whisper call.
+    /// Results are keyed by chunk index in <see cref="_streamChunkResults"/> and assembled
+    /// in order on Stop when quick-mode streaming finalizes. Ignored if streaming is not
+    /// active for this session or if the chunk arrived outside Recording state.
+    /// </summary>
+    private void OnChunkAvailable(object? sender, AudioChunkEventArgs e)
+    {
+        if (!_streamingActiveForSession) return;
+        if (_streamChunksCts == null || _streamChunksCts.IsCancellationRequested) return;
+
+        var ct = _streamChunksCts.Token;
+        var task = Task.Run(async () =>
+        {
+            try
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                var text = await _transcriptionService.TranscribeChunkRawAsync(e.PcmBytes, ct);
+                sw.Stop();
+                _streamChunkResults[e.Index] = text ?? string.Empty;
+                _logger.LogInformation(
+                    "Streaming chunk {Index} transcribed in {ElapsedMs}ms: '{Preview}'",
+                    e.Index,
+                    sw.ElapsedMilliseconds,
+                    (text ?? string.Empty).Length > 60 ? (text ?? string.Empty)[..60] + "…" : text);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Streaming chunk {Index} canceled", e.Index);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Streaming chunk {Index} transcription failed", e.Index);
+                _streamChunkResults[e.Index] = string.Empty;
+            }
+        }, ct);
+
+        _streamChunkTasks[e.Index] = task;
+    }
+
+    /// <summary>
+    /// Awaits pending chunk transcription tasks and concatenates their ordered results.
+    /// Returns null if no chunks were produced (streaming not active or no audio).
+    /// </summary>
+    private async Task<string?> CombineStreamingChunksAsync(CancellationToken cancellationToken)
+    {
+        if (!_streamingActiveForSession) return null;
+
+        // Wait for all background chunk transcriptions to complete.
+        var pending = _streamChunkTasks.Values.ToArray();
+        if (pending.Length == 0)
+        {
+            _logger.LogInformation("CombineStreamingChunks: no chunks produced");
+            return null;
+        }
+
+        try
+        {
+            await Task.WhenAll(pending).WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "One or more streaming chunk tasks faulted; proceeding with available results");
+        }
+
+        var ordered = _streamChunkResults
+            .OrderBy(kvp => kvp.Key)
+            .Select(kvp => kvp.Value?.Trim() ?? string.Empty)
+            .Where(t => t.Length > 0);
+
+        var combined = string.Join(" ", ordered);
+        return System.Text.RegularExpressions.Regex.Replace(combined, @"\s+", " ").Trim();
+    }
+
     private async Task BroadcastDictationEventAsync(DictationEventType eventType, string? text)
     {
         try
@@ -315,6 +411,24 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         {
             // Transition to Recording state
             _stateMachine.TransitionTo(DictationState.Recording);
+
+            // Freeze streaming choice for this session — toggles mid-recording have no effect
+            _streamingActiveForSession = _streamingTranscriptionEnabled;
+            _streamChunkResults.Clear();
+            _streamChunkTasks.Clear();
+            _streamChunksCts?.Dispose();
+            _streamChunksCts = null;
+
+            if (_streamingActiveForSession)
+            {
+                _streamChunksCts = new CancellationTokenSource();
+                _recordingCoordinator.EnableChunking(TimeSpan.FromSeconds(8));
+                _logger.LogInformation("Streaming transcription active for this session (8s chunks)");
+            }
+            else
+            {
+                _recordingCoordinator.DisableChunking();
+            }
 
             // Start audio recording via coordinator
             await _recordingCoordinator.StartRecordingAsync();
@@ -393,7 +507,26 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         {
             _transcriptionCts?.Dispose();
             _transcriptionCts = null;
+            ResetStreamingSessionState();
         }
+    }
+
+    /// <summary>
+    /// Clears streaming chunk state after a dictation session completes (any path).
+    /// </summary>
+    private void ResetStreamingSessionState()
+    {
+        try
+        {
+            _streamChunksCts?.Cancel();
+            _streamChunksCts?.Dispose();
+        }
+        catch { /* best effort */ }
+        _streamChunksCts = null;
+        _streamChunkResults.Clear();
+        _streamChunkTasks.Clear();
+        _streamingActiveForSession = false;
+        _recordingCoordinator.DisableChunking();
     }
 
     /// <summary>
@@ -419,14 +552,35 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
     /// <summary>
     /// Transcribes audio using raw STT only (no LLM correction) with typing sound effect.
-    /// Used for quick dictation mode.
+    /// Used for quick dictation mode. When streaming was active for this session,
+    /// assembles the cached chunk transcriptions instead of running Whisper on the full buffer.
     /// </summary>
     private async Task<TranscriptionResult?> TranscribeRawWithSoundAsync(byte[] audioData)
     {
         _typingSound.StartLoop();
         _transcriptionCts = new CancellationTokenSource();
 
-        var result = await _transcriptionService.TranscribeRawAsync(audioData, _transcriptionCts.Token);
+        TranscriptionResult result;
+        if (_streamingActiveForSession)
+        {
+            var combined = await CombineStreamingChunksAsync(_transcriptionCts.Token);
+            if (string.IsNullOrWhiteSpace(combined))
+            {
+                _logger.LogWarning("Streaming quick transcription produced empty text; falling back to full-buffer Whisper");
+                result = await _transcriptionService.TranscribeRawAsync(audioData, _transcriptionCts.Token);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Streaming quick transcription: combined {Count} chunks into {Length} chars",
+                    _streamChunkResults.Count, combined.Length);
+                result = await _transcriptionService.FinalizePreTranscribedRawAsync(combined, _transcriptionCts.Token);
+            }
+        }
+        else
+        {
+            result = await _transcriptionService.TranscribeRawAsync(audioData, _transcriptionCts.Token);
+        }
 
         if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
         {
@@ -575,6 +729,10 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         {
             _logger.LogError(ex, "Error during emergency stop");
             _stateMachine.TransitionTo(DictationState.Idle);
+        }
+        finally
+        {
+            ResetStreamingSessionState();
         }
     }
 

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -160,6 +160,17 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _logger.LogInformation(
                 "StopDictationAsync(quickMode={QuickMode}) - overriding start-time mode",
                 quickMode);
+
+            // If user picked slow mode but streaming was pre-transcribing chunks,
+            // cancel those background tasks — they'd be discarded anyway, no point
+            // burning GPU/serializing the Whisper semaphore for them.
+            if (!quickMode && _streamingActiveForSession)
+            {
+                try { _streamChunksCts?.Cancel(); } catch { /* best effort */ }
+                _recordingCoordinator.DisableChunking();
+                _logger.LogInformation("Slow-mode override: canceled pending streaming chunk transcriptions");
+            }
+
             _ = Task.Run(async () => await StopAndTranscribeAsync());
         }
 
@@ -752,6 +763,10 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _transcriptionCts?.Cancel();
             _transcriptionCts?.Dispose();
             _transcriptionCts = null;
+
+            // Cancel in-flight streaming chunk tasks and clear chunk state,
+            // otherwise they keep running into the next session.
+            ResetStreamingSessionState();
 
             // Return to Idle
             _stateMachine.TransitionTo(DictationState.Idle);

--- a/src/VirtualAssistant.Voice/Audio/AudioRecordingCoordinator.cs
+++ b/src/VirtualAssistant.Voice/Audio/AudioRecordingCoordinator.cs
@@ -27,6 +27,13 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
     private readonly object _startLock = new();
     private bool _disposed;
 
+    // Streaming chunk emission state
+    private volatile bool _chunkingEnabled;
+    private TimeSpan _chunkInterval = TimeSpan.FromSeconds(8);
+    private int _lastChunkCursor;      // byte index in _audioBuffer where last chunk ended
+    private int _nextChunkIndex;       // ordinal for next emitted chunk
+    private DateTime _lastChunkEmit;   // last emit timestamp
+
     public AudioRecordingCoordinator(
         ILogger<AudioRecordingCoordinator> logger,
         IAudioCaptureService audioCapture,
@@ -42,6 +49,24 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
     public bool IsRecording => _recordingTask != null;
 
     /// <inheritdoc />
+    public event EventHandler<AudioChunkEventArgs>? ChunkAvailable;
+
+    /// <inheritdoc />
+    public void EnableChunking(TimeSpan interval)
+    {
+        _chunkInterval = interval < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : interval;
+        _chunkingEnabled = true;
+        _logger.LogInformation("Chunk emission enabled with interval {Interval}s", _chunkInterval.TotalSeconds);
+    }
+
+    /// <inheritdoc />
+    public void DisableChunking()
+    {
+        _chunkingEnabled = false;
+        _logger.LogInformation("Chunk emission disabled");
+    }
+
+    /// <inheritdoc />
     public async Task StartRecordingAsync(CancellationToken cancellationToken = default)
     {
         // Use lock to prevent concurrent start operations (fixes race condition)
@@ -55,10 +80,13 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
 
             try
             {
-                // Clear audio buffer
+                // Clear audio buffer and reset chunking cursor
                 lock (_bufferLock)
                 {
                     _audioBuffer.Clear();
+                    _lastChunkCursor = 0;
+                    _nextChunkIndex = 0;
+                    _lastChunkEmit = DateTime.UtcNow;
                 }
 
                 // Create cancellation token for recording
@@ -123,6 +151,10 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
 
             // Stop audio capture
             _audioCapture.Stop();
+
+            // Emit final chunk (tail since last emit) before clearing buffer.
+            // No-op when chunking disabled or no pending bytes.
+            TryEmitFinalChunk();
 
             // Get recorded audio
             byte[] audioData;
@@ -227,6 +259,8 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
                     }
 
                     _logger.LogDebug("Audio chunk captured: {Bytes} bytes (total: {Total})", chunk.Length, totalBytes);
+
+                    TryEmitChunk();
                 }
             }
         }
@@ -237,6 +271,75 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error capturing audio");
+        }
+    }
+
+    /// <summary>
+    /// Emits a chunk if chunking is enabled, the interval has elapsed, and there is
+    /// audio data past the last emit cursor.
+    /// </summary>
+    private void TryEmitChunk()
+    {
+        if (!_chunkingEnabled) return;
+
+        byte[]? chunkBytes = null;
+        int chunkIndex = 0;
+
+        lock (_bufferLock)
+        {
+            if (DateTime.UtcNow - _lastChunkEmit < _chunkInterval) return;
+            var pendingBytes = _audioBuffer.Count - _lastChunkCursor;
+            if (pendingBytes <= 0) return;
+
+            chunkBytes = new byte[pendingBytes];
+            _audioBuffer.CopyTo(_lastChunkCursor, chunkBytes, 0, pendingBytes);
+            _lastChunkCursor = _audioBuffer.Count;
+            chunkIndex = _nextChunkIndex++;
+            _lastChunkEmit = DateTime.UtcNow;
+        }
+
+        try
+        {
+            ChunkAvailable?.Invoke(this, new AudioChunkEventArgs(chunkIndex, chunkBytes));
+            _logger.LogDebug("Emitted audio chunk {Index}: {Bytes} bytes", chunkIndex, chunkBytes.Length);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error invoking ChunkAvailable handler for chunk {Index}", chunkIndex);
+        }
+    }
+
+    /// <summary>
+    /// Called from stop paths to drain the last pending bytes as a final chunk before
+    /// returning the full buffer to the caller. Only emits if chunking is enabled and
+    /// there's remaining audio past the last chunk cursor.
+    /// </summary>
+    private void TryEmitFinalChunk()
+    {
+        if (!_chunkingEnabled) return;
+
+        byte[]? tailBytes = null;
+        int chunkIndex = 0;
+
+        lock (_bufferLock)
+        {
+            var pendingBytes = _audioBuffer.Count - _lastChunkCursor;
+            if (pendingBytes <= 0) return;
+
+            tailBytes = new byte[pendingBytes];
+            _audioBuffer.CopyTo(_lastChunkCursor, tailBytes, 0, pendingBytes);
+            _lastChunkCursor = _audioBuffer.Count;
+            chunkIndex = _nextChunkIndex++;
+        }
+
+        try
+        {
+            ChunkAvailable?.Invoke(this, new AudioChunkEventArgs(chunkIndex, tailBytes));
+            _logger.LogDebug("Emitted final audio chunk {Index}: {Bytes} bytes", chunkIndex, tailBytes.Length);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error invoking ChunkAvailable handler for final chunk {Index}", chunkIndex);
         }
     }
 

--- a/src/VirtualAssistant.Voice/Audio/AudioRecordingCoordinator.cs
+++ b/src/VirtualAssistant.Voice/Audio/AudioRecordingCoordinator.cs
@@ -54,15 +54,22 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
     /// <inheritdoc />
     public void EnableChunking(TimeSpan interval)
     {
-        _chunkInterval = interval < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : interval;
-        _chunkingEnabled = true;
-        _logger.LogInformation("Chunk emission enabled with interval {Interval}s", _chunkInterval.TotalSeconds);
+        var normalizedInterval = interval < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : interval;
+        lock (_bufferLock)
+        {
+            _chunkInterval = normalizedInterval;
+            _chunkingEnabled = true;
+        }
+        _logger.LogInformation("Chunk emission enabled with interval {Interval}s", normalizedInterval.TotalSeconds);
     }
 
     /// <inheritdoc />
     public void DisableChunking()
     {
-        _chunkingEnabled = false;
+        lock (_bufferLock)
+        {
+            _chunkingEnabled = false;
+        }
         _logger.LogInformation("Chunk emission disabled");
     }
 
@@ -280,13 +287,12 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
     /// </summary>
     private void TryEmitChunk()
     {
-        if (!_chunkingEnabled) return;
-
         byte[]? chunkBytes = null;
         int chunkIndex = 0;
 
         lock (_bufferLock)
         {
+            if (!_chunkingEnabled) return;
             if (DateTime.UtcNow - _lastChunkEmit < _chunkInterval) return;
             var pendingBytes = _audioBuffer.Count - _lastChunkCursor;
             if (pendingBytes <= 0) return;
@@ -316,13 +322,12 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
     /// </summary>
     private void TryEmitFinalChunk()
     {
-        if (!_chunkingEnabled) return;
-
         byte[]? tailBytes = null;
         int chunkIndex = 0;
 
         lock (_bufferLock)
         {
+            if (!_chunkingEnabled) return;
             var pendingBytes = _audioBuffer.Count - _lastChunkCursor;
             if (pendingBytes <= 0) return;
 

--- a/src/VirtualAssistant.Voice/Services/ITranscriptionService.cs
+++ b/src/VirtualAssistant.Voice/Services/ITranscriptionService.cs
@@ -35,4 +35,23 @@ public interface ITranscriptionService : IDisposable
     /// <param name="cancellationToken">Cancellation token to abort transcription.</param>
     /// <returns>Transcription result with raw STT text.</returns>
     Task<TranscriptionResult> TranscribeRawAsync(byte[] audioData, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finalizes a pre-transcribed raw text (produced externally, e.g. by combining
+    /// streaming chunk transcriptions) by emitting RawTranscriptionReady and applying
+    /// the lightweight filter, without running Whisper again.
+    /// </summary>
+    /// <param name="rawText">Concatenated raw STT text from chunk transcriptions.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Filtered transcription result equivalent to the tail of TranscribeRawAsync.</returns>
+    Task<TranscriptionResult> FinalizePreTranscribedRawAsync(string rawText, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs Whisper on a single audio chunk and returns the raw text, bypassing
+    /// events and filters. Used by the streaming transcription path in DictationWorker.
+    /// </summary>
+    /// <param name="audioData">16-bit PCM audio at 16kHz.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Raw Whisper output for this chunk; empty string on failure.</returns>
+    Task<string> TranscribeChunkRawAsync(byte[] audioData, CancellationToken cancellationToken = default);
 }

--- a/src/VirtualAssistant.Voice/Services/TranscriptionService.cs
+++ b/src/VirtualAssistant.Voice/Services/TranscriptionService.cs
@@ -280,6 +280,67 @@ public class TranscriptionService : ITranscriptionService
         };
     }
 
+    /// <inheritdoc/>
+    public Task<TranscriptionResult> FinalizePreTranscribedRawAsync(string rawText, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(rawText))
+        {
+            return Task.FromResult(new TranscriptionResult("Empty pre-transcribed text"));
+        }
+
+        try
+        {
+            RawTranscriptionReady?.Invoke(rawText);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "RawTranscriptionReady handler failed (streaming finalize)");
+        }
+
+        var filteredText = _lightweightTextFilter?.Apply(rawText) ?? rawText;
+
+        if (string.IsNullOrWhiteSpace(filteredText))
+        {
+            _logger.LogInformation(
+                "FinalizePreTranscribedRawAsync: text wiped by lightweight filter (hallucination): '{Original}'",
+                rawText);
+            return Task.FromResult(new TranscriptionResult(string.Empty, 1.0f)
+            {
+                OriginalText = rawText,
+                FilteredText = string.Empty
+            });
+        }
+
+        return Task.FromResult(new TranscriptionResult(filteredText, 1.0f)
+        {
+            OriginalText = rawText,
+            FilteredText = filteredText
+        });
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> TranscribeChunkRawAsync(byte[] audioData, CancellationToken cancellationToken = default)
+    {
+        if (audioData == null || audioData.Length == 0) return string.Empty;
+        try
+        {
+            var safeAudio = TruncateIfTooLarge(audioData);
+            var result = await _transcriber.TranscribeAsync(safeAudio, cancellationToken);
+            return result.Success ? result.Text ?? string.Empty : string.Empty;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "TranscribeChunkRawAsync failed for chunk of {Bytes} bytes", audioData.Length);
+            return string.Empty;
+        }
+    }
+
     /// <summary>
     /// Truncates audio data if it exceeds the maximum segment size.
     /// Takes the last MaxSegmentBytes to preserve the most recent speech.

--- a/src/VirtualAssistant.Voice/Services/TranscriptionService.cs
+++ b/src/VirtualAssistant.Voice/Services/TranscriptionService.cs
@@ -301,19 +301,22 @@ public class TranscriptionService : ITranscriptionService
 
         var filteredText = _lightweightTextFilter?.Apply(rawText) ?? rawText;
 
+        // Confidence 0.0f is a sentinel for "unknown" — this path has no per-chunk
+        // confidence data to aggregate, so we don't claim high confidence like a
+        // single Whisper pass would return.
         if (string.IsNullOrWhiteSpace(filteredText))
         {
             _logger.LogInformation(
                 "FinalizePreTranscribedRawAsync: text wiped by lightweight filter (hallucination): '{Original}'",
                 rawText);
-            return Task.FromResult(new TranscriptionResult(string.Empty, 1.0f)
+            return Task.FromResult(new TranscriptionResult(string.Empty, 0.0f)
             {
                 OriginalText = rawText,
                 FilteredText = string.Empty
             });
         }
 
-        return Task.FromResult(new TranscriptionResult(filteredText, 1.0f)
+        return Task.FromResult(new TranscriptionResult(filteredText, 0.0f)
         {
             OriginalText = rawText,
             FilteredText = filteredText
@@ -324,10 +327,22 @@ public class TranscriptionService : ITranscriptionService
     public async Task<string> TranscribeChunkRawAsync(byte[] audioData, CancellationToken cancellationToken = default)
     {
         if (audioData == null || audioData.Length == 0) return string.Empty;
+
+        // Do NOT use TruncateIfTooLarge here — it keeps the LAST bytes, which would
+        // drop the beginning of an individual chunk (already-spoken content) during
+        // streaming transcription. Chunks are normally small (a few seconds); if one
+        // ever exceeds the limit we log and skip rather than silently losing audio.
+        if (audioData.Length > _options.MaxSegmentBytes)
+        {
+            _logger.LogWarning(
+                "TranscribeChunkRawAsync: chunk too large ({Size} > {Max} bytes), skipping to avoid losing start of chunk",
+                audioData.Length, _options.MaxSegmentBytes);
+            return string.Empty;
+        }
+
         try
         {
-            var safeAudio = TruncateIfTooLarge(audioData);
-            var result = await _transcriber.TranscribeAsync(safeAudio, cancellationToken);
+            var result = await _transcriber.TranscribeAsync(audioData, cancellationToken);
             return result.Success ? result.Text ?? string.Empty : string.Empty;
         }
         catch (OperationCanceledException)


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
Experimental streaming transcription for the fast dictation path.

- New tray menu toggle: **"Streaming transkripce - Zapnout/Vypnout"** (in-memory, not persisted)
- When enabled + dictation Recording, audio is sliced every 8s and each chunk is transcribed via Whisper in a background task
- On Stop in **quick mode**: cached chunk texts are concatenated and passed through the lightweight text filter (same as existing `TranscribeRawAsync` tail). No full-buffer Whisper pass
- On Stop in **slow mode** (with LLM correction): chunk cache is discarded, existing flow runs (full Whisper + LLM)
- Whisper model access is already serialized inside `WhisperSpeechTranscriber` (per-model semaphore), so chunk jobs execute one at a time against the shared model

## Architecture
- `IAudioRecordingCoordinator.ChunkAvailable` event + `EnableChunking(TimeSpan)` / `DisableChunking()`
- `ITranscriptionService.TranscribeChunkRawAsync(byte[])` — bare Whisper, no events, no filter
- `ITranscriptionService.FinalizePreTranscribedRawAsync(string)` — post-Whisper tail (event + lightweight filter) for streaming finalize
- `DictationWorker` subscribes to chunks in `ExecuteAsync`, freezes streaming choice at StartRecording, combines chunks on TranscribeRawWithSoundAsync

## Tradeoffs
- Loss of cross-chunk Whisper context → punctuation boundaries may differ
- Fixed-interval chunking may split a word; acceptable for MVP
- Some wasted GPU cycles if user ends up picking slow mode
- Estimated saving for 20s prompt with 3 chunks: ~2–3s end-to-end

Closes #944

## Test plan
- [ ] Toggle appears in tray menu and flips label ✅/❌
- [ ] With toggle ON + keyboard ScrollLock (slow path): unchanged behavior
- [ ] With toggle ON + Remote quick button (fast path): chunks cached, final text assembled quickly on Stop
- [ ] With toggle OFF + quick button: unchanged (full Whisper on Stop)
- [ ] Emergency cancel during recording: chunk tasks canceled, state cleaned
- [ ] All unit tests pass (587)

🤖 Generated with [Claude Code](https://claude.com/claude-code)