### PR TITLE
feat: cancel button during recording on Remote Control

### DIFF
--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -751,7 +751,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     {
         try
         {
-            _logger.LogInformation("Canceling transcription");
+            var currentState = _stateMachine.CurrentState;
+            _logger.LogInformation("CancelTranscription called in state {State}", currentState);
 
             // Stop typing sound immediately
             _typingSound.StopLoop();
@@ -759,7 +760,14 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // Play cancel sound (paper-rip effect)
             _cancelSound.Play();
 
-            // Cancel transcription
+            // If still recording, stop audio capture and discard buffer
+            if (currentState == DictationState.Recording)
+            {
+                _logger.LogInformation("Canceling active recording (emergency stop)");
+                _ = _recordingCoordinator.EmergencyStopAsync();
+            }
+
+            // Cancel transcription if in progress
             _transcriptionCts?.Cancel();
             _transcriptionCts?.Dispose();
             _transcriptionCts = null;
@@ -771,7 +779,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // Return to Idle
             _stateMachine.TransitionTo(DictationState.Idle);
 
-            _logger.LogInformation("Transcription canceled");
+            _logger.LogInformation("Dictation canceled from state {State}", currentState);
         }
         catch (Exception ex)
         {

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -760,11 +760,13 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // Play cancel sound (paper-rip effect)
             _cancelSound.Play();
 
-            // If still recording, stop audio capture and discard buffer
+            // If still recording, stop audio capture and discard buffer.
+            // Must complete before resetting streaming state so no more
+            // chunk events arrive after the reset.
             if (currentState == DictationState.Recording)
             {
                 _logger.LogInformation("Canceling active recording (emergency stop)");
-                _ = _recordingCoordinator.EmergencyStopAsync();
+                _recordingCoordinator.EmergencyStopAsync().GetAwaiter().GetResult();
             }
 
             // Cancel transcription if in progress

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -165,6 +165,10 @@
             background: linear-gradient(135deg, #f44336 0%, #d32f2f 100%);
         }
 
+        .btn-enter.cancel-mode:hover:not(:disabled) {
+            background: linear-gradient(135deg, #e53935 0%, #c62828 100%);
+        }
+
         .btn-enter:hover:not(:disabled) {
             background: linear-gradient(135deg, #45a049 0%, #3d9142 100%);
         }

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -161,6 +161,10 @@
             font-size: 1.3rem;
         }
 
+        .btn-enter.cancel-mode {
+            background: linear-gradient(135deg, #f44336 0%, #d32f2f 100%);
+        }
+
         .btn-enter:hover:not(:disabled) {
             background: linear-gradient(135deg, #45a049 0%, #3d9142 100%);
         }
@@ -428,8 +432,8 @@
             </div>
 
             <button class="btn btn-enter" id="btnEnter" disabled>
-                <span class="icon">&#x21B5;</span>
-                Enter
+                <span class="icon" id="enterIcon">&#x21B5;</span>
+                <span id="enterText">Enter</span>
             </button>
 
             <button class="btn btn-clear" id="btnClear" disabled>
@@ -490,7 +494,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=25"></script>
+    <script src="remote.js?v=26"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,7 +4,7 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v25';
+const SCRIPT_VERSION = 'v26';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),
@@ -14,6 +14,8 @@ const elements = {
     btnZoneFast: document.getElementById('btnZoneFast'),
     btnZoneSlow: document.getElementById('btnZoneSlow'),
     btnEnter: document.getElementById('btnEnter'),
+    enterIcon: document.getElementById('enterIcon'),
+    enterText: document.getElementById('enterText'),
     btnClear: document.getElementById('btnClear'),
     dictateIcon: document.getElementById('dictateIcon'),
     dictateText: document.getElementById('dictateText'),
@@ -221,6 +223,11 @@ function setRecordingState(recording, transcribing) {
         // ("Rychle" / "Pomalu") stay visible during recording.
         elements.recordTimer.textContent = '00:00';
         startDurationTimer();
+
+        // Swap Enter → Zrušit during recording
+        elements.btnEnter.classList.add('cancel-mode');
+        elements.enterIcon.textContent = '\u2715';
+        elements.enterText.textContent = 'Zrušit';
     } else if (transcribing) {
         // Recording stopped, transcription in progress. Hide the two zones,
         // show the single button in transcribing (yellow) state. The user
@@ -234,6 +241,7 @@ function setRecordingState(recording, transcribing) {
         elements.btnZoneSlow.disabled = true;
         elements.recordTimer.textContent = '';
         stopDurationTimer();
+        restoreEnterButton();
     } else {
         // Idle: single button, default label.
         elements.controls.classList.remove('recording');
@@ -245,7 +253,14 @@ function setRecordingState(recording, transcribing) {
         elements.btnZoneSlow.disabled = true;
         elements.recordTimer.textContent = '';
         stopDurationTimer();
+        restoreEnterButton();
     }
+}
+
+function restoreEnterButton() {
+    elements.btnEnter.classList.remove('cancel-mode');
+    elements.enterIcon.textContent = '\u21B5';
+    elements.enterText.textContent = 'Enter';
 }
 
 function setTranscriptionText(text) {
@@ -577,9 +592,14 @@ elements.btnZoneSlow.addEventListener('click', () => {
 elements.btnEnter.addEventListener('click', async () => {
     try {
         elements.btnEnter.disabled = true;
-        await connection.invoke('PressEnter');
+        if (isRecording) {
+            // Cancel recording — discard audio
+            await connection.invoke('CancelTranscription');
+        } else {
+            await connection.invoke('PressEnter');
+        }
     } catch (error) {
-        console.error('Enter failed:', error);
+        console.error('Enter/Cancel failed:', error);
     } finally {
         elements.btnEnter.disabled = false;
     }

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v26';
+const CACHE_NAME = 'va-dictation-v27';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
- During recording, Enter button becomes red "Zrušit" (Cancel)
- Clicking cancels recording (emergency stop, audio discarded)
- Button reverts to green "Enter" when recording ends
- CancelTranscription now handles both Recording and Transcribing states

Closes #946

## Test plan
- [ ] Start recording → Enter shows "Zrušit" in red
- [ ] Tap Zrušit → recording stops, audio discarded, returns to idle
- [ ] Stop recording normally → button reverts to green "Enter"
- [ ] Enter still works normally when not recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)