### PR TITLE
feat: add Insert Screenshot button to Remote Control

### DIFF
--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -206,6 +206,60 @@ public class DictationHub : Hub
         catch (Exception ex) { _logger.LogError(ex, "PasteFromClipboard failed"); }
     }
 
+    private static readonly string ScreenshotDir =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Obrázky", "Snímky obrazovky");
+
+    private const string InsertScreenshotScript = "/home/jirka/.local/bin/insert-screenshot-path";
+
+    /// <summary>
+    /// Checks if a recent screenshot (&lt;5 min) exists in the screenshot directory.
+    /// </summary>
+    public Task<bool> IsScreenshotAvailable()
+    {
+        try
+        {
+            if (!Directory.Exists(ScreenshotDir)) return Task.FromResult(false);
+
+            var cutoff = DateTime.Now.AddMinutes(-5);
+            var hasRecent = Directory.EnumerateFiles(ScreenshotDir, "*.png")
+                .Select(f => new FileInfo(f))
+                .Any(fi => fi.LastWriteTime > cutoff);
+
+            return Task.FromResult(hasRecent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "IsScreenshotAvailable check failed");
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <summary>
+    /// Runs the insert-screenshot-path script which finds the most recent screenshot,
+    /// puts its path in the clipboard, and simulates Ctrl+Shift+V to paste into terminal.
+    /// </summary>
+    public async Task InsertScreenshotPath()
+    {
+        _logger.LogInformation("InsertScreenshotPath called from client {ConnectionId}", Context.ConnectionId);
+        try
+        {
+            using var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "/bin/bash",
+                    Arguments = InsertScreenshotScript,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            await process.WaitForExitAsync();
+            _logger.LogInformation("InsertScreenshotPath completed with exit code {ExitCode}", process.ExitCode);
+        }
+        catch (Exception ex) { _logger.LogError(ex, "InsertScreenshotPath failed"); }
+    }
+
     /// <summary>
     /// Pastes the given text at the current cursor position using clipboard + paste simulation.
     /// </summary>

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -249,13 +249,29 @@ public class DictationHub : Hub
                 {
                     FileName = "/bin/bash",
                     Arguments = InsertScreenshotScript,
+                    RedirectStandardError = true,
                     UseShellExecute = false,
                     CreateNoWindow = true
                 }
             };
             process.Start();
-            await process.WaitForExitAsync();
-            _logger.LogInformation("InsertScreenshotPath completed with exit code {ExitCode}", process.ExitCode);
+
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await process.WaitForExitAsync(timeoutCts.Token);
+
+            if (process.ExitCode != 0)
+            {
+                var stderr = await process.StandardError.ReadToEndAsync();
+                _logger.LogWarning("InsertScreenshotPath exit code {ExitCode}: {Stderr}", process.ExitCode, stderr);
+            }
+            else
+            {
+                _logger.LogInformation("InsertScreenshotPath completed successfully");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogError("InsertScreenshotPath timed out after 5s");
         }
         catch (Exception ex) { _logger.LogError(ex, "InsertScreenshotPath failed"); }
     }

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -173,16 +173,28 @@
             background: linear-gradient(135deg, #45a049 0%, #3d9142 100%);
         }
 
-        .btn-clipboard-paste {
-            background: linear-gradient(135deg, #5c6bc0 0%, #3f51b5 100%);
-            color: white;
-            padding: 15px 40px;
-            font-size: 1rem;
+        .paste-buttons {
+            display: flex;
+            gap: 10px;
             margin-bottom: 12px;
         }
 
-        .btn-clipboard-paste:hover:not(:disabled) {
+        .btn-clipboard-paste,
+        .btn-screenshot-paste {
+            background: linear-gradient(135deg, #5c6bc0 0%, #3f51b5 100%);
+            color: white;
+            padding: 15px 20px;
+            font-size: 0.9rem;
+            flex: 1;
+        }
+
+        .btn-clipboard-paste:hover:not(:disabled),
+        .btn-screenshot-paste:hover:not(:disabled) {
             background: linear-gradient(135deg, #3f51b5 0%, #303f9f 100%);
+        }
+
+        .btn-screenshot-paste.hidden {
+            display: none;
         }
 
         .btn-clear {
@@ -471,10 +483,16 @@
             </div>
         </div>
 
-        <button class="btn btn-clipboard-paste" id="btnClipboardPaste" disabled>
-            <span class="icon">&#x1F4CB;</span>
-            Vložit ze schránky
-        </button>
+        <div class="paste-buttons">
+            <button class="btn btn-clipboard-paste" id="btnClipboardPaste" disabled>
+                <span class="icon">&#x1F4CB;</span>
+                Vložit ze schránky
+            </button>
+            <button class="btn btn-screenshot-paste hidden" id="btnScreenshotPaste" disabled>
+                <span class="icon">&#x1F4F7;</span>
+                Vložit obrázek
+            </button>
+        </div>
 
         <div class="app-launchers">
             <button class="btn-app" id="btnDiscord" disabled>
@@ -515,7 +533,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=27"></script>
+    <script src="remote.js?v=28"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,7 +4,7 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v27';
+const SCRIPT_VERSION = 'v28';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),
@@ -25,6 +25,7 @@ const elements = {
     transcriptionText: document.getElementById('transcriptionText'),
     btnPaste: document.getElementById('btnPaste'),
     btnClipboardPaste: document.getElementById('btnClipboardPaste'),
+    btnScreenshotPaste: document.getElementById('btnScreenshotPaste'),
     btnDiscord: document.getElementById('btnDiscord'),
     btnFerdium: document.getElementById('btnFerdium'),
     workspaceButtons: {
@@ -349,6 +350,8 @@ async function refreshStatus() {
 
         const wsInfo = await connection.invoke('GetWorkspaceInfo');
         handleWorkspaceChanged(wsInfo.currentWorkspace, wsInfo.totalWorkspaces);
+
+        await checkScreenshotAvailability();
     } catch (error) {
         console.error('Failed to get status:', error);
     }
@@ -635,6 +638,46 @@ elements.btnPaste.addEventListener('click', async () => {
         elements.btnPaste.disabled = false;
     }
 });
+
+// Screenshot availability check
+async function checkScreenshotAvailability() {
+    if (!elements.btnScreenshotPaste) return;
+    try {
+        if (connection?.state !== signalR.HubConnectionState.Connected) return;
+        const available = await connection.invoke('IsScreenshotAvailable');
+        if (available) {
+            elements.btnScreenshotPaste.classList.remove('hidden');
+            elements.btnScreenshotPaste.disabled = false;
+        } else {
+            elements.btnScreenshotPaste.classList.add('hidden');
+        }
+    } catch (error) {
+        console.error('Screenshot check failed:', error);
+    }
+}
+
+// Poll screenshot availability every 15s
+setInterval(checkScreenshotAvailability, 15000);
+
+// Screenshot paste handler
+if (elements.btnScreenshotPaste) {
+    elements.btnScreenshotPaste.addEventListener('pointerdown', () => {
+        if (elements.btnScreenshotPaste.disabled) return;
+        if ('vibrate' in navigator) navigator.vibrate(50);
+    });
+
+    elements.btnScreenshotPaste.addEventListener('click', async () => {
+        if (connection?.state !== signalR.HubConnectionState.Connected) return;
+        try {
+            elements.btnScreenshotPaste.disabled = true;
+            await connection.invoke('InsertScreenshotPath');
+        } catch (error) {
+            console.error('InsertScreenshotPath failed:', error);
+        } finally {
+            elements.btnScreenshotPaste.disabled = false;
+        }
+    });
+}
 
 // Clipboard paste handler (guarded for stale HTML without the button)
 if (elements.btnClipboardPaste) {

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -187,6 +187,12 @@ function setConnectionStatus(connected) {
     elements.btnEnter.disabled = !connected;
     elements.btnClear.disabled = !connected;
     if (elements.btnClipboardPaste) elements.btnClipboardPaste.disabled = !connected;
+    if (elements.btnScreenshotPaste) {
+        if (!connected) {
+            elements.btnScreenshotPaste.classList.add('hidden');
+            elements.btnScreenshotPaste.disabled = true;
+        }
+    }
     elements.btnDiscord.disabled = !connected;
     elements.btnFerdium.disabled = !connected;
     elements.btnPaste.disabled = !connected || !lastTranscription;
@@ -650,6 +656,7 @@ async function checkScreenshotAvailability() {
             elements.btnScreenshotPaste.disabled = false;
         } else {
             elements.btnScreenshotPaste.classList.add('hidden');
+            elements.btnScreenshotPaste.disabled = true;
         }
     } catch (error) {
         console.error('Screenshot check failed:', error);

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v29';
+const CACHE_NAME = 'va-dictation-v30';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
- New "Vložit obrázek" button next to "Vložit ze schránky" in paste buttons row
- **Only visible** when a screenshot <5 min old exists in screenshot directory
- Runs existing `insert-screenshot-path` script (saves path to clipboard + Ctrl+Shift+V)
- Frontend polls `IsScreenshotAvailable()` every 15s for dynamic show/hide

## Test plan
- [ ] No recent screenshot → button hidden
- [ ] Take screenshot → within 15s button appears
- [ ] Click button → screenshot path pasted into terminal
- [ ] After 5 min → button hides automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)