### PR TITLE
fix(paste): cache CLI-app detection to survive gdbus hiccups (Claude Code paste bug)

### DIFF
--- a/src/VirtualAssistant.Core/VirtualAssistant.Core.csproj
+++ b/src/VirtualAssistant.Core/VirtualAssistant.Core.csproj
@@ -37,4 +37,8 @@
     <ProjectReference Include="..\VirtualAssistant.Data.EntityFrameworkCore\VirtualAssistant.Data.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="VirtualAssistant.Core.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -85,6 +85,10 @@ public class TerminalCliAppDetector : ICliAppDetector
             if (!TerminalClasses.Contains(focusedWindow.Value.WmClass))
             {
                 _logger.LogDebug("Focused window is not a terminal: {WmClass}", focusedWindow.Value.WmClass);
+                // Confirmed non-terminal focus: invalidate cache so a later gdbus
+                // hiccup can't serve the stale CLI-app result (which would push
+                // Shift+Insert into a GUI app whose "real" paste shortcut is Ctrl+V).
+                ClearCache();
                 return null;
             }
 
@@ -125,6 +129,9 @@ public class TerminalCliAppDetector : ICliAppDetector
             }
 
             _logger.LogDebug("No known CLI apps detected in terminal descendants or title");
+            // Confirmed terminal without any known CLI app (e.g. plain bash): same
+            // invalidation reason as the non-terminal branch.
+            ClearCache();
             return null;
         }
         catch (Exception ex)
@@ -144,6 +151,15 @@ public class TerminalCliAppDetector : ICliAppDetector
             _cachedAtUtc = DateTime.UtcNow;
         }
         return result;
+    }
+
+    private void ClearCache()
+    {
+        lock (_cacheLock)
+        {
+            _cachedResult = null;
+            _cachedAtUtc = DateTime.MinValue;
+        }
     }
 
     private CliAppDetectionResult? TryServeCachedResult(string failureReason)

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -13,6 +13,20 @@ public class TerminalCliAppDetector : ICliAppDetector
 {
     private readonly ILogger<TerminalCliAppDetector> _logger;
 
+    // Last successful detection + its timestamp. When a later probe fails transiently
+    // (gdbus slow / returns empty), we serve this value instead of falling through to
+    // the wrong paste shortcut. Claude Code intercepts Ctrl+V and Ctrl+Shift+V as
+    // "paste image", so a Ctrl+V fallback triggers the "No image found in clipboard"
+    // toast — the very bug this cache is meant to prevent. See issue #958.
+    private readonly object _cacheLock = new();
+    private CliAppDetectionResult? _cachedResult;
+    private DateTime _cachedAtUtc = DateTime.MinValue;
+
+    // Staleness cap: long enough to ride out a gdbus hiccup between consecutive taps
+    // of "Vložit rychle", short enough that a real app switch masked by a persistent
+    // gdbus outage flips us back to "no cached app" quickly.
+    internal static readonly TimeSpan CacheStaleness = TimeSpan.FromSeconds(10);
+
     /// <summary>
     /// Known CLI applications to detect, mapped to their prompt configurations.
     /// Key: process name pattern, Value: (AppName, PromptFileName)
@@ -61,8 +75,10 @@ public class TerminalCliAppDetector : ICliAppDetector
             var focusedWindow = await GetFocusedWindowInfoAsync(cancellationToken);
             if (focusedWindow == null)
             {
-                _logger.LogDebug("Could not get focused window info");
-                return null;
+                // gdbus probe failed (or GNOME Shell slow / extension stalled). If the
+                // last successful detection is fresh enough, serve it — otherwise we'd
+                // fall back to Ctrl+V which Claude Code hijacks as "paste image".
+                return TryServeCachedResult("gdbus probe returned no focused window info");
             }
 
             // Check if focused window is a terminal
@@ -87,7 +103,7 @@ public class TerminalCliAppDetector : ICliAppDetector
                 {
                     _logger.LogInformation("Detected CLI app in terminal: {AppName} (process: {ProcessName})",
                         appName, processName);
-                    return new CliAppDetectionResult(appName, promptFileName);
+                    return CacheAndReturn(new CliAppDetectionResult(appName, promptFileName));
                 }
             }
 
@@ -104,7 +120,7 @@ public class TerminalCliAppDetector : ICliAppDetector
                     _logger.LogInformation(
                         "Detected CLI app by terminal title: {AppName} (title: '{Title}')",
                         appName, title);
-                    return new CliAppDetectionResult(appName, promptFileName);
+                    return CacheAndReturn(new CliAppDetectionResult(appName, promptFileName));
                 }
             }
 
@@ -114,9 +130,47 @@ public class TerminalCliAppDetector : ICliAppDetector
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error during CLI app detection");
-            return null;
+            // Same fall-through as a null gdbus result: a recent cached value is
+            // vastly better than a Ctrl+V fallback that hits the paste-image hijack.
+            return TryServeCachedResult("unhandled exception during detection");
         }
     }
+
+    private CliAppDetectionResult CacheAndReturn(CliAppDetectionResult result)
+    {
+        lock (_cacheLock)
+        {
+            _cachedResult = result;
+            _cachedAtUtc = DateTime.UtcNow;
+        }
+        return result;
+    }
+
+    private CliAppDetectionResult? TryServeCachedResult(string failureReason)
+    {
+        CliAppDetectionResult? cached;
+        DateTime cachedAt;
+        lock (_cacheLock)
+        {
+            cached = _cachedResult;
+            cachedAt = _cachedAtUtc;
+        }
+
+        if (cached is not null && IsCacheFresh(cachedAt, DateTime.UtcNow))
+        {
+            var age = DateTime.UtcNow - cachedAt;
+            _logger.LogInformation(
+                "Serving cached CLI app detection {AppName} (age {AgeSeconds:F1}s, reason: {Reason})",
+                cached.AppName, age.TotalSeconds, failureReason);
+            return cached;
+        }
+
+        _logger.LogDebug("No usable cache (reason: {Reason})", failureReason);
+        return null;
+    }
+
+    internal static bool IsCacheFresh(DateTime cachedAtUtc, DateTime nowUtc)
+        => cachedAtUtc != DateTime.MinValue && nowUtc - cachedAtUtc <= CacheStaleness;
 
     /// <summary>
     /// Gets information about the currently focused window using GNOME window-calls extension.

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalCliAppDetectorCacheTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalCliAppDetectorCacheTests.cs
@@ -1,0 +1,58 @@
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
+
+/// <summary>
+/// Cache-freshness contract for <see cref="TerminalCliAppDetector"/>. The full
+/// <c>DetectCliAppAsync</c> flow shells out to gdbus/pgrep and is tested manually;
+/// here we pin down just the pure time-based freshness predicate that decides
+/// whether a transient gdbus failure may be papered over with a cached value
+/// instead of falling back to Ctrl+V (which Claude Code hijacks as "paste image").
+/// </summary>
+public class TerminalCliAppDetectorCacheTests
+{
+    [Fact]
+    public void IsCacheFresh_WithUninitializedCache_ReturnsFalse()
+    {
+        // Detector has never completed a successful probe yet, so the cache must
+        // not be served — the "DateTime.MinValue" sentinel means "no cache".
+        var result = TerminalCliAppDetector.IsCacheFresh(DateTime.MinValue, DateTime.UtcNow);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsCacheFresh_OneSecondOld_ReturnsTrue()
+    {
+        var now = DateTime.UtcNow;
+        var cachedAt = now.AddSeconds(-1);
+
+        var result = TerminalCliAppDetector.IsCacheFresh(cachedAt, now);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsCacheFresh_ExactlyAtStalenessBoundary_ReturnsTrue()
+    {
+        // Boundary is inclusive (<=), so a cache entry right at the limit still
+        // serves. This prevents a tiny clock drift from flipping us to "stale".
+        var now = DateTime.UtcNow;
+        var cachedAt = now - TerminalCliAppDetector.CacheStaleness;
+
+        var result = TerminalCliAppDetector.IsCacheFresh(cachedAt, now);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsCacheFresh_OneSecondPastStaleness_ReturnsFalse()
+    {
+        var now = DateTime.UtcNow;
+        var cachedAt = now - TerminalCliAppDetector.CacheStaleness - TimeSpan.FromSeconds(1);
+
+        var result = TerminalCliAppDetector.IsCacheFresh(cachedAt, now);
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

Closes #958

## Summary
Remote Control \"Vložit rychle\" and dictation-to-Claude-Code intermittently produced the red `No image found in clipboard. Use ctrl+v to paste images.` toast, because the service sent **Ctrl+V** to a TUI that hijacks Ctrl+V as paste-image.

Root cause, verified in journald 2026-04-17 18:00-18:01: `TerminalCliAppDetector.GetFocusedWindowInfoAsync` shells out to `gdbus ... Windows.List` on every call with no cache. When gdbus is slow or returns empty, the detector returns `null` → `GetPasteShortcutAsync` falls back to Ctrl+V → Claude Code toast.

Fix: cache the last successful `CliAppDetectionResult` with a **10-second staleness window**. A transient gdbus failure now serves the cached app so paste stays on Shift+Insert. A real app switch still wins because successful probes overwrite the cache; a persistent outage naturally degrades to \"no cached app\" after 10s.

## Why not share `DesktopContextService` directly
That refactor is larger — `DesktopContextService` lives in VirtualAssistant.Desktop and holds desktop-file IDs (`terminator.desktop`), not friendly CLI names (`Claude Code`), so wiring it into the paste path would also require moving or duplicating the CLI-name mapping. Documented in #958 as out-of-scope; a short cache in the detector itself closes the symptom with ~50 lines.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test --filter \"FullyQualifiedName!~IntegrationTests\"` — all pass, 4 new cache-freshness tests
- [ ] After deploy: tap \"Vložit rychle\" rapidly from Remote Control — text should land in Claude Code input, no toast
- [ ] Dictate into Claude Code — transcribed text should appear in the input field
- [ ] Watch logs for \"Serving cached CLI app detection\" info line when gdbus hiccups