### PR TITLE
feat(tray): "Obnovit cache" menu item + corrections TTL 5m → 1h

### DIFF
--- a/src/VirtualAssistant.Core/Services/IMenuEventDispatcher.cs
+++ b/src/VirtualAssistant.Core/Services/IMenuEventDispatcher.cs
@@ -60,4 +60,12 @@ public interface IMenuEventDispatcher
     /// Handles streaming transcription toggle from menu (fast dictation path only).
     /// </summary>
     void HandleStreamingTranscriptionToggle(bool enabled);
+
+    /// <summary>
+    /// Handles "Obnovit cache" click: invalidates the transcription corrections
+    /// cache so a freshly INSERTed row in <c>transcription_corrections</c> takes
+    /// effect on the next dictation, without waiting for the 1-hour TTL or a
+    /// service restart.
+    /// </summary>
+    void HandleReloadCorrectionsCache();
 }

--- a/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
@@ -122,6 +122,7 @@ public static class TrayServicesExtensions
             var dictationControl = sp.GetService<IDictationControl>();
             var promptSyncService = sp.GetService<IPromptSyncService>();
             var menuStateManager = sp.GetService<IMenuStateManager>();
+            var correctionFilter = sp.GetService<Olbrasoft.VirtualAssistant.Voice.Filters.DatabaseCorrectionFilterStrategy>();
 
             var dashboardBaseUrl = configuration["Dashboard:BaseUrl"] ?? "http://localhost:5055";
 
@@ -133,7 +134,8 @@ public static class TrayServicesExtensions
                 llmProvider,
                 dictationControl,
                 promptSyncService,
-                menuStateManager);
+                menuStateManager,
+                correctionFilter);
         });
 
         // Recording notification service for dictation status (Phase 1 - issue #670)

--- a/src/VirtualAssistant.Service/Tray/Menu/IMenuEventRouter.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/IMenuEventRouter.cs
@@ -57,6 +57,12 @@ public interface IMenuEventRouter
     event Action<bool>? OnStreamingTranscriptionToggled;
 
     /// <summary>
+    /// Event fired when user clicks "Obnovit cache" for transcription corrections
+    /// in the tray menu.
+    /// </summary>
+    event Action? OnReloadCorrectionsCacheRequested;
+
+    /// <summary>
     /// Handles a menu click event.
     /// </summary>
     /// <param name="id">Menu item ID that was clicked.</param>

--- a/src/VirtualAssistant.Service/Tray/Menu/MenuEventRouter.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/MenuEventRouter.cs
@@ -69,6 +69,11 @@ public class MenuEventRouter : IMenuEventRouter
     public event Action<bool>? OnStreamingTranscriptionToggled;
 
     /// <summary>
+    /// Event fired when user clicks "Obnovit cache" for transcription corrections.
+    /// </summary>
+    public event Action? OnReloadCorrectionsCacheRequested;
+
+    /// <summary>
     /// Handles a menu click event.
     /// Routes the event to the appropriate handler based on menu item ID.
     /// </summary>
@@ -102,7 +107,8 @@ public class MenuEventRouter : IMenuEventRouter
         [MenuItemIds.LlmCorrectionId] = HandleLlmCorrection,
         [MenuItemIds.ReloadPromptId] = HandleReloadPrompt,
         [MenuItemIds.DictationToggleId] = HandleDictationToggle,
-        [MenuItemIds.StreamingTranscriptionId] = HandleStreamingTranscriptionToggle
+        [MenuItemIds.StreamingTranscriptionId] = HandleStreamingTranscriptionToggle,
+        [MenuItemIds.ReloadCorrectionsCacheId] = HandleReloadCorrectionsCache
     };
 
     private void HandleQuit()
@@ -171,5 +177,11 @@ public class MenuEventRouter : IMenuEventRouter
         var newState = !_stateManager.IsStreamingTranscriptionEnabled;
         _stateManager.UpdateStreamingTranscriptionStatus(newState);
         OnStreamingTranscriptionToggled?.Invoke(newState);
+    }
+
+    private void HandleReloadCorrectionsCache()
+    {
+        _logger.LogInformation("Reload corrections cache menu item clicked");
+        OnReloadCorrectionsCacheRequested?.Invoke();
     }
 }

--- a/src/VirtualAssistant.Service/Tray/Menu/MenuItemIds.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/MenuItemIds.cs
@@ -21,4 +21,5 @@ public static class MenuItemIds
     public const int AboutId = 17;
     public const int MercuryBillingId = 18;
     public const int StreamingTranscriptionId = 19;
+    public const int ReloadCorrectionsCacheId = 20;
 }

--- a/src/VirtualAssistant.Service/Tray/Menu/MenuLayoutBuilder.cs
+++ b/src/VirtualAssistant.Service/Tray/Menu/MenuLayoutBuilder.cs
@@ -75,6 +75,12 @@ public class MenuLayoutBuilder : IMenuLayoutBuilder
                 ["enabled"] = VariantValue.Bool(true),
                 ["visible"] = VariantValue.Bool(true)
             }),
+            MenuItemIds.ReloadCorrectionsCacheId => (id, new Dictionary<string, VariantValue>
+            {
+                ["label"] = VariantValue.String(GetCorrectionsCacheLabel()),
+                ["enabled"] = VariantValue.Bool(true),
+                ["visible"] = VariantValue.Bool(true)
+            }),
             MenuItemIds.MuteToggleId => (id, new Dictionary<string, VariantValue>
             {
                 ["label"] = VariantValue.String(GetMuteLabel()),
@@ -146,6 +152,7 @@ public class MenuLayoutBuilder : IMenuLayoutBuilder
                 CreateChildVariant(MenuItemIds.Separator2Id, "", true),
                 CreateChildVariant(MenuItemIds.LlmCorrectionId, llmCorrectionLabel, false),
                 CreateChildVariant(MenuItemIds.ReloadPromptId, GetPromptSyncLabel(), false),
+                CreateChildVariant(MenuItemIds.ReloadCorrectionsCacheId, GetCorrectionsCacheLabel(), false),
                 CreateChildVariant(MenuItemIds.Separator3Id, "", true),
                 CreateChildVariant(MenuItemIds.MuteToggleId, muteLabel, false),
                 CreateChildVariant(MenuItemIds.TtsMuteToggleId, ttsMuteLabel, false),
@@ -231,6 +238,9 @@ public class MenuLayoutBuilder : IMenuLayoutBuilder
             ? "✅ Posílání do LLM - Vypnout"
             : "❌ Posílání do LLM - Zapnout";
     }
+
+    private static string GetCorrectionsCacheLabel()
+        => "🔄 Opravy transkripce - Obnovit cache";
 
     private string GetPromptSyncLabel()
     {

--- a/src/VirtualAssistant.Service/Tray/MenuEventDispatcher.cs
+++ b/src/VirtualAssistant.Service/Tray/MenuEventDispatcher.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Service.Services;
 using Olbrasoft.VirtualAssistant.Service.Tray.Menu;
+using Olbrasoft.VirtualAssistant.Voice.Filters;
 using Olbrasoft.VirtualAssistant.Voice.Services;
 
 namespace Olbrasoft.VirtualAssistant.Service.Tray;
@@ -21,6 +22,7 @@ public class MenuEventDispatcher : IMenuEventDispatcher
     private readonly IDictationControl? _dictationControl;
     private readonly IPromptSyncService? _promptSyncService;
     private readonly IMenuStateManager? _menuStateManager;
+    private readonly DatabaseCorrectionFilterStrategy? _correctionFilter;
 
     public MenuEventDispatcher(
         ILogger<MenuEventDispatcher> logger,
@@ -30,7 +32,8 @@ public class MenuEventDispatcher : IMenuEventDispatcher
         ILlmProvider? llmProvider = null,
         IDictationControl? dictationControl = null,
         IPromptSyncService? promptSyncService = null,
-        IMenuStateManager? menuStateManager = null)
+        IMenuStateManager? menuStateManager = null,
+        DatabaseCorrectionFilterStrategy? correctionFilter = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _muteService = muteService ?? throw new ArgumentNullException(nameof(muteService));
@@ -40,6 +43,7 @@ public class MenuEventDispatcher : IMenuEventDispatcher
         _dictationControl = dictationControl;
         _promptSyncService = promptSyncService;
         _menuStateManager = menuStateManager;
+        _correctionFilter = correctionFilter;
     }
 
     /// <inheritdoc/>
@@ -245,6 +249,30 @@ public class MenuEventDispatcher : IMenuEventDispatcher
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to toggle dictation");
+        }
+    }
+
+    /// <summary>
+    /// Invalidates the transcription corrections cache so a freshly INSERTed row in
+    /// <c>transcription_corrections</c> takes effect on the very next dictation.
+    /// No-op if the filter strategy is not available (e.g. running in tests).
+    /// </summary>
+    public void HandleReloadCorrectionsCache()
+    {
+        if (_correctionFilter is null)
+        {
+            _logger.LogWarning("Transcription correction filter not available; cache invalidation skipped");
+            return;
+        }
+
+        try
+        {
+            _correctionFilter.InvalidateCache();
+            _logger.LogInformation("Transcription corrections cache invalidated from tray menu");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to invalidate transcription corrections cache");
         }
     }
 

--- a/src/VirtualAssistant.Service/Tray/TrayCoordinatorService.cs
+++ b/src/VirtualAssistant.Service/Tray/TrayCoordinatorService.cs
@@ -89,6 +89,7 @@ public class TrayCoordinatorService : IDisposable
             handler.OnDictationToggleRequested += _menuDispatcher.HandleDictationToggle;
             handler.OnMercuryBillingRequested += _menuDispatcher.HandleMercuryBilling;
             handler.OnStreamingTranscriptionToggled += _menuDispatcher.HandleStreamingTranscriptionToggle;
+            handler.OnReloadCorrectionsCacheRequested += _menuDispatcher.HandleReloadCorrectionsCache;
 
             _logger.LogDebug("Menu handler events wired up successfully");
         }

--- a/src/VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/VirtualAssistantDBusMenuHandler.cs
@@ -31,6 +31,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
     private readonly Action<bool> _ttsMuteToggleHandler;
     private readonly Action _mercuryBillingHandler;
     private readonly Action<bool> _streamingTranscriptionHandler;
+    private readonly Action _reloadCorrectionsCacheHandler;
 
     /// <summary>
     /// Event fired when user selects Quit from the menu.
@@ -82,6 +83,11 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
     /// </summary>
     public event Action? OnMercuryBillingRequested;
 
+    /// <summary>
+    /// Event fired when user clicks "Obnovit cache" for transcription corrections.
+    /// </summary>
+    public event Action? OnReloadCorrectionsCacheRequested;
+
     public VirtualAssistantDBusMenuHandler(
         ILogger<VirtualAssistantDBusMenuHandler> logger,
         IMenuStateManager stateManager,
@@ -110,6 +116,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
         _ttsMuteToggleHandler = (muted) => OnTtsMuteToggleRequested?.Invoke(muted);
         _mercuryBillingHandler = () => OnMercuryBillingRequested?.Invoke();
         _streamingTranscriptionHandler = (enabled) => OnStreamingTranscriptionToggled?.Invoke(enabled);
+        _reloadCorrectionsCacheHandler = () => OnReloadCorrectionsCacheRequested?.Invoke();
 
         // Subscribe to state changes to emit layout updates
         _stateManager.StateChanged += OnStateChanged;
@@ -125,6 +132,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
         _eventRouter.OnTtsMuteToggleRequested += _ttsMuteToggleHandler;
         _eventRouter.OnMercuryBillingRequested += _mercuryBillingHandler;
         _eventRouter.OnStreamingTranscriptionToggled += _streamingTranscriptionHandler;
+        _eventRouter.OnReloadCorrectionsCacheRequested += _reloadCorrectionsCacheHandler;
     }
 
     public override Connection Connection => _connection ?? throw new InvalidOperationException("Connection not set. Call RegisterWithDbus first.");
@@ -335,6 +343,7 @@ internal class VirtualAssistantDBusMenuHandler : ComCanonicalDbusmenuHandler, Sy
         _eventRouter.OnTtsMuteToggleRequested -= _ttsMuteToggleHandler;
         _eventRouter.OnMercuryBillingRequested -= _mercuryBillingHandler;
         _eventRouter.OnStreamingTranscriptionToggled -= _streamingTranscriptionHandler;
+        _eventRouter.OnReloadCorrectionsCacheRequested -= _reloadCorrectionsCacheHandler;
     }
 
     protected override ValueTask<bool> OnAboutToShowAsync(Message request, int id)

--- a/src/VirtualAssistant.Voice/Filters/DatabaseCorrectionFilterStrategy.cs
+++ b/src/VirtualAssistant.Voice/Filters/DatabaseCorrectionFilterStrategy.cs
@@ -5,7 +5,9 @@ namespace Olbrasoft.VirtualAssistant.Voice.Filters;
 
 /// <summary>
 /// Filter strategy that applies database-driven text corrections with priority ordering.
-/// Corrections are cached for 5 minutes for performance.
+/// Corrections are cached for 1 hour for performance; use <see cref="InvalidateCache"/>
+/// (wired to the tray menu) to force a reload after inserting a new row into the
+/// <c>transcription_corrections</c> table.
 /// </summary>
 public class DatabaseCorrectionFilterStrategy : ITextFilterStrategy
 {
@@ -15,7 +17,10 @@ public class DatabaseCorrectionFilterStrategy : ITextFilterStrategy
     // Database corrections cache
     private IReadOnlyList<TranscriptionCorrection> _cachedCorrections = Array.Empty<TranscriptionCorrection>();
     private DateTime _cacheExpiry = DateTime.MinValue;
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+    // 1 hour: with a tray-menu "Obnovit cache" button available, a short polling TTL
+    // is no longer the primary path for picking up new rows. Manual invalidation is
+    // instant; the periodic refresh is just a safety net.
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
     private readonly object _lock = new();
 
     public DatabaseCorrectionFilterStrategy(
@@ -144,6 +149,22 @@ public class DatabaseCorrectionFilterStrategy : ITextFilterStrategy
         {
             _logger.LogError(ex, "Failed to warm corrections cache");
         }
+    }
+
+    /// <summary>
+    /// Forces the cache to be reloaded on the next <see cref="Apply"/> call.
+    /// Intended for a tray-menu action so a freshly INSERTed row in
+    /// <c>transcription_corrections</c> takes effect on the very next dictation
+    /// without waiting for the periodic refresh or restarting the service.
+    /// Safe to call from any thread.
+    /// </summary>
+    public void InvalidateCache()
+    {
+        lock (_lock)
+        {
+            _cacheExpiry = DateTime.MinValue;
+        }
+        _logger.LogInformation("Transcription corrections cache invalidated; next Apply will reload from DB");
     }
 
     /// <summary>

--- a/src/VirtualAssistant.Voice/Filters/DatabaseCorrectionFilterStrategy.cs
+++ b/src/VirtualAssistant.Voice/Filters/DatabaseCorrectionFilterStrategy.cs
@@ -19,8 +19,9 @@ public class DatabaseCorrectionFilterStrategy : ITextFilterStrategy
     private DateTime _cacheExpiry = DateTime.MinValue;
     // 1 hour: with a tray-menu "Obnovit cache" button available, a short polling TTL
     // is no longer the primary path for picking up new rows. Manual invalidation is
-    // instant; the periodic refresh is just a safety net.
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+    // instant; the periodic refresh is just a safety net. Exposed so the warm-up
+    // background service can derive its refresh interval from this single source.
+    public static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
     private readonly object _lock = new();
 
     public DatabaseCorrectionFilterStrategy(
@@ -80,19 +81,20 @@ public class DatabaseCorrectionFilterStrategy : ITextFilterStrategy
     }
 
     /// <summary>
-    /// Refreshes the database corrections cache if expired.
+    /// Refreshes the database corrections cache if expired. Always acquires
+    /// <see cref="_lock"/> before reading <see cref="_cacheExpiry"/>; the previous
+    /// un-synchronized fast-path read could legally observe a stale expiry after
+    /// <see cref="InvalidateCache"/> was called from another thread, defeating the
+    /// "next dictation" guarantee. The lock is cheap in practice — Apply is only
+    /// called on the dictation pipeline, not in any hot loop.
     /// </summary>
     private void RefreshCorrectionsCache()
     {
         if (_repository == null)
             return;
 
-        if (DateTime.UtcNow < _cacheExpiry)
-            return;
-
         lock (_lock)
         {
-            // Double-check after acquiring lock
             if (DateTime.UtcNow < _cacheExpiry)
                 return;
 

--- a/src/VirtualAssistant.Voice/Services/DatabaseCorrectionCacheWarmupService.cs
+++ b/src/VirtualAssistant.Voice/Services/DatabaseCorrectionCacheWarmupService.cs
@@ -10,15 +10,16 @@ namespace Olbrasoft.VirtualAssistant.Voice.Services;
 /// Quick Dictation hot path always finds a fresh in-memory cache and
 /// never has to wait for a synchronous DB round-trip.
 ///
-/// The strategy's internal cache has a 5-minute TTL. Without warm-up,
-/// the very first transcription after startup (or after every 5 minutes
-/// of idle) would block on a synchronous EF Core call inside the audio
-/// pipeline. This service refreshes every 4 minutes — under the TTL —
-/// so the cache is always served from RAM.
+/// The refresh interval is derived from <see cref="DatabaseCorrectionFilterStrategy.CacheDuration"/>
+/// with a 5-minute safety margin, so the warm-up always completes before the
+/// underlying cache expires. If the strategy's TTL changes (e.g. the tray-menu
+/// "Obnovit cache" button lets us relax the polling), this service follows
+/// automatically.
 /// </summary>
 public class DatabaseCorrectionCacheWarmupService : BackgroundService
 {
-    private static readonly TimeSpan RefreshInterval = TimeSpan.FromMinutes(4);
+    private static readonly TimeSpan RefreshInterval =
+        DatabaseCorrectionFilterStrategy.CacheDuration - TimeSpan.FromMinutes(5);
 
     private readonly DatabaseCorrectionFilterStrategy _strategy;
     private readonly ILogger<DatabaseCorrectionCacheWarmupService> _logger;

--- a/tests/VirtualAssistant.Service.Tests/Tray/MenuEventDispatcherTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/MenuEventDispatcherTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Data.Entities;
 using Olbrasoft.VirtualAssistant.Service.Tray;
+using Olbrasoft.VirtualAssistant.Voice.Filters;
 using Olbrasoft.VirtualAssistant.Voice.Services;
 
 namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray;
@@ -455,6 +457,54 @@ public class MenuEventDispatcherTests
 
         // Assert - Should not throw, but should log error
         _dictationControlMock.Verify(x => x.SetDictationEnabled(true), Times.Once);
+    }
+
+    #endregion
+
+    #region HandleReloadCorrectionsCache Tests
+
+    [Fact]
+    public void HandleReloadCorrectionsCache_WithoutFilter_LogsWarningDoesNotThrow()
+    {
+        // correctionFilter omitted — the tray should not crash if the Voice layer
+        // decided to disable DB corrections (repository: null construction).
+        var sut = new MenuEventDispatcher(
+            _loggerMock.Object,
+            _muteServiceMock.Object,
+            _settingsServiceMock.Object,
+            DashboardBaseUrl,
+            correctionFilter: null);
+
+        var ex = Record.Exception(() => sut.HandleReloadCorrectionsCache());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void HandleReloadCorrectionsCache_WithFilter_ForcesNextApplyToReloadFromRepository()
+    {
+        // Verifies the contract the tray button was built for: after a click, the
+        // very next Apply() calls the repository, picking up newly INSERTed rows.
+        var repo = new Mock<ITranscriptionCorrectionRepository>();
+        repo.Setup(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TranscriptionCorrection>());
+
+        var filter = new DatabaseCorrectionFilterStrategy(
+            Mock.Of<ILogger<DatabaseCorrectionFilterStrategy>>(),
+            repo.Object);
+
+        var sut = new MenuEventDispatcher(
+            _loggerMock.Object,
+            _muteServiceMock.Object,
+            _settingsServiceMock.Object,
+            DashboardBaseUrl,
+            correctionFilter: filter);
+
+        filter.Apply("warm cache");
+        sut.HandleReloadCorrectionsCache();
+        filter.Apply("trigger reload");
+
+        repo.Verify(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     #endregion

--- a/tests/VirtualAssistant.Service.Tests/Tray/MenuEventRouterTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/MenuEventRouterTests.cs
@@ -201,6 +201,21 @@ public class MenuEventRouterTests
 
     #endregion
 
+    #region HandleMenuEvent - ReloadCorrectionsCache
+
+    [Fact]
+    public void HandleMenuEvent_ReloadCorrectionsCacheClicked_FiresOnReloadCorrectionsCacheRequested()
+    {
+        var eventFired = false;
+        _router.OnReloadCorrectionsCacheRequested += () => eventFired = true;
+
+        _router.HandleMenuEvent(MenuItemIds.ReloadCorrectionsCacheId, "clicked");
+
+        Assert.True(eventFired);
+    }
+
+    #endregion
+
     #region HandleMenuEvent - DictationToggle
 
     [Fact]

--- a/tests/VirtualAssistant.Voice.Tests/Filters/DatabaseCorrectionFilterStrategyInvalidateCacheTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Filters/DatabaseCorrectionFilterStrategyInvalidateCacheTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Data.Entities;
+using Olbrasoft.VirtualAssistant.Voice.Filters;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Tests.Filters;
+
+/// <summary>
+/// Verifies that <see cref="DatabaseCorrectionFilterStrategy.InvalidateCache"/>
+/// forces the next <c>Apply</c> to reload corrections from the repository,
+/// which is the contract the tray-menu "Obnovit cache" button depends on.
+/// </summary>
+public class DatabaseCorrectionFilterStrategyInvalidateCacheTests
+{
+    private static DatabaseCorrectionFilterStrategy CreateStrategy(Mock<ITranscriptionCorrectionRepository> repo)
+    {
+        return new DatabaseCorrectionFilterStrategy(
+            Mock.Of<ILogger<DatabaseCorrectionFilterStrategy>>(),
+            repo.Object);
+    }
+
+    private static TranscriptionCorrection BuildCorrection(int id, string incorrect, string correct)
+    {
+        return new TranscriptionCorrection
+        {
+            Id = id,
+            IncorrectText = incorrect,
+            CorrectText = correct,
+            CaseSensitive = false,
+            Priority = 90,
+            IsActive = true
+        };
+    }
+
+    [Fact]
+    public void Apply_CachesAfterFirstCall_DoesNotRefetchOnSecondCall()
+    {
+        // Baseline: without invalidation, cache is sticky. This pins the behavior
+        // so a later test showing the opposite is meaningful.
+        var repo = new Mock<ITranscriptionCorrectionRepository>();
+        repo.Setup(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { BuildCorrection(1, "foo", "bar") });
+
+        var strategy = CreateStrategy(repo);
+
+        strategy.Apply("x");
+        strategy.Apply("y");
+
+        repo.Verify(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void InvalidateCache_ForcesNextApplyToReloadFromRepository()
+    {
+        // Full contract: Apply once → cached; Invalidate → next Apply re-queries.
+        var repo = new Mock<ITranscriptionCorrectionRepository>();
+        repo.Setup(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { BuildCorrection(1, "foo", "bar") });
+
+        var strategy = CreateStrategy(repo);
+
+        strategy.Apply("x");
+        strategy.InvalidateCache();
+        strategy.Apply("y");
+
+        repo.Verify(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void InvalidateCache_NextApplyUsesFreshlyInsertedCorrection()
+    {
+        // Simulates the real flow: user INSERTs a row, clicks the tray button,
+        // the very next dictation already applies the new correction. The mock
+        // returns an empty set first, then a non-empty set after invalidation.
+        var firstCall = true;
+        var repo = new Mock<ITranscriptionCorrectionRepository>();
+        repo.Setup(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                if (firstCall)
+                {
+                    firstCall = false;
+                    return Array.Empty<TranscriptionCorrection>();
+                }
+                return new[] { BuildCorrection(1, "PlayWrite", "Playwright") };
+            });
+
+        var strategy = CreateStrategy(repo);
+
+        var before = strategy.Apply("I use PlayWrite daily");
+        strategy.InvalidateCache();
+        var after = strategy.Apply("I use PlayWrite daily");
+
+        Assert.Equal("I use PlayWrite daily", before);
+        Assert.Equal("I use Playwright daily", after);
+    }
+}


### PR DESCRIPTION
<!-- claude-session: 25850b5b-12aa-4e47-9047-5684d57a52a0 -->

Closes #957

## Summary
Adds a tray-menu action that **invalidates the transcription corrections cache** so a freshly `INSERT`ed row in `transcription_corrections` takes effect on the very next dictation. With manual invalidation available, the periodic TTL is bumped from **5 minutes → 1 hour** (the short TTL only existed as a polling mechanism to pick up new rules reasonably soon).

No behavioral change to the existing "LLM Prompts (synced)" item.

## Files touched
- `DatabaseCorrectionFilterStrategy`: `CacheDuration` bumped, new `InvalidateCache()` public method (resets `_cacheExpiry` under the existing lock).
- Menu infrastructure: new `ReloadCorrectionsCacheId`, new menu item placed directly below LLM Prompts, new event `OnReloadCorrectionsCacheRequested` through `MenuEventRouter` → `VirtualAssistantDBusMenuHandler` → `TrayCoordinatorService` → `MenuEventDispatcher.HandleReloadCorrectionsCache`.
- DI: `TrayServicesExtensions` injects the singleton `DatabaseCorrectionFilterStrategy` into the dispatcher.

## Test plan
- [x] `dotnet build` clean, 0 errors
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — all green including 3 new `DatabaseCorrectionFilterStrategyInvalidateCacheTests`
- [ ] After deploy: open tray menu, click "🔄 Opravy transkripce - Obnovit cache", verify log line `Transcription corrections cache invalidated` appears
- [ ] INSERT a row manually into `transcription_corrections`, click the menu item, dictate — new rule should apply without restart