### PR TITLE
feat: add Paste from Clipboard button to Remote Control

### DIFF
--- a/src/VirtualAssistant.Core/Keyboard/IKeyboardSimulationService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/IKeyboardSimulationService.cs
@@ -31,4 +31,10 @@ public interface IKeyboardSimulationService
     /// Used for quick dictation where latency matters more than clipboard preservation.
     /// </summary>
     Task<bool> FastPasteAsync(string text, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends the correct paste shortcut (Ctrl+V for GUI, Ctrl+Shift+V for terminal)
+    /// to paste from the system clipboard into the active window.
+    /// </summary>
+    Task PasteFromClipboardAsync(CancellationToken cancellationToken = default);
 }

--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -353,6 +353,14 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
         }
     }
 
+    /// <inheritdoc/>
+    public async Task PasteFromClipboardAsync(CancellationToken cancellationToken = default)
+    {
+        var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
+        _logger.LogInformation("PasteFromClipboard: sending {Shortcut}", pasteShortcut);
+        await SendKeyAsync(pasteShortcut, cancellationToken);
+    }
+
     private static void TryKillProcess(Process? process)
     {
         if (process == null) return;

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -195,6 +195,23 @@ public class DictationHub : Hub
     }
 
     /// <summary>
+    /// Pastes from the system clipboard using the correct shortcut for the active window.
+    /// Terminal apps use Ctrl+Shift+V, GUI apps use Ctrl+V.
+    /// </summary>
+    public async Task PasteFromClipboard()
+    {
+        _logger.LogInformation("PasteFromClipboard called from client {ConnectionId}", Context.ConnectionId);
+        try
+        {
+            var isTerminal = await _terminalDetector.IsTerminalActiveAsync();
+            var pasteKey = isTerminal ? "ctrl+shift+v" : "ctrl+v";
+            _logger.LogInformation("PasteFromClipboard: {Key} (terminal={IsTerminal})", pasteKey, isTerminal);
+            await _keyboardSimulation.SendKeyAsync(pasteKey);
+        }
+        catch (Exception ex) { _logger.LogError(ex, "PasteFromClipboard failed"); }
+    }
+
+    /// <summary>
     /// Pastes the given text at the current cursor position using clipboard + paste simulation.
     /// </summary>
     public async Task<bool> PasteTranscription(string text)

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -196,18 +196,13 @@ public class DictationHub : Hub
 
     /// <summary>
     /// Pastes from the system clipboard using the correct shortcut for the active window.
-    /// Terminal apps use Ctrl+Shift+V, GUI apps use Ctrl+V.
+    /// Delegates to IKeyboardSimulationService.PasteFromClipboardAsync which centrally
+    /// handles terminal (Ctrl+Shift+V) vs GUI (Ctrl+V) detection.
     /// </summary>
     public async Task PasteFromClipboard()
     {
         _logger.LogInformation("PasteFromClipboard called from client {ConnectionId}", Context.ConnectionId);
-        try
-        {
-            var isTerminal = await _terminalDetector.IsTerminalActiveAsync();
-            var pasteKey = isTerminal ? "ctrl+shift+v" : "ctrl+v";
-            _logger.LogInformation("PasteFromClipboard: {Key} (terminal={IsTerminal})", pasteKey, isTerminal);
-            await _keyboardSimulation.SendKeyAsync(pasteKey);
-        }
+        try { await _keyboardSimulation.PasteFromClipboardAsync(); }
         catch (Exception ex) { _logger.LogError(ex, "PasteFromClipboard failed"); }
     }
 

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -173,6 +173,18 @@
             background: linear-gradient(135deg, #45a049 0%, #3d9142 100%);
         }
 
+        .btn-clipboard-paste {
+            background: linear-gradient(135deg, #5c6bc0 0%, #3f51b5 100%);
+            color: white;
+            padding: 15px 40px;
+            font-size: 1rem;
+            margin-bottom: 12px;
+        }
+
+        .btn-clipboard-paste:hover:not(:disabled) {
+            background: linear-gradient(135deg, #3f51b5 0%, #303f9f 100%);
+        }
+
         .btn-clear {
             background: linear-gradient(135deg, #ff9800 0%, #f57c00 100%);
             color: white;
@@ -459,6 +471,11 @@
             </div>
         </div>
 
+        <button class="btn btn-clipboard-paste" id="btnClipboardPaste" disabled>
+            <span class="icon">&#x1F4CB;</span>
+            Vložit ze schránky
+        </button>
+
         <div class="app-launchers">
             <button class="btn-app" id="btnDiscord" disabled>
                 <svg viewBox="0 -28.5 256 256" xmlns="http://www.w3.org/2000/svg" fill="white">
@@ -498,7 +515,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=26"></script>
+    <script src="remote.js?v=27"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,7 +4,7 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v26';
+const SCRIPT_VERSION = 'v27';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),
@@ -24,6 +24,7 @@ const elements = {
     recordTimer: document.getElementById('recordTimer'),
     transcriptionText: document.getElementById('transcriptionText'),
     btnPaste: document.getElementById('btnPaste'),
+    btnClipboardPaste: document.getElementById('btnClipboardPaste'),
     btnDiscord: document.getElementById('btnDiscord'),
     btnFerdium: document.getElementById('btnFerdium'),
     workspaceButtons: {
@@ -184,6 +185,7 @@ function setConnectionStatus(connected) {
     elements.btnDictate.disabled = !connected;
     elements.btnEnter.disabled = !connected;
     elements.btnClear.disabled = !connected;
+    elements.btnClipboardPaste.disabled = !connected;
     elements.btnDiscord.disabled = !connected;
     elements.btnFerdium.disabled = !connected;
     elements.btnPaste.disabled = !connected || !lastTranscription;
@@ -631,6 +633,24 @@ elements.btnPaste.addEventListener('click', async () => {
         console.error('Paste failed:', error);
     } finally {
         elements.btnPaste.disabled = false;
+    }
+});
+
+// Clipboard paste handler
+elements.btnClipboardPaste.addEventListener('pointerdown', () => {
+    if (elements.btnClipboardPaste.disabled) return;
+    if ('vibrate' in navigator) navigator.vibrate(50);
+});
+
+elements.btnClipboardPaste.addEventListener('click', async () => {
+    if (connection?.state !== signalR.HubConnectionState.Connected) return;
+    try {
+        elements.btnClipboardPaste.disabled = true;
+        await connection.invoke('PasteFromClipboard');
+    } catch (error) {
+        console.error('PasteFromClipboard failed:', error);
+    } finally {
+        elements.btnClipboardPaste.disabled = false;
     }
 });
 

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -185,7 +185,7 @@ function setConnectionStatus(connected) {
     elements.btnDictate.disabled = !connected;
     elements.btnEnter.disabled = !connected;
     elements.btnClear.disabled = !connected;
-    elements.btnClipboardPaste.disabled = !connected;
+    if (elements.btnClipboardPaste) elements.btnClipboardPaste.disabled = !connected;
     elements.btnDiscord.disabled = !connected;
     elements.btnFerdium.disabled = !connected;
     elements.btnPaste.disabled = !connected || !lastTranscription;
@@ -636,23 +636,25 @@ elements.btnPaste.addEventListener('click', async () => {
     }
 });
 
-// Clipboard paste handler
-elements.btnClipboardPaste.addEventListener('pointerdown', () => {
-    if (elements.btnClipboardPaste.disabled) return;
-    if ('vibrate' in navigator) navigator.vibrate(50);
-});
+// Clipboard paste handler (guarded for stale HTML without the button)
+if (elements.btnClipboardPaste) {
+    elements.btnClipboardPaste.addEventListener('pointerdown', () => {
+        if (elements.btnClipboardPaste.disabled) return;
+        if ('vibrate' in navigator) navigator.vibrate(50);
+    });
 
-elements.btnClipboardPaste.addEventListener('click', async () => {
-    if (connection?.state !== signalR.HubConnectionState.Connected) return;
-    try {
-        elements.btnClipboardPaste.disabled = true;
-        await connection.invoke('PasteFromClipboard');
-    } catch (error) {
-        console.error('PasteFromClipboard failed:', error);
-    } finally {
-        elements.btnClipboardPaste.disabled = false;
-    }
-});
+    elements.btnClipboardPaste.addEventListener('click', async () => {
+        if (connection?.state !== signalR.HubConnectionState.Connected) return;
+        try {
+            elements.btnClipboardPaste.disabled = true;
+            await connection.invoke('PasteFromClipboard');
+        } catch (error) {
+            console.error('PasteFromClipboard failed:', error);
+        } finally {
+            elements.btnClipboardPaste.disabled = false;
+        }
+    });
+}
 
 // App launcher haptic feedback
 elements.btnDiscord.addEventListener('pointerdown', () => {

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v28';
+const CACHE_NAME = 'va-dictation-v29';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
- New "Vložit ze schránky" button between workspace buttons and Discord/Ferdium
- Detects terminal vs GUI via ITerminalDetector
- Sends Ctrl+Shift+V for terminal, Ctrl+V for GUI — one button, correct shortcut
- Indigo color to distinguish from other action buttons

## Test plan
- [ ] Button visible on remote.html
- [ ] Click in terminal app → Ctrl+Shift+V sent
- [ ] Click in GUI app → Ctrl+V sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)