### PR TITLE
fix: resolve TTS notification failure caused by shared DbContext in singleton repository

### DIFF
--- a/src/VirtualAssistant.Service/Infrastructure/TranscriptionCorrectionRepository.cs
+++ b/src/VirtualAssistant.Service/Infrastructure/TranscriptionCorrectionRepository.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Olbrasoft.Data.Cqrs;
 using Olbrasoft.VirtualAssistant.Data.Commands.TranscriptionCorrectionCommands;
 using Olbrasoft.VirtualAssistant.Data.Entities;
@@ -8,28 +9,30 @@ namespace Olbrasoft.VirtualAssistant.Service.Infrastructure;
 
 /// <summary>
 /// Repository implementation for accessing transcription corrections via CQRS.
+/// Uses IServiceScopeFactory to create a fresh DbContext scope per operation,
+/// making it safe for concurrent use from the transcription pipeline.
 /// </summary>
 public class TranscriptionCorrectionRepository : ITranscriptionCorrectionRepository
 {
-    private readonly IQueryProcessor _queryProcessor;
-    private readonly ICommandExecutor _commandExecutor;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<TranscriptionCorrectionRepository> _logger;
 
     public TranscriptionCorrectionRepository(
-        IQueryProcessor queryProcessor,
-        ICommandExecutor commandExecutor,
+        IServiceScopeFactory scopeFactory,
         ILogger<TranscriptionCorrectionRepository> logger)
     {
-        _queryProcessor = queryProcessor ?? throw new ArgumentNullException(nameof(queryProcessor));
-        _commandExecutor = commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<TranscriptionCorrection>> GetActiveCorrectionsAsync(CancellationToken ct = default)
     {
+        using var scope = _scopeFactory.CreateScope();
+        var queryProcessor = scope.ServiceProvider.GetRequiredService<IQueryProcessor>();
+
         var query = new GetActiveTranscriptionCorrectionsQuery();
-        return await _queryProcessor.ProcessAsync(query, ct);
+        return await queryProcessor.ProcessAsync(query, ct);
     }
 
     /// <inheritdoc />
@@ -37,8 +40,11 @@ public class TranscriptionCorrectionRepository : ITranscriptionCorrectionReposit
     {
         try
         {
+            using var scope = _scopeFactory.CreateScope();
+            var commandExecutor = scope.ServiceProvider.GetRequiredService<ICommandExecutor>();
+
             var command = new TrackCorrectionUsageCommand(CorrectionId: correctionId);
-            await _commandExecutor.ExecuteAsync(command, ct);
+            await commandExecutor.ExecuteAsync(command, ct);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary

- `TranscriptionCorrectionRepository` (Singleton) previously injected `IQueryProcessor` and `ICommandExecutor` (both Scoped), pinning a single root-scope `VirtualAssistantDbContext` for the lifetime of the process.
- Because `TrackCorrectionUsageAsync` runs concurrently from the transcription pipeline, multiple threads mutated the same (non-thread-safe) DbContext, corrupting its change tracker and eventually producing a duplicate-key conflict on `TranscriptionCorrectionUsage`.
- The exception surfaced later in `UpdateNotificationStatusBatchCommandHandler.SaveChangesAsync` during `DetectChanges`, causing every subsequent notification status update to fail — TTS never spoke queued notifications.
- Switched the repository to the `IServiceScopeFactory` pattern already used by `PromptResolver`: each call creates a fresh scope with its own DbContext, which is disposed when the call returns. Concurrent callers no longer share EF state.

## Observed symptom

```
fail: Error processing notification from claude-code
System.InvalidOperationException: The instance of entity type 'TranscriptionCorrectionUsage' cannot be tracked because another instance with the same key value for {'Id'} is already being tracked.
   at UpdateNotificationStatusBatchCommandHandler.GetResultToHandleAsync(...) line 28
   at NotificationService.UpdateStatusAsync(...) line 87
   at NotificationTracker.MarkAsProcessingAsync(...) line 27
   at NotificationBatchingService.ProcessSingleNotificationAsync(...) line 107
```

## Test plan

- [x] Build passes (`dotnet build src/VirtualAssistant.Service`)
- [x] Deployed to `/opt/olbrasoft/virtual-assistant` via deploy script
- [x] Sent test notification — completed full lifecycle: Created → Queued → Processing → TTS success (GoogleCloudMultiKey, 8400ms) → Played
- [x] No `Error processing notification` / `InvalidOperationException` entries in service logs after fix
- [ ] CI build + tests pass
- [ ] Copilot code review addressed

## Follow-up (not in this PR)

`NotificationBatchingService` (Singleton) still injects `INotificationTracker` (Scoped), which captures the same root-scope `VirtualAssistantDbContext` at startup. This fix addresses the immediate concurrency corruption via `TrackCorrectionUsage`, but the Notification tracker path should receive the same scope-factory treatment in a follow-up PR.