### PR TITLE
refactor: extract gdbus JSON array helper + round-2 chain test

### DIFF
--- a/src/VirtualAssistant.Core/WindowManagement/GdbusJsonHelper.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/GdbusJsonHelper.cs
@@ -36,10 +36,10 @@ public static class GdbusJsonHelper
     }
 
     /// <summary>
-    /// Extracts the first JSON array substring (from the first <c>[</c> to the
-    /// matching last <c>]</c>) from raw <c>gdbus</c> output wrapped in the
-    /// GVariant tuple prefix, e.g. <c>('[{…}]',)</c>. Returns <c>null</c>
-    /// when no bracket pair can be located.
+    /// Extracts the substring from the first <c>[</c> to the last <c>]</c>
+    /// found in raw <c>gdbus</c> output wrapped in the GVariant tuple prefix,
+    /// e.g. <c>('[{…}]',)</c>. Returns <c>null</c> when no opening bracket is
+    /// found or when no later closing bracket can be located.
     /// </summary>
     /// <param name="rawOutput">Unprocessed stdout from a gdbus call.</param>
     /// <returns>The JSON array substring, or <c>null</c> if not present.</returns>

--- a/src/VirtualAssistant.Core/WindowManagement/GdbusJsonHelper.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/GdbusJsonHelper.cs
@@ -34,4 +34,29 @@ public static class GdbusJsonHelper
 
         return json.Replace("\\\\\"", "\\\"");
     }
+
+    /// <summary>
+    /// Extracts the first JSON array substring (from the first <c>[</c> to the
+    /// matching last <c>]</c>) from raw <c>gdbus</c> output wrapped in the
+    /// GVariant tuple prefix, e.g. <c>('[{…}]',)</c>. Returns <c>null</c>
+    /// when no bracket pair can be located.
+    /// </summary>
+    /// <param name="rawOutput">Unprocessed stdout from a gdbus call.</param>
+    /// <returns>The JSON array substring, or <c>null</c> if not present.</returns>
+    public static string? TryExtractJsonArray(string? rawOutput)
+    {
+        if (string.IsNullOrEmpty(rawOutput))
+        {
+            return null;
+        }
+
+        var jsonStart = rawOutput.IndexOf('[');
+        var jsonEnd = rawOutput.LastIndexOf(']');
+        if (jsonStart < 0 || jsonEnd <= jsonStart)
+        {
+            return null;
+        }
+
+        return rawOutput.Substring(jsonStart, jsonEnd - jsonStart + 1);
+    }
 }

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -151,16 +151,14 @@ public class TerminalCliAppDetector : ICliAppDetector
             }
 
             // Extract JSON array from gdbus output: ('[{...}]',)
-            var jsonStart = output.IndexOf('[');
-            var jsonEnd = output.LastIndexOf(']');
-            if (jsonStart < 0 || jsonEnd <= jsonStart)
+            var rawJsonArray = GdbusJsonHelper.TryExtractJsonArray(output);
+            if (rawJsonArray is null)
             {
                 _logger.LogDebug("Could not parse D-Bus output");
                 return null;
             }
 
-            var jsonArray = GdbusJsonHelper.UnescapeQuotes(
-                output.Substring(jsonStart, jsonEnd - jsonStart + 1));
+            var jsonArray = GdbusJsonHelper.UnescapeQuotes(rawJsonArray);
 
             var windows = JsonSerializer.Deserialize<JsonElement>(jsonArray);
 

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/GdbusJsonHelperTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/GdbusJsonHelperTests.cs
@@ -79,4 +79,47 @@ public class GdbusJsonHelperTests
 
         Assert.Equal(input, result);
     }
+
+    [Fact]
+    public void TryExtractJsonArray_WithGdbusTuplePrefix_ReturnsArraySubstring()
+    {
+        // Happy path: gdbus emits a single-element tuple with a string value,
+        // e.g. ('[{"focus":true}]',) — we want the inner JSON array.
+        var raw = "('[{\"focus\":true,\"wm_class\":\"kitty\"}]',)";
+
+        var result = GdbusJsonHelper.TryExtractJsonArray(raw);
+
+        Assert.Equal("[{\"focus\":true,\"wm_class\":\"kitty\"}]", result);
+    }
+
+    [Fact]
+    public void TryExtractJsonArray_WithNoBrackets_ReturnsNull()
+    {
+        // Edge case: gdbus returned an error/empty payload without any brackets.
+        var raw = "no data";
+
+        var result = GdbusJsonHelper.TryExtractJsonArray(raw);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryExtractJsonArray_WithNullInput_ReturnsNull()
+    {
+        var result = GdbusJsonHelper.TryExtractJsonArray(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryExtractJsonArray_WithOnlyOpeningBracket_ReturnsNull()
+    {
+        // Malformed: opening bracket but no closing one — do not return a
+        // half-formed substring.
+        var raw = "('[broken',)";
+
+        var result = GdbusJsonHelper.TryExtractJsonArray(raw);
+
+        Assert.Null(result);
+    }
 }


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

## Summary
Round-2 ghnotify chain test: validates (a) review-submitted wake fires for both `action=submitted` and `action=edited`, and (b) dismissed reviews do NOT wake.

Functional change: pull the gdbus bracket-scan out of `TerminalCliAppDetector.GetFocusedWindowInfoAsync` into a reusable `GdbusJsonHelper.TryExtractJsonArray` pure helper. Behaviorally identical; easier to unit-test and reuse.

- **Positive path**: gdbus tuple `('[…]',)` → returns clean JSON array.
- **Negative path**: no brackets / null / only-opening-bracket → returns null.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~GdbusJsonHelperTests` → 11/11 pass
- [x] `dotnet build src/VirtualAssistant.Core` → 0 errors
- [ ] Positive: /copilot review wake arrives (action=submitted or edited)
- [ ] Negative: dismissing a self-submitted review emits NO wake
- [ ] Post-merge: ci-success + deploy wakes on main