### PR TITLE
feat: add Pokračuj button to Remote Control for Claude Code

### DIFF
--- a/docs/paste-into-claude-code-issue.md
+++ b/docs/paste-into-claude-code-issue.md
@@ -1,0 +1,370 @@
+# Paste into Claude Code (inside tmux) — the recurring "No image found in clipboard" bug
+
+**Status:** Actively managed. A structural fix landed in PR #953 (2026-04-16)
+but the class of bugs this document describes keeps recurring, so any future
+regression should start here instead of from scratch.
+
+---
+
+## TL;DR
+
+Pasting text into a TUI agent (Claude Code is the worst offender, but OpenCode
+and Gemini CLI have the same shape) running **inside tmux** intermittently
+breaks:
+
+- The Remote Control's **"Vložit ze schránky"** button does nothing in Claude
+  Code, or pastes *something other* than what the user copied.
+- After a **dictation**, the wrong text lands in Claude Code — very often the
+  text from the **previous** dictation (the "off-by-one" symptom).
+- A red-on-black message appears in the bottom-right corner of the Claude Code
+  TUI: **`No image found in clipboard. Use ctrl+v to paste images.`**
+- A **service restart** makes the problem vanish for a while. It then
+  re-appears, usually after the user interacts with an image in the clipboard
+  (copying a screenshot, dragging an image, etc.).
+- We've "fixed" this at least half a dozen times. Each fix improves the happy
+  path but leaves at least one unhandled edge in the timing / selection / CopyQ
+  interaction that surfaces later.
+
+If you're reading this because it broke again — **do not just restart the
+service**. Follow the debug checklist near the bottom first.
+
+---
+
+## The moving parts that make this hard
+
+```
+ Remote Control (phone)           Virtual Assistant service
+ ──────────────                   ────────────────────────
+ Vložit ze schránky  ─────SignalR──►  DictationHub
+                                         │
+                                         ▼
+                                  XDoToolKeyboardService
+                                  .PasteFromClipboardAsync
+                                         │
+                      ┌──────────────────┼──────────────────┐
+                      ▼                                     ▼
+               IClipboardManager                       dotool (uinput)
+               wl-copy / wl-paste                    emits key event:
+                      │                              Shift+Insert  or
+                      │                              Ctrl+Shift+V  or
+                      │                              Ctrl+V
+                      ▼
+              GNOME Shell clipboard  ◄────────────────────┐
+              (Wayland ↔ XWayland)                        │
+                      │                                   │
+                      ▼                                   │
+                   CopyQ  ──auto-sync CLIPBOARD⇄PRIMARY──►┘
+                      │
+                      ▼
+                 terminator  (XWayland client)
+                      │
+                      ▼
+                  tmux server  (systemd daemon,
+                                NOT a child of terminator)
+                      │
+                      ▼
+                  tmux pane
+                      │
+                      ▼
+                 claude (TUI)   ← interprets Ctrl+V / Ctrl+Shift+V
+                                  itself as "paste image"
+```
+
+Every arrow is either async, a different process, or both. That's the setup
+that keeps biting us.
+
+---
+
+## Known-complicating factors
+
+1. **Claude Code intercepts `Ctrl+V` and `Ctrl+Shift+V`** as "paste image"
+   shortcuts. If the clipboard holds text (no `image/*` MIME), Claude Code
+   prints `No image found in clipboard. Use ctrl+v to paste images.` This is
+   the ground-truth symptom — if you see this message, it means our keystroke
+   was delivered to Claude Code instead of the terminal.
+
+2. **tmux detaches the CLI app from the terminal process tree.** The tmux
+   server runs under `systemd --user`, so `claude` inside a pane is NOT a
+   descendant of the focused terminal. Any detection that relies on `pgrep -P`
+   descending from the focused window's PID will miss it. Title-based
+   detection (the terminal title contains "Claude Code") is the only reliable
+   fallback.
+
+3. **Shift+Insert reads X11 `PRIMARY` selection, not `CLIPBOARD`.** This is the
+   traditional X11 middle-click paste buffer. It's a DIFFERENT selection from
+   `Ctrl+C`/`Ctrl+V`'s `CLIPBOARD`. Writing to one does not automatically put
+   text in the other.
+
+4. **CopyQ runs as a clipboard manager and auto-syncs `CLIPBOARD` ↔ `PRIMARY`
+   with asynchronous, non-deterministic delay.** This was the true cause of
+   the "off-by-one" symptom. If we set `CLIPBOARD = X` and immediately send
+   `Shift+Insert`, `PRIMARY` still holds whatever was there last cycle —
+   CopyQ hasn't finished the sync yet. The paste reads stale `PRIMARY`. Then
+   CopyQ eventually syncs `PRIMARY = X`, which is what the *next* cycle's
+   paste reads. Hence the user sees each dictation paste as "the one from
+   last time".
+
+5. **Wayland + XWayland split surfaces.** The user runs GNOME/Wayland, but
+   `terminator` is an XWayland client. GNOME Shell bridges `CLIPBOARD` across
+   Wayland and XWayland; `PRIMARY` is *also* bridged in modern GNOME, but
+   with extra latency.
+
+6. **The image path.** When the user copies a screenshot (image MIME) into
+   the clipboard, several things happen:
+   - CopyQ stores the image entry and (depending on settings) tries to
+     synthesize a preview.
+   - Any subsequent text write races the image entry.
+   - If our code happens to read the clipboard while it holds an image MIME,
+     `wl-paste --no-newline` without `-t` might return empty/garbage,
+     overwriting our "original" backup and making restore nondeterministic.
+   This is the most likely origin of the "it starts misbehaving after
+   I do something with an image" pattern the user keeps reporting.
+
+7. **dotool emits uinput events**, which go through the compositor. There is
+   NO synchronous acknowledgement that the target app has *read* the selection.
+   We insert fixed delays (100–300 ms); anything that moves slower than that
+   (tmux under load, remote tmux-attach, long Claude Code render frames)
+   re-opens the race.
+
+---
+
+## Symptom → likely cause map
+
+| Symptom | Most likely cause |
+| --- | --- |
+| "No image found in clipboard" shown by Claude Code | Our keystroke was `Ctrl+V` or `Ctrl+Shift+V`. Either `GetPasteShortcutAsync` didn't detect the CLI app, or the user is NOT in Claude Code but our detector thinks they are. |
+| Dictation pastes previous dictation's text ("off-by-one") | CopyQ CLIPBOARD↔PRIMARY sync is racing our write. We set `CLIPBOARD`, `Shift+Insert` read stale `PRIMARY`. Fixed by writing directly to `PRIMARY`. |
+| Paste does nothing at all (no error, no text) | (a) `PRIMARY` is genuinely empty and Shift+Insert had nothing to read; or (b) the restore step ran before the terminal read the selection. |
+| Wrong content pasted (something from much earlier) | Our `originalClipboard`/`originalPrimary` backup captured a stale or garbage value (image MIME, truncated UTF-8), then we "restored" that stale value before the terminal consumed our real text. |
+| Problem appears only after image interaction | We read the clipboard while it held an image MIME; `wl-paste --no-newline` returned something we then treated as `originalClipboard`, and the restore poisoned subsequent cycles. |
+| Restart "fixes" it, then it recurs | Not a real fix — just resets whatever stale state accumulated (CopyQ queue, long-running `wl-paste --watch` handle, tmux buffer, our in-process delays). The underlying race is still there. |
+
+---
+
+## History of attempted fixes (abridged)
+
+The root bug has been reshuffled many times. Each bullet is a fix that
+helped the common case but did not remove the class of bugs.
+
+1. Send `Ctrl+Shift+V` in terminals, `Ctrl+V` elsewhere. Broke the moment
+   `Ctrl+Shift+V` started being handled by Claude Code as "paste image".
+2. Detect CLI app via process tree (`pgrep -P` descend from focused terminal).
+   Worked for direct `claude` children; broke under tmux where the claude
+   process's parent is the tmux server, not the terminal.
+3. Add title-based detection fallback ("Claude Code" substring in window
+   title). Makes detection survive tmux but means *any* window titled
+   "Claude Code" triggers CLI handling — brittle.
+4. Switch to `Shift+Insert` for CLI apps. Bypasses Claude Code's
+   `Ctrl+*+V` handler. But `Shift+Insert` reads `PRIMARY`, not `CLIPBOARD`,
+   so we had to stage text in `PRIMARY` too — and CopyQ's auto-sync defeated
+   our initial attempt to do this via `CLIPBOARD`.
+5. Stage text directly in `PRIMARY` via `wl-copy --primary`, restore
+   `PRIMARY` after 300 ms. **This is the current state (PR #953).** It
+   covers the off-by-one and the `No image found` cases on the happy path.
+
+What is **not** covered:
+
+- Behaviour when the original clipboard holds an image MIME at the moment
+  we snapshot it for "restore".
+- Long tail on the 300 ms delay — on a slow tmux or a heavily loaded host
+  the terminal may not have consumed `PRIMARY` yet.
+- What happens if CopyQ is configured differently on the user's host (e.g.
+  "Store selection changes" ON vs OFF — currently unknown / not audited).
+- What happens if the focused window changes between the moment we detect
+  the CLI app and the moment dotool fires.
+
+---
+
+## Current implementation (PR #953)
+
+Entry point: `XDoToolKeyboardService` in
+`src/VirtualAssistant.Core/Keyboard/`.
+
+**`GetPasteShortcutAsync()`** returns:
+- `shift+insert` — if the CLI detector reports an active agent TUI. This is
+  both the process-tree detection AND the terminal title fallback.
+- `ctrl+shift+v` — if the focused window is any other terminal.
+- `ctrl+v` — for everything else (GUI apps).
+
+**`TypeIntoActiveWindowAsync(text)`** (dictation insert path):
+1. Resolve paste shortcut and `usePrimary = shortcut == "shift+insert"`.
+2. Snapshot the selection we are about to overwrite (`PRIMARY` if
+   `usePrimary`, else `CLIPBOARD`).
+3. Write `text + " "` to that selection.
+4. Sleep 50 ms.
+5. Fire `dotool key <shortcut>`.
+6. Sleep 300 ms — terminal / tmux / TUI must have read the selection by now.
+7. Restore the original selection.
+
+**`FastPasteAsync(text)`** (quick dictation): same as above but skips the
+snapshot/restore steps for latency. The user accepts that quick dictation
+leaves the text in the selection.
+
+**`PasteFromClipboardAsync()`** ("Vložit ze schránky" button):
+1. Resolve paste shortcut.
+2. If `shift+insert`, mirror `CLIPBOARD` → `PRIMARY` for the paste and
+   restore `PRIMARY` after 300 ms. **`CLIPBOARD` is never written or
+   restored on this path — the user's clipboard is left exactly as it was.**
+3. Otherwise just send the shortcut.
+
+---
+
+## Debug checklist when it breaks again
+
+**Before restarting the service**, collect:
+
+1. What does the focused window title say? Run
+   ```
+   gdbus call --session --dest org.gnome.Shell \
+     --object-path /org/gnome/Shell/Extensions/Windows \
+     --method org.gnome.Shell.Extensions.Windows.List
+   ```
+   Look for `"focus": true` and read the `title` field. Does it contain
+   "Claude Code"?
+
+2. What does VA detect? Hit
+   `http://localhost:5055/Admin/DesktopMonitor` and check `APP NAME`,
+   `CORRECTION PROMPT`. If they don't say `Claude Code` /
+   `ClaudeCodeCorrection`, the CLI detector is the bug.
+
+3. What does CopyQ have? Look in CopyQ's history for entries created AT the
+   moment of the failed paste. If the top entry is an `image/*` MIME
+   and the paste failed immediately after, you're in the image-poisoning
+   path (see "Known-complicating factors" #6).
+
+4. What did VA log? Tail the service and look for the paste shortcut line:
+   ```
+   journalctl --user -u virtual-assistant.service -f \
+     | grep -E "paste|PRIMARY|CLIPBOARD|CliApp"
+   ```
+   Key log lines:
+   - `Using paste shortcut: shift+insert (CLI app: Claude Code …)`
+     — correct detection.
+   - `Using paste shortcut: ctrl+shift+v (terminal: True)` while the user
+     is in Claude Code — detector missed it.
+   - `Set PRIMARY content (N chars)` followed by `Simulating paste with
+     shortcut: shift+insert` — our write landed.
+   - Any `wl-paste failed` / `wl-copy failed` — a clipboard tool crashed
+     or raced; inspect surrounding lines.
+
+5. What happens if the user pastes from keyboard manually (middle-click,
+   or `Shift+Insert` from the physical keyboard)? If manual paste works and
+   ours doesn't, it's timing/async; if manual paste *also* produces "No
+   image found", Claude Code itself has changed its key handling and our
+   Shift+Insert assumption no longer holds.
+
+6. What's in `PRIMARY` right before VA sends the paste? Add a temporary
+   diagnostic: in `XDoToolKeyboardService.PasteFromClipboardAsync`, log
+   `wl-paste --primary --no-newline` output before and after the write,
+   plus `wl-paste --list-types` to catch image MIME.
+
+7. Has Claude Code been updated? The `No image found in clipboard` message
+   is emitted by Claude Code itself. If the shortcut it reacts to has been
+   extended (e.g. it starts handling `Shift+Insert`), our whole strategy
+   needs to move to another escape — most likely tmux `load-buffer`+`paste-buffer`
+   injected into the target pane.
+
+---
+
+## Hypotheses still not ruled out
+
+1. **Image MIME poisoning of `originalClipboard`.** `IClipboardManager.GetClipboardAsync`
+   calls `wl-paste --no-newline` without a MIME filter. If the clipboard
+   holds an image, the returned bytes are whatever `wl-paste` prints for
+   images (often empty with a nonzero exit). We then treat that as the
+   "original" and restore it. This could leave the clipboard in a bad
+   state that survives across dictations until a restart clears it.
+   **Mitigation idea:** call `wl-paste --list-types` first; if the top
+   type is `image/*`, skip the save/restore and paste without touching
+   CLIPBOARD at all. (Not implemented.)
+
+2. **CopyQ synthesizing paste while we're writing.** CopyQ has a "paste
+   current clipboard into window on shortcut" feature. If any of its
+   global shortcuts overlaps with `Shift+Insert` for this user, our event
+   goes to CopyQ's handler, not the terminal. (Not verified — check
+   `~/.config/copyq/copyq.conf`.)
+
+3. **`dotool` firing before the target window has re-focused.** We resolve
+   the CLI app and the selection on one thread, then send the keystroke.
+   If the focused window changed in between, we paste into the wrong app.
+   A focus check immediately before `dotool key` would catch it.
+
+4. **`PRIMARY` already owned by another client that refuses to release it.**
+   Some X clients hold `PRIMARY` and respond to SetSelectionOwner slowly.
+   If terminator reads `PRIMARY` via XWayland while GNOME Shell is still
+   transferring ownership, terminator sees the old content.
+
+---
+
+## What to try next if PR #953 isn't enough
+
+In rough order of complexity:
+
+1. **Extend the post-paste delay to e.g. 500 ms** when the focused terminal
+   is running under tmux. Cheap to try; only affects latency.
+
+2. **Skip clipboard save/restore when an image MIME is present.** Guard
+   `GetClipboardAsync` / the worker's call site with a
+   `--list-types`-based check.
+
+3. **Target tmux directly.** When we detect "tmux is between us and
+   Claude Code", bypass the keyboard path entirely:
+   `tmux set-buffer -b __va_paste "<text>" && tmux paste-buffer -b __va_paste -t <pane>`.
+   Needs a way to identify which pane holds Claude Code (we already have
+   `tmux list-panes -a -F` working for diagnosis — wire it into detection).
+
+4. **Stop using the user's selections at all.** Pipe text directly to the
+   pane's pty via `tmux send-keys -l -t <pane> "<text>"`. This bypasses
+   every clipboard, every selection, every keybinding. Main risk: the
+   text is interpreted one char at a time, so Czech diacritics need the
+   `-l` (literal) flag, which tmux 2.6+ supports.
+
+5. **Write our own, minimal clipboard daemon** that pretends to be CopyQ
+   but gives us synchronous `CLIPBOARD` writes with no cross-selection
+   sync. High effort, last resort.
+
+---
+
+## Files involved
+
+- `src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs` — all
+  keyboard simulation, paste shortcut selection, clipboard save/restore.
+- `src/VirtualAssistant.Core/Clipboard/WlClipboardManager.cs` — `wl-copy` /
+  `wl-paste` wrapper, including `--primary` variants.
+- `src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs` —
+  process-tree + title-based detection of Claude Code / OpenCode / Gemini.
+- `src/VirtualAssistant.Service/Workers/DesktopMonitorBroadcastWorker.cs` —
+  broadcasts `CliAppChanged` to the Remote Control based on the same
+  detection flow.
+- `src/VirtualAssistant.Service/Hubs/DictationHub.cs` — SignalR entry
+  points: `PasteFromClipboard`, `PressEnter`, `SendContinue`,
+  `GetActiveCliApp`.
+
+## Related PRs
+
+- PR #953 — Pokračuj button + CliAppChanged broadcast + Shift+Insert paste
+  + PRIMARY-selection staging. *The current state.*
+
+---
+
+## Quick self-test (manual)
+
+With the service running and the user's Claude Code session focused in tmux
+under terminator:
+
+1. Copy any plain text on the desktop (`Ctrl+C`).
+2. Open the Remote Control on the phone. Confirm the **Pokračuj** button
+   is visible (confirms `CliAppChanged` is "Claude Code").
+3. Tap **Vložit ze schránky**.
+   - ✅ The copied text appears at the Claude Code prompt.
+   - ❌ If "No image found in clipboard" shows → the shortcut path
+     reverted to `Ctrl+Shift+V`. Jump to debug checklist.
+   - ❌ If something else pastes → PRIMARY raced. Jump to debug checklist.
+4. Re-dictate a fresh Czech sentence (e.g. "Příklad s háčky").
+   - ✅ Exactly that sentence lands in Claude Code.
+   - ❌ If *previous* sentence lands → off-by-one re-appeared. CopyQ sync
+     is fighting us; confirm write went to PRIMARY, not CLIPBOARD.
+5. After steps 3–4, check that the CLIPBOARD still holds the text from
+   step 1 (open CopyQ; the top entry should still be that text).
+6. Repeat steps 3–4 five times in a row to check for drift. The system
+   must not need a restart after those five iterations.

--- a/src/VirtualAssistant.Core/Clipboard/IClipboardManager.cs
+++ b/src/VirtualAssistant.Core/Clipboard/IClipboardManager.cs
@@ -18,4 +18,16 @@ public interface IClipboardManager
     /// <param name="content">Content to set in the clipboard.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task SetClipboardAsync(string content, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current X11/Wayland PRIMARY selection (the "mouse middle-click"
+    /// selection, read by Shift+Insert in most terminals).
+    /// </summary>
+    Task<string?> GetPrimarySelectionAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the X11/Wayland PRIMARY selection. Used when pasting into terminal
+    /// agents (e.g. Claude Code) via Shift+Insert, which reads PRIMARY, not CLIPBOARD.
+    /// </summary>
+    Task SetPrimarySelectionAsync(string content, CancellationToken cancellationToken = default);
 }

--- a/src/VirtualAssistant.Core/Clipboard/WlClipboardManager.cs
+++ b/src/VirtualAssistant.Core/Clipboard/WlClipboardManager.cs
@@ -16,7 +16,13 @@ public class WlClipboardManager : IClipboardManager
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<string?> GetClipboardAsync(CancellationToken cancellationToken = default)
+    public Task<string?> GetClipboardAsync(CancellationToken cancellationToken = default)
+        => ReadSelectionAsync(primary: false, cancellationToken);
+
+    public Task<string?> GetPrimarySelectionAsync(CancellationToken cancellationToken = default)
+        => ReadSelectionAsync(primary: true, cancellationToken);
+
+    private async Task<string?> ReadSelectionAsync(bool primary, CancellationToken cancellationToken)
     {
         try
         {
@@ -25,7 +31,7 @@ public class WlClipboardManager : IClipboardManager
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "wl-paste",
-                    Arguments = "--no-newline",
+                    Arguments = primary ? "--primary --no-newline" : "--no-newline",
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
@@ -39,22 +45,24 @@ public class WlClipboardManager : IClipboardManager
 
             if (process.ExitCode == 0)
             {
-                _logger.LogDebug("Retrieved clipboard content ({Length} chars)", content?.Length ?? 0);
+                _logger.LogDebug("Retrieved {Selection} content ({Length} chars)",
+                    primary ? "PRIMARY" : "clipboard", content?.Length ?? 0);
                 return content;
             }
 
             var error = await process.StandardError.ReadToEndAsync(cancellationToken);
-            _logger.LogDebug("wl-paste failed with exit code {ExitCode}: {Error}", process.ExitCode, error);
+            _logger.LogDebug("wl-paste {Selection} failed with exit code {ExitCode}: {Error}",
+                primary ? "--primary" : "", process.ExitCode, error);
             return null;
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogDebug("Could not get clipboard (invalid state): {Message}", ex.Message);
+            _logger.LogDebug("Could not get selection (invalid state): {Message}", ex.Message);
             return null;
         }
         catch (System.ComponentModel.Win32Exception ex)
         {
-            _logger.LogDebug("Could not get clipboard (process error): {Message}", ex.Message);
+            _logger.LogDebug("Could not get selection (process error): {Message}", ex.Message);
             return null;
         }
     }
@@ -67,7 +75,13 @@ public class WlClipboardManager : IClipboardManager
     /// <returns>A task that completes when the clipboard is set.</returns>
     /// <exception cref="ArgumentNullException">Thrown when content is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown when wl-copy process fails or cannot start.</exception>
-    public async Task SetClipboardAsync(string content, CancellationToken cancellationToken = default)
+    public Task SetClipboardAsync(string content, CancellationToken cancellationToken = default)
+        => WriteSelectionAsync(content, primary: false, cancellationToken);
+
+    public Task SetPrimarySelectionAsync(string content, CancellationToken cancellationToken = default)
+        => WriteSelectionAsync(content, primary: true, cancellationToken);
+
+    private async Task WriteSelectionAsync(string content, bool primary, CancellationToken cancellationToken)
     {
         if (content == null)
         {
@@ -81,6 +95,7 @@ public class WlClipboardManager : IClipboardManager
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "wl-copy",
+                    Arguments = primary ? "--primary" : "",
                     RedirectStandardInput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
@@ -96,11 +111,13 @@ public class WlClipboardManager : IClipboardManager
             if (process.ExitCode != 0)
             {
                 var error = await process.StandardError.ReadToEndAsync(cancellationToken);
-                _logger.LogError("wl-copy failed with exit code {ExitCode}: {Error}", process.ExitCode, error);
+                _logger.LogError("wl-copy {Selection} failed with exit code {ExitCode}: {Error}",
+                    primary ? "--primary" : "", process.ExitCode, error);
                 throw new InvalidOperationException($"wl-copy failed: {error}");
             }
 
-            _logger.LogDebug("Set clipboard content ({Length} chars)", content.Length);
+            _logger.LogDebug("Set {Selection} content ({Length} chars)",
+                primary ? "PRIMARY" : "clipboard", content.Length);
         }
         catch (InvalidOperationException)
         {

--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -31,6 +31,10 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
 
     /// <summary>
     /// Types text into the active window using clipboard + dotool paste.
+    /// For terminal CLI agents (Claude Code, OpenCode, Gemini) the text is
+    /// staged in the PRIMARY selection and pasted via Shift+Insert — these
+    /// TUIs hijack Ctrl+Shift+V as a "paste image" shortcut, so the
+    /// traditional X11 primary-paste route is the reliable one.
     /// </summary>
     public async Task<bool> TypeIntoActiveWindowAsync(string text, CancellationToken cancellationToken = default)
     {
@@ -49,19 +53,28 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             // Add space after text
             var textToType = text + " ";
 
-            // Step 1: Save current clipboard content
-            var originalClipboard = await _clipboardManager.GetClipboardAsync(cancellationToken);
+            var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
+            var usePrimary = pasteShortcut == "shift+insert";
 
-            // Step 2: Copy our text to clipboard
-            await _clipboardManager.SetClipboardAsync(textToType, cancellationToken);
+            // Step 1: Save current selection we are about to overwrite
+            string? originalClipboard = null;
+            string? originalPrimary = null;
+            if (usePrimary)
+            {
+                originalPrimary = await _clipboardManager.GetPrimarySelectionAsync(cancellationToken);
+                await _clipboardManager.SetPrimarySelectionAsync(textToType, cancellationToken);
+            }
+            else
+            {
+                originalClipboard = await _clipboardManager.GetClipboardAsync(cancellationToken);
+                await _clipboardManager.SetClipboardAsync(textToType, cancellationToken);
+            }
 
-            // Small delay to ensure clipboard is ready
+            // Small delay to ensure selection is ready before we trigger the paste
             await Task.Delay(50, cancellationToken);
 
-            // Step 3: Simulate paste using dotool (clipboard already contains our text)
-            // Note: dotool type doesn't support Czech diacritics properly, so we use paste simulation
-            var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
-            _logger.LogInformation("Simulating paste with shortcut: {Shortcut}", pasteShortcut);
+            _logger.LogInformation("Simulating paste with shortcut: {Shortcut} (selection: {Selection})",
+                pasteShortcut, usePrimary ? "PRIMARY" : "CLIPBOARD");
 
             var dotoolProcess = new Process
             {
@@ -104,21 +117,30 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
                 return false;
             }
 
-            // Small delay to ensure paste completed
-            await Task.Delay(100, cancellationToken);
+            // Wait long enough for the terminal/tmux/TUI chain to read the
+            // selection before we restore it. 100 ms was too short in tmux —
+            // the terminal paste handler had not yet read the PRIMARY by the
+            // time we wrote the original value back, so the user saw the old
+            // content pasted.
+            await Task.Delay(300, cancellationToken);
 
-            // Step 4: Restore original clipboard content
-            if (!string.IsNullOrEmpty(originalClipboard))
+            // Step 4: Restore the original selection we overwrote
+            try
             {
-                try
+                if (usePrimary && !string.IsNullOrEmpty(originalPrimary))
+                {
+                    await _clipboardManager.SetPrimarySelectionAsync(originalPrimary, cancellationToken);
+                    _logger.LogDebug("Restored original PRIMARY selection");
+                }
+                else if (!usePrimary && !string.IsNullOrEmpty(originalClipboard))
                 {
                     await _clipboardManager.SetClipboardAsync(originalClipboard, cancellationToken);
                     _logger.LogDebug("Restored original clipboard content");
                 }
-                catch (InvalidOperationException ex)
-                {
-                    _logger.LogWarning("Could not restore clipboard: {Message}", ex.Message);
-                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning("Could not restore selection: {Message}", ex.Message);
             }
 
             _logger.LogInformation("✅ Typed {Length} characters into active window", textToType.Length);
@@ -292,12 +314,17 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
 
         try
         {
-            // 1. Set clipboard (skip save/restore for speed)
-            await _clipboardManager.SetClipboardAsync(text, cancellationToken);
-            await Task.Delay(30, cancellationToken);
-
-            // 2. Detect paste shortcut and send via dotool
+            // 1. Detect paste shortcut first so we know which selection to write to
             var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
+            var usePrimary = pasteShortcut == "shift+insert";
+
+            // 2. Stage the text in the right selection (Shift+Insert reads PRIMARY)
+            if (usePrimary)
+                await _clipboardManager.SetPrimarySelectionAsync(text, cancellationToken);
+            else
+                await _clipboardManager.SetClipboardAsync(text, cancellationToken);
+
+            await Task.Delay(30, cancellationToken);
 
             dotoolProcess = new Process
             {
@@ -362,6 +389,39 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
     {
         var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
         _logger.LogInformation("PasteFromClipboard: sending {Shortcut}", pasteShortcut);
+
+        // Shift+Insert path (CLI agent TUIs) reads PRIMARY, not CLIPBOARD.
+        // The user clicked "Paste from clipboard" intending to paste the
+        // current CLIPBOARD content, so mirror CLIPBOARD → PRIMARY for the
+        // duration of the paste, then restore PRIMARY.
+        if (pasteShortcut == "shift+insert")
+        {
+            var clipboard = await _clipboardManager.GetClipboardAsync(cancellationToken);
+            if (string.IsNullOrEmpty(clipboard))
+            {
+                _logger.LogWarning("PasteFromClipboard: clipboard is empty, nothing to paste");
+                return;
+            }
+
+            var originalPrimary = await _clipboardManager.GetPrimarySelectionAsync(cancellationToken);
+            try
+            {
+                await _clipboardManager.SetPrimarySelectionAsync(clipboard, cancellationToken);
+                await Task.Delay(50, cancellationToken);
+                await SendKeyAsync(pasteShortcut, cancellationToken);
+                await Task.Delay(300, cancellationToken);
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(originalPrimary))
+                {
+                    try { await _clipboardManager.SetPrimarySelectionAsync(originalPrimary, cancellationToken); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Could not restore PRIMARY selection"); }
+                }
+            }
+            return;
+        }
+
         await SendKeyAsync(pasteShortcut, cancellationToken);
     }
 

--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -14,15 +14,18 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
 {
     private readonly IClipboardManager _clipboardManager;
     private readonly ITerminalDetector _terminalDetector;
+    private readonly ICliAppDetector _cliAppDetector;
     private readonly ILogger<XDoToolKeyboardService> _logger;
 
     public XDoToolKeyboardService(
         IClipboardManager clipboardManager,
         ITerminalDetector terminalDetector,
+        ICliAppDetector cliAppDetector,
         ILogger<XDoToolKeyboardService> logger)
     {
         _clipboardManager = clipboardManager ?? throw new ArgumentNullException(nameof(clipboardManager));
         _terminalDetector = terminalDetector ?? throw new ArgumentNullException(nameof(terminalDetector));
+        _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -135,7 +138,8 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
 
     private static readonly HashSet<string> AllowedKeys = new(StringComparer.OrdinalIgnoreCase)
     {
-        "enter", "ctrl+u", "ctrl+v", "ctrl+shift+v", "escape", "tab", "backspace", "delete", "alt+F4",
+        "enter", "ctrl+u", "ctrl+v", "ctrl+shift+v", "shift+insert",
+        "escape", "tab", "backspace", "delete", "alt+F4",
         "super+kp1", "super+kp2", "super+kp3", "super+kp4",
         "super+kp5", "super+kp6", "super+kp7", "super+kp8",
         "end", "ctrl+a"
@@ -372,11 +376,25 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
     }
 
     /// <summary>
-    /// Gets the appropriate paste shortcut based on the active window type.
-    /// Terminals use Ctrl+Shift+V, other applications use Ctrl+V.
+    /// Gets the appropriate paste shortcut based on the active window type:
+    /// - CLI apps running in a terminal (Claude Code, OpenCode, Gemini CLI) use Shift+Insert.
+    ///   These TUIs hijack Ctrl+Shift+V for their own purposes (Claude Code treats it as
+    ///   "paste image"), so we fall back to the traditional X11 paste binding which goes
+    ///   to the terminal first and is delivered to the app as bracketed paste.
+    /// - Other terminals use Ctrl+Shift+V (standard terminal paste).
+    /// - GUI apps use Ctrl+V.
     /// </summary>
     private async Task<string> GetPasteShortcutAsync(CancellationToken cancellationToken)
     {
+        var cliApp = await _cliAppDetector.DetectCliAppAsync(cancellationToken);
+        if (cliApp != null)
+        {
+            _logger.LogInformation(
+                "Using paste shortcut: shift+insert (CLI app: {AppName} — Ctrl+Shift+V would be hijacked)",
+                cliApp.AppName);
+            return "shift+insert";
+        }
+
         var isTerminal = await _terminalDetector.IsTerminalActiveAsync(cancellationToken);
         var pasteShortcut = isTerminal ? "ctrl+shift+v" : "ctrl+v";
 

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -25,6 +25,20 @@ public class TerminalCliAppDetector : ICliAppDetector
     };
 
     /// <summary>
+    /// Title-based fallback for when process-tree detection fails (e.g. claude
+    /// runs inside tmux, whose server is a systemd daemon and not a descendant
+    /// of the focused terminal). Matches on substrings in the terminal window
+    /// title that the TUI agent sets itself.
+    /// </summary>
+    private static readonly (string TitleMarker, string AppName, string PromptFileName)[] TitleMarkers =
+    {
+        ("Claude Code", "Claude Code", "ClaudeCodeCorrection"),
+        ("OpenCode", "OpenCode", "OpenCodeCorrection"),
+        ("OC |", "OpenCode", "OpenCodeCorrection"),
+        ("Gemini", "Gemini CLI", "GeminiCorrection")
+    };
+
+    /// <summary>
     /// Terminal window classes that we know how to detect CLI apps in.
     /// </summary>
     private static readonly HashSet<string> TerminalClasses = new(StringComparer.OrdinalIgnoreCase)
@@ -77,7 +91,24 @@ public class TerminalCliAppDetector : ICliAppDetector
                 }
             }
 
-            _logger.LogDebug("No known CLI apps detected in terminal descendants");
+            // Fallback: when the CLI app runs under tmux, the tmux server is a
+            // systemd daemon and its panes (including claude) are NOT in the
+            // process tree of the focused terminal. In that case, trust the
+            // terminal window title — TUI agents set it themselves (e.g.
+            // "Claude Code", "OC | ...").
+            var title = focusedWindow.Value.Title ?? "";
+            foreach (var (titleMarker, appName, promptFileName) in TitleMarkers)
+            {
+                if (title.Contains(titleMarker, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogInformation(
+                        "Detected CLI app by terminal title: {AppName} (title: '{Title}')",
+                        appName, title);
+                    return new CliAppDetectionResult(appName, promptFileName);
+                }
+            }
+
+            _logger.LogDebug("No known CLI apps detected in terminal descendants or title");
             return null;
         }
         catch (Exception ex)
@@ -90,7 +121,7 @@ public class TerminalCliAppDetector : ICliAppDetector
     /// <summary>
     /// Gets information about the currently focused window using GNOME window-calls extension.
     /// </summary>
-    private async Task<(string WmClass, int Pid)?> GetFocusedWindowInfoAsync(CancellationToken cancellationToken)
+    private async Task<(string WmClass, int Pid, string Title)?> GetFocusedWindowInfoAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -143,11 +174,14 @@ public class TerminalCliAppDetector : ICliAppDetector
                     var pid = window.TryGetProperty("pid", out var pidProp)
                         ? pidProp.GetInt32()
                         : 0;
+                    var title = window.TryGetProperty("title", out var titleProp)
+                        ? titleProp.GetString() ?? ""
+                        : "";
 
                     if (pid > 0)
                     {
-                        _logger.LogDebug("Focused window: {WmClass}, PID: {Pid}", wmClass, pid);
-                        return (wmClass, pid);
+                        _logger.LogDebug("Focused window: {WmClass} \"{Title}\" (PID: {Pid})", wmClass, title, pid);
+                        return (wmClass, pid, title);
                     }
                 }
             }

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.SignalR;
+using Olbrasoft.Data.Cqrs;
 using Olbrasoft.LinuxDesktop.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Keyboard;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+using Olbrasoft.VirtualAssistant.Data.Queries.PromptQueries;
 using IDesktopContextService = Olbrasoft.VirtualAssistant.Core.Services.IDesktopContextService;
 
 namespace Olbrasoft.VirtualAssistant.Service.Hubs;
@@ -25,6 +27,7 @@ public class DictationHub : Hub
     private readonly IDesktopContextService _desktopContext;
     private readonly ICliAppDetector _cliAppDetector;
     private readonly ITerminalDetector _terminalDetector;
+    private readonly IQueryProcessor _queryProcessor;
     private readonly ILogger<DictationHub> _logger;
 
     public DictationHub(
@@ -35,6 +38,7 @@ public class DictationHub : Hub
         IDesktopContextService desktopContext,
         ICliAppDetector cliAppDetector,
         ITerminalDetector terminalDetector,
+        IQueryProcessor queryProcessor,
         ILogger<DictationHub> logger)
     {
         _dictationService = dictationService;
@@ -44,6 +48,7 @@ public class DictationHub : Hub
         _desktopContext = desktopContext;
         _cliAppDetector = cliAppDetector;
         _terminalDetector = terminalDetector;
+        _queryProcessor = queryProcessor;
         _logger = logger;
     }
 
@@ -210,16 +215,29 @@ public class DictationHub : Hub
     }
 
     /// <summary>
-    /// Returns the name of the CLI app currently running in the focused terminal
-    /// (e.g., "Claude Code", "OpenCode", "Gemini CLI"), or empty string if none.
-    /// Used by the Remote Control to toggle agent-specific buttons (e.g., Pokračuj).
+    /// Returns the name of the CLI app currently detected as the focused
+    /// application (e.g., "Claude Code", "OpenCode", "Gemini CLI"), or empty
+    /// string if none. Used by the Remote Control on initial connection to
+    /// set the initial state of agent-specific buttons (e.g., Pokračuj).
+    ///
+    /// Matches the same detection flow as DesktopMonitorBroadcastWorker:
+    /// first the process-tree-based CLI detector, then title/application
+    /// pattern matching — the latter works even when the CLI detector can't
+    /// see the process (e.g., claude running under tmux).
     /// </summary>
     public async Task<string> GetActiveCliApp()
     {
         try
         {
             var cliApp = await _cliAppDetector.DetectCliAppAsync();
-            return cliApp?.AppName ?? "";
+            if (cliApp != null)
+                return cliApp.AppName;
+
+            var context = await _desktopContext.GetCurrentContextAsync();
+            var prompt = await _queryProcessor.ProcessAsync(
+                new GetPromptByAppIdPatternQuery(context.ActiveWindowTitle, context.ActiveApplication),
+                CancellationToken.None);
+            return prompt?.ApplicationName ?? "";
         }
         catch (Exception ex)
         {

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -195,6 +195,40 @@ public class DictationHub : Hub
     }
 
     /// <summary>
+    /// Types the word "Pokračuj" into the active window and presses Enter.
+    /// Used by the Remote Control "Pokračuj" button when Claude Code is the active CLI app.
+    /// </summary>
+    public async Task SendContinue()
+    {
+        _logger.LogInformation("SendContinue called from client {ConnectionId}", Context.ConnectionId);
+        try
+        {
+            await _keyboardSimulation.TypeIntoActiveWindowAsync("Pokračuj");
+            await _keyboardSimulation.SendKeyAsync("enter");
+        }
+        catch (Exception ex) { _logger.LogError(ex, "SendContinue failed"); }
+    }
+
+    /// <summary>
+    /// Returns the name of the CLI app currently running in the focused terminal
+    /// (e.g., "Claude Code", "OpenCode", "Gemini CLI"), or empty string if none.
+    /// Used by the Remote Control to toggle agent-specific buttons (e.g., Pokračuj).
+    /// </summary>
+    public async Task<string> GetActiveCliApp()
+    {
+        try
+        {
+            var cliApp = await _cliAppDetector.DetectCliAppAsync();
+            return cliApp?.AppName ?? "";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "GetActiveCliApp failed");
+            return "";
+        }
+    }
+
+    /// <summary>
     /// Pastes from the system clipboard using the correct shortcut for the active window.
     /// Delegates to IKeyboardSimulationService.PasteFromClipboardAsync which centrally
     /// handles terminal (Ctrl+Shift+V) vs GUI (Ctrl+V) detection.

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -202,16 +202,33 @@ public class DictationHub : Hub
     /// <summary>
     /// Types the word "Pokračuj" into the active window and presses Enter.
     /// Used by the Remote Control "Pokračuj" button when Claude Code is the active CLI app.
+    /// Guarded server-side: the UI toggle on the client is best-effort (focus
+    /// can change between CliAppChanged broadcasts and the button press), so
+    /// we re-validate that the currently focused CLI app is Claude Code before
+    /// typing. If not, we no-op and return false to avoid sending "Pokračuj"
+    /// into an unrelated window.
     /// </summary>
-    public async Task SendContinue()
+    public async Task<bool> SendContinue()
     {
         _logger.LogInformation("SendContinue called from client {ConnectionId}", Context.ConnectionId);
         try
         {
+            var activeApp = await GetActiveCliApp();
+            if (!string.Equals(activeApp, "Claude Code", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("SendContinue rejected: active CLI app is '{App}', not Claude Code", activeApp);
+                return false;
+            }
+
             await _keyboardSimulation.TypeIntoActiveWindowAsync("Pokračuj");
             await _keyboardSimulation.SendKeyAsync("enter");
+            return true;
         }
-        catch (Exception ex) { _logger.LogError(ex, "SendContinue failed"); }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SendContinue failed");
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/VirtualAssistant.Service/Workers/DesktopMonitorBroadcastWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DesktopMonitorBroadcastWorker.cs
@@ -140,7 +140,6 @@ public class DesktopMonitorBroadcastWorker : BackgroundService
             // Priority 0: Check for CLI apps running in terminals (e.g., Claude Code, OpenCode)
             // This handles cases where CLI apps change the terminal window title
             var cliApp = await _cliAppDetector.DetectCliAppAsync(CancellationToken.None);
-            await _dictationHubContext.Clients.All.SendAsync("CliAppChanged", cliApp?.AppName ?? "");
             if (cliApp != null)
             {
                 _logger.LogDebug(
@@ -152,6 +151,7 @@ public class DesktopMonitorBroadcastWorker : BackgroundService
                     cliApp.AppName,
                     context.ActiveWindowTitle,
                     cliApp.PromptFileName);
+                await _dictationHubContext.Clients.All.SendAsync("CliAppChanged", cliApp.AppName);
                 return;
             }
 
@@ -171,13 +171,21 @@ public class DesktopMonitorBroadcastWorker : BackgroundService
                 "Broadcasting prompt change: {WindowTitle} ({App}) → {Prompt}",
                 context.ActiveWindowTitle, context.ActiveApplication, prompt?.PromptFileName ?? "null");
 
+            var applicationName = prompt?.ApplicationName ?? "Unknown";
+
             // Broadcast prompt change to all connected clients
             // Use context.ActiveWindowTitle for APP ID to match ACTIVE WINDOW display
             await _hubContext.Clients.All.SendAsync(
                 "PromptChanged",
-                prompt?.ApplicationName ?? "Unknown",  // e.g., "Claude Code"
+                applicationName,                       // e.g., "Claude Code"
                 context.ActiveWindowTitle,             // SAME as ACTIVE WINDOW field
                 prompt?.PromptFileName ?? "DefaultCorrection");
+
+            // Emit CliAppChanged so the Remote Control can toggle agent-specific
+            // buttons (e.g., Pokračuj for Claude Code). Pattern-matched prompt
+            // names are the canonical source — title-based detection works even
+            // when the CLI detector can't see the process (e.g., claude inside tmux).
+            await _dictationHubContext.Clients.All.SendAsync("CliAppChanged", applicationName);
         }
         catch (Exception ex)
         {
@@ -189,6 +197,7 @@ public class DesktopMonitorBroadcastWorker : BackgroundService
                 "Default",
                 context.ActiveWindowTitle,  // SAME as ACTIVE WINDOW field
                 "DefaultCorrection");
+            await _dictationHubContext.Clients.All.SendAsync("CliAppChanged", "");
         }
         finally
         {

--- a/src/VirtualAssistant.Service/Workers/DesktopMonitorBroadcastWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DesktopMonitorBroadcastWorker.cs
@@ -140,6 +140,7 @@ public class DesktopMonitorBroadcastWorker : BackgroundService
             // Priority 0: Check for CLI apps running in terminals (e.g., Claude Code, OpenCode)
             // This handles cases where CLI apps change the terminal window title
             var cliApp = await _cliAppDetector.DetectCliAppAsync(CancellationToken.None);
+            await _dictationHubContext.Clients.All.SendAsync("CliAppChanged", cliApp?.AppName ?? "");
             if (cliApp != null)
             {
                 _logger.LogDebug(

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -93,11 +93,11 @@
 
         /* Pokračuj button — only visible when Claude Code is the active CLI
            app. When visible, shares the dictation row equally with btn-dictate
-           (each takes half width). Green to distinguish it from the blue
-           Diktovat button. */
+           (each takes half width). Purple to distinguish it from both the
+           blue Diktovat above and the green Enter below. */
         .btn-continue {
             flex: 1;
-            background: linear-gradient(135deg, #4caf50 0%, #388e3c 100%);
+            background: linear-gradient(135deg, #7c4dff 0%, #651fff 100%);
             color: white;
             padding: 50px 20px;
             font-size: 1.4rem;
@@ -105,7 +105,7 @@
         }
 
         .btn-continue:hover:not(:disabled) {
-            background: linear-gradient(135deg, #388e3c 0%, #2e7d32 100%);
+            background: linear-gradient(135deg, #651fff 0%, #5e35b1 100%);
         }
 
         .dictation-row.claude-code .btn-continue {
@@ -455,7 +455,7 @@
                  .recording class on #controls. -->
             <div class="dictation-row" id="dictationRow">
                 <button class="btn btn-continue" id="btnContinue" disabled>
-                    <span class="icon">&#x25B6;</span>
+                    <span class="icon">&#x279C;</span>
                     <span>Pokračuj</span>
                 </button>
                 <button class="btn btn-dictate" id="btnDictate" disabled>
@@ -559,7 +559,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=31"></script>
+    <script src="remote.js?v=32"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -76,6 +76,7 @@
            release zones (fast + slow) while recording. */
         .dictation-row {
             display: flex;
+            gap: 12px;
         }
 
         .btn-dictate {
@@ -88,6 +89,27 @@
 
         .btn-dictate:hover:not(:disabled) {
             background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%);
+        }
+
+        /* Pokračuj button — only visible when Claude Code is the active CLI
+           app. When visible, shares the dictation row equally with btn-dictate
+           (each takes half width). Green to distinguish it from the blue
+           Diktovat button. */
+        .btn-continue {
+            flex: 1;
+            background: linear-gradient(135deg, #4caf50 0%, #388e3c 100%);
+            color: white;
+            padding: 50px 20px;
+            font-size: 1.4rem;
+            display: none;
+        }
+
+        .btn-continue:hover:not(:disabled) {
+            background: linear-gradient(135deg, #388e3c 0%, #2e7d32 100%);
+        }
+
+        .dictation-row.claude-code .btn-continue {
+            display: flex;
         }
 
         .btn-dictate.transcribing {
@@ -431,7 +453,11 @@
             <!-- Idle: single dictation button. Pressed → start recording.
                  Once recording is in progress this row is hidden via the
                  .recording class on #controls. -->
-            <div class="dictation-row">
+            <div class="dictation-row" id="dictationRow">
+                <button class="btn btn-continue" id="btnContinue" disabled>
+                    <span class="icon">&#x25B6;</span>
+                    <span>Pokračuj</span>
+                </button>
                 <button class="btn btn-dictate" id="btnDictate" disabled>
                     <span class="icon" id="dictateIcon">&#x25CF;</span>
                     <span id="dictateText">Diktovat</span>
@@ -533,7 +559,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=29"></script>
+    <script src="remote.js?v=30"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -559,7 +559,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=30"></script>
+    <script src="remote.js?v=31"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,7 +4,7 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v30';
+const SCRIPT_VERSION = 'v31';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,13 +4,15 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v29';
+const SCRIPT_VERSION = 'v30';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),
     debugLogContent: document.getElementById('debugLogContent'),
     controls: document.getElementById('controls'),
+    dictationRow: document.getElementById('dictationRow'),
     btnDictate: document.getElementById('btnDictate'),
+    btnContinue: document.getElementById('btnContinue'),
     btnZoneFast: document.getElementById('btnZoneFast'),
     btnZoneSlow: document.getElementById('btnZoneSlow'),
     btnEnter: document.getElementById('btnEnter'),
@@ -130,6 +132,7 @@ function buildConnection() {
     connection.on('AppFocusChanged', handleAppFocusChanged);
     connection.on('WorkspaceChanged', handleWorkspaceChanged);
     connection.on('ScreenshotAvailable', handleScreenshotAvailable);
+    connection.on('CliAppChanged', handleCliAppChanged);
     connection.on('Connected', (connectionId) => {
         console.log('Connected with ID:', connectionId);
     });
@@ -185,6 +188,7 @@ function setConnectionStatus(connected) {
     elements.connectionStatus.className = 'connection-status ' + (connected ? 'connected' : 'disconnected');
 
     elements.btnDictate.disabled = !connected;
+    if (elements.btnContinue) elements.btnContinue.disabled = !connected;
     elements.btnEnter.disabled = !connected;
     elements.btnClear.disabled = !connected;
     if (elements.btnClipboardPaste) elements.btnClipboardPaste.disabled = !connected;
@@ -287,6 +291,15 @@ function handleAppFocusChanged(wmClass) {
     updateAppButton(elements.btnFerdium, 'ferdium', 'Ferdium');
 }
 
+// Toggles the "Pokračuj" button visibility based on the active CLI app
+// detected in the focused terminal. Only Claude Code enables the split —
+// other CLI apps (OpenCode, Gemini) keep the single full-width Diktovat.
+function handleCliAppChanged(cliAppName) {
+    const isClaudeCode = (cliAppName || '').toLowerCase() === 'claude code';
+    if (!elements.dictationRow) return;
+    elements.dictationRow.classList.toggle('claude-code', isClaudeCode);
+}
+
 function handleWorkspaceChanged(workspace, total) {
     console.log('WorkspaceChanged:', workspace, '/', total);
     currentWorkspace = workspace;
@@ -357,6 +370,13 @@ async function refreshStatus() {
 
         const wsInfo = await connection.invoke('GetWorkspaceInfo');
         handleWorkspaceChanged(wsInfo.currentWorkspace, wsInfo.totalWorkspaces);
+
+        try {
+            const cliApp = await connection.invoke('GetActiveCliApp');
+            handleCliAppChanged(cliApp);
+        } catch (error) {
+            console.error('GetActiveCliApp failed:', error);
+        }
 
         await checkScreenshotAvailability();
     } catch (error) {
@@ -562,6 +582,27 @@ elements.btnEnter.addEventListener('pointerdown', () => {
     if (elements.btnEnter.disabled) return;
     if ('vibrate' in navigator) navigator.vibrate(50);
 });
+
+if (elements.btnContinue) {
+    elements.btnContinue.addEventListener('pointerdown', () => {
+        if (elements.btnContinue.disabled) return;
+        if ('vibrate' in navigator) navigator.vibrate(50);
+    });
+
+    elements.btnContinue.addEventListener('click', async () => {
+        if (connection?.state !== signalR.HubConnectionState.Connected) return;
+        try {
+            elements.btnContinue.disabled = true;
+            await connection.invoke('SendContinue');
+        } catch (error) {
+            console.error('SendContinue failed:', error);
+        } finally {
+            if (connection.state === signalR.HubConnectionState.Connected) {
+                elements.btnContinue.disabled = false;
+            }
+        }
+    });
+}
 
 elements.btnClear.addEventListener('pointerdown', () => {
     if (elements.btnClear.disabled) return;

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,7 +4,7 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v31';
+const SCRIPT_VERSION = 'v32';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v32';
+const CACHE_NAME = 'va-dictation-v33';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',

--- a/src/VirtualAssistant.Service/wwwroot/service-worker.js
+++ b/src/VirtualAssistant.Service/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'va-dictation-v31';
+const CACHE_NAME = 'va-dictation-v32';
 
 const SAME_ORIGIN_URLS = [
     '/remote.html',


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
- Splits the Remote Control's single `Diktovat` button into two halves (`Pokračuj` + `Diktovat`) only when Claude Code is the active CLI app in the focused terminal.
- `Pokračuj` (green) types the word *Pokračuj* into the active window and presses Enter — a one-tap way to unblock a Claude Code session from the phone.
- `Diktovat` (blue) keeps its existing behavior and styling.

## How it works
Backend:
- `DictationHub.SendContinue()` types `Pokračuj` + Enter via `IKeyboardSimulationService`.
- `DictationHub.GetActiveCliApp()` returns the current CLI app name so a freshly connected client can set its initial UI state.
- `DesktopMonitorBroadcastWorker` now also emits `CliAppChanged` (with the detected app name, or `""` when none) to the DictationHub on every prompt change — so the button appears/disappears as the user switches focus.

Frontend:
- `remote.html` gets a new `#btnContinue` next to `#btnDictate`, hidden by default via CSS.
- `remote.js` listens for `CliAppChanged`; when the value matches \"Claude Code\" it toggles the `claude-code` class on `.dictation-row`, which reveals the Pokračuj button.
- The initial state is fetched via `GetActiveCliApp` from `refreshStatus()`.
- Script cache-busted to `v30`.

Only Claude Code enables the split; OpenCode / Gemini CLI keep the single full-width Diktovat.

## Test plan
- [x] `dotnet build` succeeds.
- [x] `dotnet test tests/VirtualAssistant.Service.Tests --filter "FullyQualifiedName!~IntegrationTests"` — 299 passed.
- [x] Deployed locally; `/health` returns OK; `/remote.html` and `/remote.js?v=30` serve the new content.
- [ ] Manual UI verification: open `http://localhost:5055/remote.html` on a phone, focus a terminal running `claude`, confirm the split button appears and pressing Pokračuj types the word and sends Enter. (Could not run automated browser test — local Playwright Edge ports do not match this session's wrapper.)
- [ ] Manual UI verification: leave Claude Code terminal; confirm the split collapses back to single full-width Diktovat.