### PR TITLE
test: ghnotify chain verification

### DIFF
--- a/tests/VirtualAssistant.Core.Tests/Utilities/RateLimitParserTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Utilities/RateLimitParserTests.cs
@@ -91,8 +91,10 @@ public class RateLimitParserTests
         var result = RateLimitParser.ParseResetTimeFromError(errorBody);
 
         Assert.NotNull(result);
-        var expected = before.AddSeconds(0.25);
-        Assert.True(result.Value >= expected.AddSeconds(-2) && result.Value <= expected.AddSeconds(2));
+        var actualDelay = result.Value - before;
+        var expectedDelay = TimeSpan.FromSeconds(0.25);
+        var tolerance = TimeSpan.FromMilliseconds(100);
+        Assert.True(actualDelay >= expectedDelay - tolerance && actualDelay <= expectedDelay + tolerance);
     }
 
     [Fact]

--- a/tests/VirtualAssistant.Core.Tests/Utilities/RateLimitParserTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Utilities/RateLimitParserTests.cs
@@ -81,4 +81,25 @@ public class RateLimitParserTests
         var expected = before.AddMinutes(10).AddSeconds(120.5);
         Assert.True(result.Value >= expected.AddSeconds(-2) && result.Value <= expected.AddSeconds(2));
     }
+
+    [Fact]
+    public void ParseResetTimeFromError_WithSubSecondPrecision_ReturnsCorrectTime()
+    {
+        var errorBody = "try again in 0m0.25s";
+        var before = DateTime.UtcNow;
+
+        var result = RateLimitParser.ParseResetTimeFromError(errorBody);
+
+        Assert.NotNull(result);
+        var expected = before.AddSeconds(0.25);
+        Assert.True(result.Value >= expected.AddSeconds(-2) && result.Value <= expected.AddSeconds(2));
+    }
+
+    [Fact]
+    public void ParseResetTimeFromError_WithNullInput_ReturnsNullWithoutThrowing()
+    {
+        var result = RateLimitParser.ParseResetTimeFromError(null!);
+
+        Assert.Null(result);
+    }
 }


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
Smoke-test the full ghnotify chain (Copilot review → CI → deploy wakes).
Adds two tiny tests to `RateLimitParser`:

- **happy path**: sub-second precision — `0m0.25s` parses cleanly.
- **edge case**: null input — `ParseResetTimeFromError(null)` returns null without throwing.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~RateLimitParserTests` → 11/11 pass
- [ ] Copilot code review fires `code-review-complete` wake
- [ ] CI `ci-success` wake after squash-merge
- [ ] Deploy workflow wake after push to main