### PR TITLE
feat: instant screenshot button via FileSystemWatcher

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -156,6 +156,9 @@ public static class WorkerServicesExtensions
         // Desktop Monitor broadcasting (SignalR hub updates)
         services.AddHostedService<DesktopMonitorBroadcastWorker>();
 
+        // Screenshot watcher (instant SignalR broadcast when new screenshot appears)
+        services.AddHostedService<ScreenshotWatcherWorker>();
+
         return services;
     }
 }

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -206,8 +206,7 @@ public class DictationHub : Hub
         catch (Exception ex) { _logger.LogError(ex, "PasteFromClipboard failed"); }
     }
 
-    private static readonly string ScreenshotDir =
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Obrázky", "Snímky obrazovky");
+    private static string ScreenshotDir => Workers.ScreenshotWatcherWorker.ScreenshotDir;
 
     private const string InsertScreenshotScript = "/home/jirka/.local/bin/insert-screenshot-path";
 
@@ -220,7 +219,7 @@ public class DictationHub : Hub
         {
             if (!Directory.Exists(ScreenshotDir)) return Task.FromResult(false);
 
-            var cutoff = DateTime.Now.AddMinutes(-5);
+            var cutoff = DateTime.Now - Workers.ScreenshotWatcherWorker.FreshnessWindow;
             var hasRecent = Directory.EnumerateFiles(ScreenshotDir, "*.png")
                 .Select(f => new FileInfo(f))
                 .Any(fi => fi.LastWriteTime > cutoff);

--- a/src/VirtualAssistant.Service/Workers/ScreenshotWatcherWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/ScreenshotWatcherWorker.cs
@@ -9,15 +9,22 @@ namespace Olbrasoft.VirtualAssistant.Service.Workers;
 /// </summary>
 public class ScreenshotWatcherWorker : BackgroundService
 {
-    private static readonly string ScreenshotDir =
+    /// <summary>
+    /// Shared screenshot directory path — used by both this worker and DictationHub.
+    /// </summary>
+    public static readonly string ScreenshotDir =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Obrázky", "Snímky obrazovky");
 
-    private static readonly TimeSpan FreshnessWindow = TimeSpan.FromMinutes(5);
+    /// <summary>
+    /// Shared freshness window — screenshots older than this are considered expired.
+    /// </summary>
+    public static readonly TimeSpan FreshnessWindow = TimeSpan.FromMinutes(5);
 
     private readonly ILogger<ScreenshotWatcherWorker> _logger;
     private readonly IHubContext<DictationHub> _hubContext;
     private FileSystemWatcher? _watcher;
     private bool _lastBroadcastState;
+    private DateTime _latestScreenshotTime = DateTime.MinValue;
 
     public ScreenshotWatcherWorker(
         ILogger<ScreenshotWatcherWorker> logger,
@@ -44,10 +51,15 @@ public class ScreenshotWatcherWorker : BackgroundService
         _watcher.Created += (_, e) =>
         {
             _logger.LogInformation("New screenshot detected: {File}", e.Name);
+            _latestScreenshotTime = DateTime.Now;
             _ = BroadcastAvailabilityAsync(true);
         };
 
         _logger.LogInformation("Screenshot watcher started on {Dir}", ScreenshotDir);
+
+        // Broadcast initial state immediately so clients don't wait 30s
+        var initialState = HasRecentScreenshot();
+        await BroadcastAvailabilityAsync(initialState);
 
         // Periodic check for expiry (every 30s)
         while (!stoppingToken.IsCancellationRequested)
@@ -55,7 +67,19 @@ public class ScreenshotWatcherWorker : BackgroundService
             try
             {
                 await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
-                var available = HasRecentScreenshot();
+
+                // Fast path: if we know the latest screenshot time from watcher events,
+                // just check that timestamp instead of scanning the directory.
+                bool available;
+                if (_latestScreenshotTime > DateTime.MinValue)
+                {
+                    available = (DateTime.Now - _latestScreenshotTime) < FreshnessWindow;
+                }
+                else
+                {
+                    available = HasRecentScreenshot();
+                }
+
                 if (available != _lastBroadcastState)
                 {
                     await BroadcastAvailabilityAsync(available);
@@ -74,7 +98,11 @@ public class ScreenshotWatcherWorker : BackgroundService
                 .Select(f => new FileInfo(f))
                 .Any(fi => fi.LastWriteTime > cutoff);
         }
-        catch { return false; }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Error checking recent screenshots in {Dir}", ScreenshotDir);
+            return false;
+        }
     }
 
     private async Task BroadcastAvailabilityAsync(bool available)

--- a/src/VirtualAssistant.Service/Workers/ScreenshotWatcherWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/ScreenshotWatcherWorker.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.SignalR;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers;
+
+/// <summary>
+/// Watches the GNOME screenshot directory for new .png files and broadcasts
+/// availability changes to Remote Control clients via DictationHub SignalR.
+/// </summary>
+public class ScreenshotWatcherWorker : BackgroundService
+{
+    private static readonly string ScreenshotDir =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Obrázky", "Snímky obrazovky");
+
+    private static readonly TimeSpan FreshnessWindow = TimeSpan.FromMinutes(5);
+
+    private readonly ILogger<ScreenshotWatcherWorker> _logger;
+    private readonly IHubContext<DictationHub> _hubContext;
+    private FileSystemWatcher? _watcher;
+    private bool _lastBroadcastState;
+
+    public ScreenshotWatcherWorker(
+        ILogger<ScreenshotWatcherWorker> logger,
+        IHubContext<DictationHub> hubContext)
+    {
+        _logger = logger;
+        _hubContext = hubContext;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!Directory.Exists(ScreenshotDir))
+        {
+            _logger.LogWarning("Screenshot directory not found: {Dir}, watcher disabled", ScreenshotDir);
+            return;
+        }
+
+        _watcher = new FileSystemWatcher(ScreenshotDir, "*.png")
+        {
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.CreationTime,
+            EnableRaisingEvents = true
+        };
+
+        _watcher.Created += (_, e) =>
+        {
+            _logger.LogInformation("New screenshot detected: {File}", e.Name);
+            _ = BroadcastAvailabilityAsync(true);
+        };
+
+        _logger.LogInformation("Screenshot watcher started on {Dir}", ScreenshotDir);
+
+        // Periodic check for expiry (every 30s)
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+                var available = HasRecentScreenshot();
+                if (available != _lastBroadcastState)
+                {
+                    await BroadcastAvailabilityAsync(available);
+                }
+            }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    private bool HasRecentScreenshot()
+    {
+        try
+        {
+            var cutoff = DateTime.Now - FreshnessWindow;
+            return Directory.EnumerateFiles(ScreenshotDir, "*.png")
+                .Select(f => new FileInfo(f))
+                .Any(fi => fi.LastWriteTime > cutoff);
+        }
+        catch { return false; }
+    }
+
+    private async Task BroadcastAvailabilityAsync(bool available)
+    {
+        _lastBroadcastState = available;
+        try
+        {
+            await _hubContext.Clients.All.SendAsync("ScreenshotAvailable", available);
+            _logger.LogDebug("Broadcast ScreenshotAvailable={Available}", available);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to broadcast ScreenshotAvailable");
+        }
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _watcher?.Dispose();
+        return base.StopAsync(cancellationToken);
+    }
+}

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -533,7 +533,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=28"></script>
+    <script src="remote.js?v=29"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,7 +4,7 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v28';
+const SCRIPT_VERSION = 'v29';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),
@@ -129,6 +129,7 @@ function buildConnection() {
     connection.on('DictationEvent', handleDictationEvent);
     connection.on('AppFocusChanged', handleAppFocusChanged);
     connection.on('WorkspaceChanged', handleWorkspaceChanged);
+    connection.on('ScreenshotAvailable', handleScreenshotAvailable);
     connection.on('Connected', (connectionId) => {
         console.log('Connected with ID:', connectionId);
     });
@@ -645,26 +646,30 @@ elements.btnPaste.addEventListener('click', async () => {
     }
 });
 
-// Screenshot availability check
+// Screenshot availability — driven by ScreenshotWatcherWorker SignalR broadcast
+function handleScreenshotAvailable(available) {
+    if (!elements.btnScreenshotPaste) return;
+    console.log('ScreenshotAvailable:', available);
+    if (available) {
+        elements.btnScreenshotPaste.classList.remove('hidden');
+        elements.btnScreenshotPaste.disabled = false;
+    } else {
+        elements.btnScreenshotPaste.classList.add('hidden');
+        elements.btnScreenshotPaste.disabled = true;
+    }
+}
+
+// Initial check on connect (replaces polling)
 async function checkScreenshotAvailability() {
     if (!elements.btnScreenshotPaste) return;
     try {
         if (connection?.state !== signalR.HubConnectionState.Connected) return;
         const available = await connection.invoke('IsScreenshotAvailable');
-        if (available) {
-            elements.btnScreenshotPaste.classList.remove('hidden');
-            elements.btnScreenshotPaste.disabled = false;
-        } else {
-            elements.btnScreenshotPaste.classList.add('hidden');
-            elements.btnScreenshotPaste.disabled = true;
-        }
+        handleScreenshotAvailable(available);
     } catch (error) {
         console.error('Screenshot check failed:', error);
     }
 }
-
-// Poll screenshot availability every 15s
-setInterval(checkScreenshotAvailability, 15000);
 
 // Screenshot paste handler
 if (elements.btnScreenshotPaste) {

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v30';
+const CACHE_NAME = 'va-dictation-v31';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
- Replace 15s polling with FileSystemWatcher for instant screenshot detection
- New ScreenshotWatcherWorker watches ~/Obrázky/Snímky obrazovky/ for new .png files
- Broadcasts ScreenshotAvailable(bool) via SignalR immediately on new screenshot
- 30s periodic check for expiry (screenshots >5 min old)
- Button appears instantly after printscreen, hides when screenshot expires

## Test plan
- [ ] Take screenshot → button appears within 1-2s on phone
- [ ] Wait 5 min → button hides
- [ ] Click button → screenshot path pasted into terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)