### PR TITLE
fix(detection): detect Claude/OpenCode/Gemini via tmux session name

### DIFF
--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -28,43 +28,28 @@ public class TerminalCliAppDetector : ICliAppDetector
     internal static readonly TimeSpan CacheStaleness = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// Known CLI applications to detect, mapped to their prompt configurations.
-    /// Key: process name pattern, Value: (AppName, PromptFileName)
+    /// A CLI agent we know how to detect, plus everything the three detection
+    /// strategies need: the process name we'd find in the terminal's descendants,
+    /// the substrings the TUI sets in the terminal title, and the prefix the
+    /// user's tmux wrapper gives to sessions it spawns for this agent. Keeping
+    /// these together means adding a new agent is a one-line change — there's
+    /// no risk of the three detection paths drifting out of sync.
     /// </summary>
-    private static readonly Dictionary<string, (string AppName, string PromptFileName)> KnownCliApps = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["claude"] = ("Claude Code", "ClaudeCodeCorrection"),
-        ["opencode"] = ("OpenCode", "OpenCodeCorrection"),
-        ["gemini"] = ("Gemini CLI", "GeminiCorrection")
-    };
+    private sealed record KnownAgent(
+        string AppName,
+        string PromptFileName,
+        string ProcessName,
+        string[] TitleMarkers,
+        string TmuxSessionPrefix);
 
-    /// <summary>
-    /// Title-based fallback for when process-tree detection fails (e.g. claude
-    /// runs inside tmux, whose server is a systemd daemon and not a descendant
-    /// of the focused terminal). Matches on substrings in the terminal window
-    /// title that the TUI agent sets itself.
-    /// </summary>
-    private static readonly (string TitleMarker, string AppName, string PromptFileName)[] TitleMarkers =
+    private static readonly KnownAgent[] KnownAgents =
     {
-        ("Claude Code", "Claude Code", "ClaudeCodeCorrection"),
-        ("OpenCode", "OpenCode", "OpenCodeCorrection"),
-        ("OC |", "OpenCode", "OpenCodeCorrection"),
-        ("Gemini", "Gemini CLI", "GeminiCorrection")
-    };
-
-    /// <summary>
-    /// tmux session-name fallback for when the CLI app runs under the user's
-    /// tmux wrapper (bashrc names sessions <c>claude-&lt;repo&gt;-&lt;tty&gt;</c>,
-    /// <c>opencode-…</c> etc.). The tmux server is a systemd daemon so claude
-    /// is never a descendant of the focused terminal; the tmux *client*
-    /// however is, and tmux can tell us which session that client is attached
-    /// to. We look at the session name prefix to identify the CLI agent.
-    /// </summary>
-    private static readonly (string Prefix, string AppName, string PromptFileName)[] TmuxSessionPrefixes =
-    {
-        ("claude-", "Claude Code", "ClaudeCodeCorrection"),
-        ("opencode-", "OpenCode", "OpenCodeCorrection"),
-        ("gemini-", "Gemini CLI", "GeminiCorrection")
+        new("Claude Code", "ClaudeCodeCorrection", "claude",
+            new[] { "Claude Code" }, "claude-"),
+        new("OpenCode", "OpenCodeCorrection", "opencode",
+            new[] { "OpenCode", "OC |" }, "opencode-"),
+        new("Gemini CLI", "GeminiCorrection", "gemini",
+            new[] { "Gemini" }, "gemini-")
     };
 
     /// <summary>
@@ -116,13 +101,13 @@ public class TerminalCliAppDetector : ICliAppDetector
                 descendantPids.Count, focusedWindow.Value.Pid);
 
             // Check if any known CLI app is among descendants
-            foreach (var (processName, (appName, promptFileName)) in KnownCliApps)
+            foreach (var agent in KnownAgents)
             {
-                if (await IsProcessAmongPidsAsync(processName, descendantPids, cancellationToken))
+                if (await IsProcessAmongPidsAsync(agent.ProcessName, descendantPids, cancellationToken))
                 {
                     _logger.LogInformation("Detected CLI app in terminal: {AppName} (process: {ProcessName})",
-                        appName, processName);
-                    return CacheAndReturn(new CliAppDetectionResult(appName, promptFileName));
+                        agent.AppName, agent.ProcessName);
+                    return CacheAndReturn(new CliAppDetectionResult(agent.AppName, agent.PromptFileName));
                 }
             }
 
@@ -132,14 +117,17 @@ public class TerminalCliAppDetector : ICliAppDetector
             // terminal window title — TUI agents set it themselves (e.g.
             // "Claude Code", "OC | ...").
             var title = focusedWindow.Value.Title ?? "";
-            foreach (var (titleMarker, appName, promptFileName) in TitleMarkers)
+            foreach (var agent in KnownAgents)
             {
-                if (title.Contains(titleMarker, StringComparison.OrdinalIgnoreCase))
+                foreach (var marker in agent.TitleMarkers)
                 {
-                    _logger.LogInformation(
-                        "Detected CLI app by terminal title: {AppName} (title: '{Title}')",
-                        appName, title);
-                    return CacheAndReturn(new CliAppDetectionResult(appName, promptFileName));
+                    if (title.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogInformation(
+                            "Detected CLI app by terminal title: {AppName} (title: '{Title}')",
+                            agent.AppName, title);
+                        return CacheAndReturn(new CliAppDetectionResult(agent.AppName, agent.PromptFileName));
+                    }
                 }
             }
 
@@ -404,16 +392,16 @@ public class TerminalCliAppDetector : ICliAppDetector
     }
 
     /// <summary>
-    /// Matches a tmux session name against <see cref="TmuxSessionPrefixes"/> and
-    /// returns the CLI-app detection result if the prefix is known, otherwise null.
+    /// Matches a tmux session name against the known-agent prefixes and returns
+    /// the CLI-app detection result if the prefix is known, otherwise null.
     /// </summary>
     internal static CliAppDetectionResult? MatchTmuxSessionName(string sessionName)
     {
-        foreach (var (prefix, appName, promptFileName) in TmuxSessionPrefixes)
+        foreach (var agent in KnownAgents)
         {
-            if (sessionName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            if (sessionName.StartsWith(agent.TmuxSessionPrefix, StringComparison.OrdinalIgnoreCase))
             {
-                return new CliAppDetectionResult(appName, promptFileName);
+                return new CliAppDetectionResult(agent.AppName, agent.PromptFileName);
             }
         }
         return null;
@@ -432,7 +420,7 @@ public class TerminalCliAppDetector : ICliAppDetector
 
         try
         {
-            var process = new Process
+            using var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
@@ -446,34 +434,53 @@ public class TerminalCliAppDetector : ICliAppDetector
             };
 
             process.Start();
-            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
-
-            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+            try
             {
-                _logger.LogDebug("tmux list-clients returned no data (exit {ExitCode})", process.ExitCode);
+                var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+                await process.WaitForExitAsync(cancellationToken);
+
+                if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+                {
+                    _logger.LogDebug("tmux list-clients returned no data (exit {ExitCode})", process.ExitCode);
+                    return null;
+                }
+
+                // Iterate the (small) client list and probe the descendant set
+                // instead of the other way round — a long-running terminal can
+                // accumulate hundreds of descendants while `tmux list-clients`
+                // is at most one row per attached terminal.
+                var clients = ParseTmuxClients(output);
+                foreach (var (clientPid, sessionName) in clients)
+                {
+                    if (!descendantPids.Contains(clientPid))
+                    {
+                        continue;
+                    }
+
+                    var match = MatchTmuxSessionName(sessionName);
+                    if (match != null)
+                    {
+                        _logger.LogInformation(
+                            "Detected CLI app via tmux session '{Session}' (client PID {Pid}): {AppName}",
+                            sessionName, clientPid, match.AppName);
+                        return match;
+                    }
+                }
+
                 return null;
             }
-
-            var clients = ParseTmuxClients(output);
-            foreach (var pid in descendantPids)
+            catch (OperationCanceledException)
             {
-                if (!clients.TryGetValue(pid, out var sessionName))
-                {
-                    continue;
-                }
-
-                var match = MatchTmuxSessionName(sessionName);
-                if (match != null)
-                {
-                    _logger.LogInformation(
-                        "Detected CLI app via tmux session '{Session}' (client PID {Pid}): {AppName}",
-                        sessionName, pid, match.AppName);
-                    return match;
-                }
+                // Caller cancelled mid-probe. Kill the tmux child so it can't
+                // outlive the detection call and leak into ps output. Swallow
+                // kill errors — the process may already have exited.
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
             }
-
-            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -53,6 +53,21 @@ public class TerminalCliAppDetector : ICliAppDetector
     };
 
     /// <summary>
+    /// tmux session-name fallback for when the CLI app runs under the user's
+    /// tmux wrapper (bashrc names sessions <c>claude-&lt;repo&gt;-&lt;tty&gt;</c>,
+    /// <c>opencode-…</c> etc.). The tmux server is a systemd daemon so claude
+    /// is never a descendant of the focused terminal; the tmux *client*
+    /// however is, and tmux can tell us which session that client is attached
+    /// to. We look at the session name prefix to identify the CLI agent.
+    /// </summary>
+    private static readonly (string Prefix, string AppName, string PromptFileName)[] TmuxSessionPrefixes =
+    {
+        ("claude-", "Claude Code", "ClaudeCodeCorrection"),
+        ("opencode-", "OpenCode", "OpenCodeCorrection"),
+        ("gemini-", "Gemini CLI", "GeminiCorrection")
+    };
+
+    /// <summary>
     /// Terminal window classes that we know how to detect CLI apps in.
     /// </summary>
     private static readonly HashSet<string> TerminalClasses = new(StringComparer.OrdinalIgnoreCase)
@@ -128,7 +143,18 @@ public class TerminalCliAppDetector : ICliAppDetector
                 }
             }
 
-            _logger.LogDebug("No known CLI apps detected in terminal descendants or title");
+            // Last fallback: the user's bashrc wrapper runs `tmux new-session -s
+            // claude-<repo>-<tty> -- claude "$@"`, so the tmux *client* is in the
+            // terminal's descendants but the claude process lives under the tmux
+            // server (systemd-scoped, not in the process tree). Ask tmux which
+            // session that client is attached to and match the session name prefix.
+            var cliAppFromTmux = await DetectCliAppViaTmuxAsync(descendantPids, cancellationToken);
+            if (cliAppFromTmux != null)
+            {
+                return CacheAndReturn(cliAppFromTmux);
+            }
+
+            _logger.LogDebug("No known CLI apps detected in terminal descendants, title or tmux sessions");
             // Confirmed terminal without any known CLI app (e.g. plain bash): same
             // invalidation reason as the non-terminal branch.
             ClearCache();
@@ -338,6 +364,122 @@ public class TerminalCliAppDetector : ICliAppDetector
         }
 
         return children;
+    }
+
+    /// <summary>
+    /// Parses the output of <c>tmux list-clients -F "#{client_pid}:#{session_name}"</c>
+    /// into a map of client PID → session name. Blank and malformed lines are
+    /// skipped. Session names may contain colons so we split on the first ':' only.
+    /// </summary>
+    internal static Dictionary<int, string> ParseTmuxClients(string? output)
+    {
+        var map = new Dictionary<int, string>();
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return map;
+        }
+
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = line.Trim();
+            var separator = trimmed.IndexOf(':');
+            if (separator <= 0 || separator == trimmed.Length - 1)
+            {
+                continue;
+            }
+
+            if (!int.TryParse(trimmed[..separator], out var pid))
+            {
+                continue;
+            }
+
+            var session = trimmed[(separator + 1)..];
+            if (!string.IsNullOrEmpty(session))
+            {
+                map[pid] = session;
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Matches a tmux session name against <see cref="TmuxSessionPrefixes"/> and
+    /// returns the CLI-app detection result if the prefix is known, otherwise null.
+    /// </summary>
+    internal static CliAppDetectionResult? MatchTmuxSessionName(string sessionName)
+    {
+        foreach (var (prefix, appName, promptFileName) in TmuxSessionPrefixes)
+        {
+            if (sessionName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return new CliAppDetectionResult(appName, promptFileName);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Runs <c>tmux list-clients</c> and returns the first descendant PID's
+    /// session whose name matches a known CLI-agent prefix.
+    /// </summary>
+    private async Task<CliAppDetectionResult?> DetectCliAppViaTmuxAsync(HashSet<int> descendantPids, CancellationToken cancellationToken)
+    {
+        if (descendantPids.Count == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "tmux",
+                    Arguments = "list-clients -F \"#{client_pid}:#{session_name}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+
+            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+            {
+                _logger.LogDebug("tmux list-clients returned no data (exit {ExitCode})", process.ExitCode);
+                return null;
+            }
+
+            var clients = ParseTmuxClients(output);
+            foreach (var pid in descendantPids)
+            {
+                if (!clients.TryGetValue(pid, out var sessionName))
+                {
+                    continue;
+                }
+
+                var match = MatchTmuxSessionName(sessionName);
+                if (match != null)
+                {
+                    _logger.LogInformation(
+                        "Detected CLI app via tmux session '{Session}' (client PID {Pid}): {AppName}",
+                        sessionName, pid, match.AppName);
+                    return match;
+                }
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to query tmux clients for CLI app detection");
+            return null;
+        }
     }
 
     /// <summary>

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalCliAppDetectorTmuxTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalCliAppDetectorTmuxTests.cs
@@ -1,0 +1,112 @@
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
+
+/// <summary>
+/// Covers the pure helpers that back the tmux-session fallback for
+/// <see cref="TerminalCliAppDetector"/>. The full process-invoking path is
+/// tested manually; the parser and prefix matcher are the interesting bits
+/// because the bashrc wrapper's session naming (<c>claude-&lt;repo&gt;-&lt;tty&gt;</c>)
+/// is what lets us detect claude inside tmux at all.
+/// </summary>
+public class TerminalCliAppDetectorTmuxTests
+{
+    [Fact]
+    public void ParseTmuxClients_EmptyOrNull_ReturnsEmptyMap()
+    {
+        Assert.Empty(TerminalCliAppDetector.ParseTmuxClients(null));
+        Assert.Empty(TerminalCliAppDetector.ParseTmuxClients(""));
+        Assert.Empty(TerminalCliAppDetector.ParseTmuxClients("   \n  "));
+    }
+
+    [Fact]
+    public void ParseTmuxClients_ThreeClientsRealOutput_ParsesAll()
+    {
+        var output = "78600:claude-VirtualAssistant\n98159:claude-vercel-pts-2\n106024:claude-streamtape-pts-3\n";
+
+        var map = TerminalCliAppDetector.ParseTmuxClients(output);
+
+        Assert.Equal(3, map.Count);
+        Assert.Equal("claude-VirtualAssistant", map[78600]);
+        Assert.Equal("claude-vercel-pts-2", map[98159]);
+        Assert.Equal("claude-streamtape-pts-3", map[106024]);
+    }
+
+    [Fact]
+    public void ParseTmuxClients_SkipsMalformedLines()
+    {
+        var output = "12345:valid-session\nnot-a-pid:whatever\n:missing-pid\nnocolon-line\n67890:\n";
+
+        var map = TerminalCliAppDetector.ParseTmuxClients(output);
+
+        Assert.Single(map);
+        Assert.Equal("valid-session", map[12345]);
+    }
+
+    [Fact]
+    public void ParseTmuxClients_SessionNameWithColon_PreservedAfterFirstSplit()
+    {
+        // Split on first ':' only so session names containing colons still parse.
+        var output = "1001:weird:session:name\n";
+
+        var map = TerminalCliAppDetector.ParseTmuxClients(output);
+
+        Assert.Equal("weird:session:name", map[1001]);
+    }
+
+    [Fact]
+    public void MatchTmuxSessionName_ClaudePrefix_ReturnsClaudeCode()
+    {
+        var result = TerminalCliAppDetector.MatchTmuxSessionName("claude-VirtualAssistant-pts-0");
+
+        Assert.NotNull(result);
+        Assert.Equal("Claude Code", result!.AppName);
+        Assert.Equal("ClaudeCodeCorrection", result.PromptFileName);
+    }
+
+    [Fact]
+    public void MatchTmuxSessionName_OpenCodePrefix_ReturnsOpenCode()
+    {
+        var result = TerminalCliAppDetector.MatchTmuxSessionName("opencode-repo");
+
+        Assert.NotNull(result);
+        Assert.Equal("OpenCode", result!.AppName);
+    }
+
+    [Fact]
+    public void MatchTmuxSessionName_GeminiPrefix_ReturnsGeminiCli()
+    {
+        var result = TerminalCliAppDetector.MatchTmuxSessionName("gemini-foo");
+
+        Assert.NotNull(result);
+        Assert.Equal("Gemini CLI", result!.AppName);
+    }
+
+    [Fact]
+    public void MatchTmuxSessionName_PrefixMatchIsCaseInsensitive()
+    {
+        // Session names come from tmux verbatim, but treat the match as case-
+        // insensitive so a user who names a session "Claude-foo" still wins.
+        var result = TerminalCliAppDetector.MatchTmuxSessionName("Claude-Foo");
+
+        Assert.NotNull(result);
+        Assert.Equal("Claude Code", result!.AppName);
+    }
+
+    [Fact]
+    public void MatchTmuxSessionName_UnknownPrefix_ReturnsNull()
+    {
+        Assert.Null(TerminalCliAppDetector.MatchTmuxSessionName("work"));
+        Assert.Null(TerminalCliAppDetector.MatchTmuxSessionName("main"));
+        Assert.Null(TerminalCliAppDetector.MatchTmuxSessionName(""));
+    }
+
+    [Fact]
+    public void MatchTmuxSessionName_PrefixMustBeAtStart_NotSubstring()
+    {
+        // "my-claude-session" contains "claude-" but not at the start — we
+        // require the prefix so that the bashrc wrapper's naming stays the
+        // single source of truth.
+        Assert.Null(TerminalCliAppDetector.MatchTmuxSessionName("my-claude-session"));
+    }
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

## Summary
- Desktop Monitor stopped recognizing Claude Code after switching to the bashrc tmux wrapper (sessions named `claude-<repo>-<tty>`). The tmux server is a systemd daemon, so claude is never a descendant of the focused terminal, and tmux does not propagate inner window titles to the outer terminal → both existing fallbacks in `TerminalCliAppDetector` (process-tree and title-marker) silently miss, leaving the UI showing `/bin/bash` / `Default` and pushing a generic paste shortcut + correction prompt.
- Added a third fallback: `tmux list-clients -F "#{client_pid}:#{session_name}"` → map a descendant PID of the focused terminal to its attached session → match the session-name prefix (`claude-`, `opencode-`, `gemini-`) to an agent. The parser and prefix matcher are `internal static` helpers so they get clean unit-test coverage without invoking processes.

## Test plan
- [x] `dotnet build -c Release` (clean, 0 errors)
- [x] `dotnet test -c Release --filter "FullyQualifiedName!~IntegrationTests"` — all 856 unit tests pass, including 10 new tests in `TerminalCliAppDetectorTmuxTests`
- [ ] After deploy: open a terminator running `claude` (via the bashrc wrapper), open `http://localhost:5055/Admin/DesktopMonitor`, confirm `ACTIVE APPLICATION: Claude Code` and `CORRECTION PROMPT: ClaudeCodeCorrection`
- [ ] Confirm dictation in the terminal uses Ctrl+Shift+V paste (no "paste image" hijack toast)