### PR TITLE
fix: green Rychle/Pomalu buttons, red Zrušit only

### DIFF
--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -130,19 +130,19 @@
         }
 
         .btn-zone-fast {
-            background: linear-gradient(135deg, #f44336 0%, #d32f2f 100%);
+            background: linear-gradient(135deg, #4caf50 0%, #45a049 100%);
         }
 
         .btn-zone-fast:hover:not(:disabled) {
-            background: linear-gradient(135deg, #d32f2f 0%, #c62828 100%);
+            background: linear-gradient(135deg, #45a049 0%, #3d9142 100%);
         }
 
         .btn-zone-slow {
-            background: linear-gradient(135deg, #d32f2f 0%, #b71c1c 100%);
+            background: linear-gradient(135deg, #388e3c 0%, #2e7d32 100%);
         }
 
         .btn-zone-slow:hover:not(:disabled) {
-            background: linear-gradient(135deg, #b71c1c 0%, #a01919 100%);
+            background: linear-gradient(135deg, #2e7d32 0%, #1b5e20 100%);
         }
 
         /* Show the two zones (and hide the single button) while recording. */

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v27';
+const CACHE_NAME = 'va-dictation-v28';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
- Change Rychle/Pomalu zone buttons from red to green (action = green)
- Only Zrušit stays red (cancel = red)
- Clearer visual distinction during recording

## Test plan
- [ ] During recording: Rychle/Pomalu green, Zrušit red

🤖 Generated with [Claude Code](https://claude.com/claude-code)