### PR TITLE
fix(deploy): prepend ~/.cargo/bin to PATH so ghnotify is findable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,9 +191,17 @@ jobs:
           else
             WAKE_PROMPT="ghnotify deploy-failure: repo=${GITHUB_REPOSITORY} status=${{ job.status }} commit=${COMMIT_SHA} failed_step=${FAILED_STEP:-unknown} run_url=${RUN_URL} | next: deploy FAILED (job.status=${{ job.status }}${FAILED_STEP:+, failed step: $FAILED_STEP}). Read the run logs at ${RUN_URL}, diagnose, fix on main or a hotfix branch, push. Service may still be serving the previous build — verify http://localhost:5055/health before trusting the current state."
           fi
+          # GitHub Actions on self-hosted runners inherit a minimal PATH
+          # that does NOT include `~/.cargo/bin` where `cargo install` puts
+          # the ghnotify binary. Prepend the common install locations so
+          # `command -v ghnotify` can actually find it; the `command -v`
+          # lookup honors the current process PATH only, so exporting here
+          # (rather than trying to source ~/.bashrc — unreliable under
+          # non-interactive runners) is the robust approach.
+          export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
           if command -v ghnotify > /dev/null 2>&1; then
             ghnotify send --repo "$GITHUB_REPOSITORY" --prompt "$WAKE_PROMPT" || \
               echo "ghnotify send failed; wake not delivered" >&2
           else
-            echo "ghnotify CLI not found on PATH — install via 'cargo install --path /home/jirka/Olbrasoft/ghnotify'" >&2
+            echo "ghnotify CLI not found on PATH (looked in: $PATH) — install via 'cargo install --path /home/jirka/Olbrasoft/ghnotify'" >&2
           fi


### PR DESCRIPTION
<!-- claude-session: e143e465-2e2a-41b6-9e08-4a4e73434d7e -->

Follow-up to #962. The ghnotify-send wake path was never actually exercised end-to-end by #962 because the very first run of the updated Notify step (Deploy VirtualAssistant run #379 for commit `167089c6`) logged:

```
Deploy event written to …/Olbrasoft-VirtualAssistant-deploy-167089c-24577048988-1.json
ghnotify CLI not found on PATH — install via 'cargo install --path /home/jirka/Olbrasoft/ghnotify'
```

so no wake was delivered and the WS8 Claude session sat idle after merge waiting for a deploy-complete signal that would never come — exactly the pre-#962 behaviour.

## Root cause

GitHub Actions on a self-hosted runner inherits a minimal PATH (typically `/usr/local/bin:/usr/bin:/bin:…`), which does NOT include `~/.cargo/bin` where `cargo install --path .` installs the ghnotify binary. My interactive shell has the cargo dir on PATH because it's set by `.bashrc` / `.profile`; the non-interactive runner environment does not source either.

## Fix

Prepend `$HOME/.cargo/bin:$HOME/.local/bin` to PATH at the top of the wake block.

- `$HOME/.cargo/bin` is where `cargo install` places binaries (primary).
- `$HOME/.local/bin` covers user-local CLI installs from other toolchains (defensive; cheap to add, no downside).

The existing `command -v ghnotify` guard remains the single gate — it just now has a PATH that can actually find the binary.

I also improved the error message so future misconfigurations self-diagnose: the `not found` branch now logs the effective PATH it searched, which would have let us spot this in the run #379 logs immediately instead of needing to cross-reference against the runner's actual env.

## Alternatives considered

- **Hard-code `/home/jirka/.cargo/bin/ghnotify`** — works, but leaks machine-specific paths into a committed workflow; anyone else running the same deploy (or future me after a home dir move) would have to edit the file.
- **Source `~/.bashrc`** — non-interactive shells explicitly skip that file in Bash; even if they didn't, `~/.bashrc` often contains interactive-only setup (aliases, PS1 manipulation) that would break `set -e` deploys.
- **Install ghnotify to `/usr/local/bin`** — possible but out of scope here; the local `cargo install` workflow is what the ghnotify repo README recommends.

The chosen approach keeps all ghnotify installs via `cargo` and makes the workflow self-sufficient about locating them.

## Test plan
- [ ] After merge, the next push to main dispatches Deploy VirtualAssistant; the Notify step should succeed with no "not found" error and the claude-VirtualAssistant tmux session should receive an actual `ghnotify deploy-complete: …` wake prompt. End-to-end validation.
- [x] Local smoke: `env -i PATH=/usr/bin:/bin bash -c 'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"; command -v ghnotify'` resolves to `/home/jirka/.cargo/bin/ghnotify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)