### PR TITLE
feat(dictation): strip trailing 'Děkuji.'/'Ahoj.' when pasting into Claude Code

### DIFF
--- a/src/VirtualAssistant.Core/Services/CivilityTrimmer.cs
+++ b/src/VirtualAssistant.Core/Services/CivilityTrimmer.cs
@@ -1,0 +1,92 @@
+using System.Text.RegularExpressions;
+
+namespace Olbrasoft.VirtualAssistant.Core.Services;
+
+/// <summary>
+/// Strips trailing polite/filler sentences (e.g. "Děkuji.", "Ahoj.") from a
+/// dictated transcript when it is being pasted into a CLI agent (Claude Code
+/// etc.). Two sources feed this: the user's habit of saying "Děkuji." after a
+/// request, and Whisper hallucinating subtitle-style sign-offs during silent
+/// tails of audio (its training corpus is heavy on TED/subtitle tracks).
+/// </summary>
+/// <remarks>
+/// Applied only on the quick-dictation path into known CLI agents — the LLM
+/// correction pipeline is bypassed there, so without this pass the agent
+/// prompt ends up with "…do X. Děkuji." which is noise. Regular dictation into
+/// chat apps (WhatsApp etc.) must NOT invoke this; "Děkuji." is a legitimate
+/// message there.
+/// </remarks>
+public static class CivilityTrimmer
+{
+    // Whole-sentence civility phrases, normalized to lowercase and without
+    // trailing punctuation. Comparisons are case-insensitive so "Děkuji" and
+    // "děkuji" both match. Substring matches never trigger — only a full
+    // trailing sentence is eligible — so "díky tomu, že…" mid-text is safe.
+    private static readonly HashSet<string> CivilityPhrases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "děkuji",
+        "děkuju",
+        "děkujeme",
+        "díky",
+        "díky moc",
+        "díky mockrát",
+        "díky za info",
+        "díky za informaci",
+        "ahoj",
+        "nashle",
+        "nashledanou",
+        "čau",
+        "měj se",
+        "měj se hezky",
+        // Whisper hallucinations during silent audio tails — the model was
+        // trained on tons of Czech subtitle tracks ending with these sign-offs.
+        "děkuji za titulky",
+        "děkuji za sledování",
+        "děkuji za pozornost",
+    };
+
+    // Match the final sentence: anchored at the end, starts either at the
+    // string start or immediately after a previous sentence terminator. The
+    // inner group is the sentence content (no terminators), non-greedy so the
+    // match stays confined to the last sentence.
+    private static readonly Regex TrailingSentence = new(
+        @"(?:^|(?<=[.!?]))\s*([^.!?]+?)\s*[.!?]+\s*$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns <paramref name="text"/> with any trailing civility-only
+    /// sentences stripped. Repeats the strip so multiple tacked-on civilities
+    /// ("… Děkuji. Ahoj.") all come off. Null is normalized to empty.
+    /// </summary>
+    public static string StripTrailingCivility(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return text ?? string.Empty;
+        }
+
+        var current = text;
+        while (true)
+        {
+            var trimmedEnd = current.TrimEnd();
+            if (trimmedEnd.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var match = TrailingSentence.Match(trimmedEnd);
+            if (!match.Success)
+            {
+                return trimmedEnd;
+            }
+
+            var phrase = match.Groups[1].Value.Trim();
+            if (!CivilityPhrases.Contains(phrase))
+            {
+                return trimmedEnd;
+            }
+
+            current = trimmedEnd[..match.Index];
+        }
+    }
+}

--- a/src/VirtualAssistant.Core/Services/CivilityTrimmer.cs
+++ b/src/VirtualAssistant.Core/Services/CivilityTrimmer.cs
@@ -57,6 +57,9 @@ public static class CivilityTrimmer
     /// Returns <paramref name="text"/> with any trailing civility-only
     /// sentences stripped. Repeats the strip so multiple tacked-on civilities
     /// ("… Děkuji. Ahoj.") all come off. Null is normalized to empty.
+    /// When nothing is stripped the original text is returned verbatim —
+    /// trailing whitespace/newlines the user typed are preserved, never
+    /// silently normalized by this pass.
     /// </summary>
     public static string StripTrailingCivility(string? text)
     {
@@ -77,15 +80,19 @@ public static class CivilityTrimmer
             var match = TrailingSentence.Match(trimmedEnd);
             if (!match.Success)
             {
-                return trimmedEnd;
+                return current;
             }
 
             var phrase = match.Groups[1].Value.Trim();
             if (!CivilityPhrases.Contains(phrase))
             {
-                return trimmedEnd;
+                return current;
             }
 
+            // Keep only the content before the matched civility sentence —
+            // this also discards the whitespace/newlines between the last
+            // real sentence and the stripped trailer, which is the desired
+            // behaviour when a strip actually happens.
             current = trimmedEnd[..match.Index];
         }
     }

--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -4,6 +4,7 @@ using Olbrasoft.VirtualAssistant.Core.Configuration;
 using Olbrasoft.VirtualAssistant.Core.Keyboard;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
 using Microsoft.AspNetCore.SignalR;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Infrastructure;
@@ -121,6 +122,7 @@ public static class WorkerServicesExtensions
                 llmProviderOptions);
 
             var hubContext = sp.GetRequiredService<IHubContext<DictationHub>>();
+            var cliAppDetector = sp.GetRequiredService<ICliAppDetector>();
 
             return new DictationWorker(
                 logger,
@@ -133,6 +135,7 @@ public static class WorkerServicesExtensions
                 cancelSound,
                 scopeFactory,
                 hubContext,
+                cliAppDetector,
                 dictationOptionsService);
         });
 

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -6,6 +6,7 @@ using Olbrasoft.VirtualAssistant.Core.Keyboard;
 using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
 using Olbrasoft.VirtualAssistant.Voice.Services;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Voice.StateMachine;
@@ -30,6 +31,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly ISoundEffectPlayer _cancelSound;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IHubContext<DictationHub> _hubContext;
+    private readonly ICliAppDetector _cliAppDetector;
     private readonly DictationOptions _options;
 
     private CancellationTokenSource? _transcriptionCts;
@@ -61,6 +63,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         ISoundEffectPlayer cancelSound,
         IServiceScopeFactory scopeFactory,
         IHubContext<DictationHub> hubContext,
+        ICliAppDetector cliAppDetector,
         IOptions<DictationOptions> options)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -73,6 +76,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _cancelSound = cancelSound ?? throw new ArgumentNullException(nameof(cancelSound));
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
+        _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
     }
@@ -479,8 +483,21 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
             if (_quickDictationMode)
             {
+                // Strip trailing civility ("… Děkuji.", "… Ahoj.", Whisper
+                // hallucinated sign-offs) when pasting into a CLI agent that
+                // reads the text as a prompt. Scoped to Claude Code only — in
+                // chat apps "Děkuji." is a legitimate message and must stay.
+                var textToPaste = await StripCivilityForClaudeCodeAsync(transcriptionResult.Text, _transcriptionCts!.Token);
+                if (string.IsNullOrWhiteSpace(textToPaste))
+                {
+                    _logger.LogInformation("Quick dictation: transcription reduced to empty after civility trim — skipping paste");
+                    _typingSound.StopLoop();
+                    _stateMachine.TransitionTo(DictationState.Idle);
+                    return;
+                }
+
                 // Quick mode: fast paste without clipboard save/restore
-                var pasteSucceeded = await _keyboardSimulation.FastPasteAsync(transcriptionResult.Text, _transcriptionCts!.Token);
+                var pasteSucceeded = await _keyboardSimulation.FastPasteAsync(textToPaste, _transcriptionCts!.Token);
                 _typingSound.StopLoop();
 
                 if (!pasteSucceeded)
@@ -491,7 +508,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
                 }
 
                 // Broadcast QuickTranscriptionCompleted BEFORE idle transition so client sets pending flag first
-                await BroadcastDictationEventAsync(DictationEventType.QuickTranscriptionCompleted, transcriptionResult.Text);
+                await BroadcastDictationEventAsync(DictationEventType.QuickTranscriptionCompleted, textToPaste);
                 _stateMachine.TransitionTo(DictationState.Idle);
                 _logger.LogInformation("Quick dictation: text pasted, QuickTranscriptionCompleted sent");
             }
@@ -680,6 +697,52 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
                 sttProviderId,
                 _transcriptionCts!.Token);
         }
+    }
+
+    /// <summary>
+    /// Applies <see cref="CivilityTrimmer"/> to the dictated text if the active
+    /// CLI app is Claude Code. For any other CLI agent or a plain GUI focus,
+    /// returns the text unchanged — the trimmer is Claude-Code-scoped per the
+    /// feature request ("Děkuji." is a legitimate message in chat apps).
+    /// Detection errors fall back to leaving the text untouched — the worst
+    /// case here is one stray civility word, worth less than mangling valid
+    /// input when gdbus hiccups.
+    /// </summary>
+    private async Task<string> StripCivilityForClaudeCodeAsync(string text, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return text;
+        }
+
+        CliAppDetectionResult? cliApp;
+        try
+        {
+            cliApp = await _cliAppDetector.DetectCliAppAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "CLI app detection failed before quick paste — skipping civility trim");
+            return text;
+        }
+
+        if (cliApp is null || !string.Equals(cliApp.AppName, "Claude Code", StringComparison.Ordinal))
+        {
+            return text;
+        }
+
+        var stripped = CivilityTrimmer.StripTrailingCivility(text);
+        if (stripped.Length != text.Length)
+        {
+            _logger.LogInformation(
+                "Quick dictation: stripped trailing civility for Claude Code ({Before} → {After} chars)",
+                text.Length, stripped.Length);
+        }
+        return stripped;
     }
 
     /// <summary>

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -730,7 +730,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             return text;
         }
 
-        if (cliApp is null || !string.Equals(cliApp.AppName, "Claude Code", StringComparison.Ordinal))
+        if (cliApp is null || !string.Equals(cliApp.AppName, "Claude Code", StringComparison.OrdinalIgnoreCase))
         {
             return text;
         }

--- a/tests/VirtualAssistant.Core.Tests/Services/CivilityTrimmerTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Services/CivilityTrimmerTests.cs
@@ -85,6 +85,19 @@ public class CivilityTrimmerTests
         Assert.Equal(input, CivilityTrimmer.StripTrailingCivility(input));
     }
 
+    [Theory]
+    [InlineData("Hotovo.   ")]
+    [InlineData("Hotovo.\n")]
+    [InlineData("Hotovo.\r\n\t")]
+    public void StripTrailingCivility_NoTrailingCivilityWithTrailingWhitespace_ReturnsUnchanged(string input)
+    {
+        // No civility to strip → the trimmer must not silently normalize
+        // trailing whitespace the user (or Whisper) produced. The only time
+        // we discard trailing whitespace is when it precedes a civility we
+        // actually removed — in the no-op case the input is returned verbatim.
+        Assert.Equal(input, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
     [Fact]
     public void StripTrailingCivility_CivilityMidSentence_DoesNotStrip()
     {

--- a/tests/VirtualAssistant.Core.Tests/Services/CivilityTrimmerTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Services/CivilityTrimmerTests.cs
@@ -1,0 +1,145 @@
+using Olbrasoft.VirtualAssistant.Core.Services;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.Services;
+
+/// <summary>
+/// Cases mirror the real transcriptions from <c>voice_transcriptions</c> that
+/// prompted this trimmer — users dictating a prompt and closing with "Děkuji."
+/// out of habit, plus a few classic Whisper hallucinations during silent tails.
+/// The substring-safety tests pin down what must NEVER be touched so pasting
+/// code/prose isn't silently mangled.
+/// </summary>
+public class CivilityTrimmerTests
+{
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "   ")]
+    public void StripTrailingCivility_NullEmptyOrBlank_ReturnsSafely(string? input, string expected)
+    {
+        Assert.Equal(expected, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Theory]
+    [InlineData("Děkuji.", "")]
+    [InlineData("Děkuju.", "")]
+    [InlineData("Díky.", "")]
+    [InlineData("Ahoj.", "")]
+    [InlineData("Čau.", "")]
+    [InlineData("Díky moc.", "")]
+    [InlineData("Díky za info.", "")]
+    [InlineData("Děkuji za titulky.", "")]
+    [InlineData("Děkuji za sledování.", "")]
+    public void StripTrailingCivility_JustCivility_ReturnsEmpty(string input, string expected)
+    {
+        Assert.Equal(expected, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_CivilityFollowingContent_StripsOnlyTrailing()
+    {
+        // Real transcription from voice_transcriptions table, trimmed.
+        var input = "Stáhneme video a nahrajeme ho na StreamTape. Děkuji.";
+        var expected = "Stáhneme video a nahrajeme ho na StreamTape.";
+
+        Assert.Equal(expected, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_MultipleChainedCivilities_StripsAll()
+    {
+        // Not something the user explicitly asked for but trivially correct if
+        // the single-strip logic is applied iteratively — keeps us from having
+        // to handle "Děkuji. Ahoj." awkwardly if Whisper ever produces it.
+        var input = "Udělej to prosím. Děkuji. Ahoj.";
+        var expected = "Udělej to prosím.";
+
+        Assert.Equal(expected, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_CaseInsensitive_Strips()
+    {
+        // Whisper is usually consistent with casing but we shouldn't depend on it.
+        Assert.Equal("Hotovo.", CivilityTrimmer.StripTrailingCivility("Hotovo. DĚKUJI."));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_ExclamationTerminator_Strips()
+    {
+        Assert.Equal("Hotovo.", CivilityTrimmer.StripTrailingCivility("Hotovo. Ahoj!"));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_EllipsisTerminator_Strips()
+    {
+        Assert.Equal("Hotovo.", CivilityTrimmer.StripTrailingCivility("Hotovo. Ahoj..."));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_NoTrailingCivility_ReturnsUnchanged()
+    {
+        // Real transcription — should pass through untouched.
+        var input = "Prosím tě, dej mi informaci, ať můžu pokračovat.";
+
+        Assert.Equal(input, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_CivilityMidSentence_DoesNotStrip()
+    {
+        // "Díky" here is inside the sentence, not a standalone trailing phrase.
+        // Substring matching would incorrectly strip this — we require the
+        // civility to BE the final sentence.
+        var input = "Díky tomu bychom to měli hotovo rychleji.";
+
+        Assert.Equal(input, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_CivilityEndingLongerSentence_DoesNotStrip()
+    {
+        // Real case: "V pohodě, děkuji za informaci a teď pokračujeme."
+        // The final sentence is more than civility, so we keep it.
+        var input = "V pohodě, děkuji za informaci a teď pokračujeme.";
+
+        Assert.Equal(input, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_RozumimDekuji_DoesNotStripBecauseCommaJoined()
+    {
+        // "Rozumím, děkuji" is one sentence (comma-joined). Even though it
+        // ends in "děkuji.", the trimmer should see the full content and bail.
+        var input = "Rozumím, děkuji.";
+
+        Assert.Equal(input, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_RealTranscription_Filmy_StripsTrailing()
+    {
+        // Verbatim from voice_transcriptions: a multi-sentence request ending
+        // in a standalone "Děkuji." that adds nothing for the LLM agent.
+        var input = "Chtěl bych vytvořit seznam filmů. Budu je stahovat a nahrávat. Děkuji.";
+        var expected = "Chtěl bych vytvořit seznam filmů. Budu je stahovat a nahrávat.";
+
+        Assert.Equal(expected, CivilityTrimmer.StripTrailingCivility(input));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_TrailingWhitespaceAfterCivility_HandledCleanly()
+    {
+        Assert.Equal("Hotovo.", CivilityTrimmer.StripTrailingCivility("Hotovo. Děkuji.   "));
+    }
+
+    [Fact]
+    public void StripTrailingCivility_UnknownPolitePhrase_DoesNotStrip()
+    {
+        // "Zdravím." is polite but not in our list — we keep the conservative
+        // set to avoid stripping things the user might want preserved.
+        var input = "Hotovo. Zdravím.";
+
+        Assert.Equal(input, CivilityTrimmer.StripTrailingCivility(input));
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -11,6 +11,7 @@ using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Workers;
 using Olbrasoft.VirtualAssistant.Voice.Services;
@@ -33,6 +34,7 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IServiceProvider> _serviceProviderMock;
     private readonly Mock<IDictationPersistenceService> _persistenceServiceMock;
     private readonly Mock<IHubContext<DictationHub>> _hubContextMock;
+    private readonly Mock<ICliAppDetector> _cliAppDetectorMock;
     private readonly DictationOptions _options;
     private readonly DictationWorker _sut;
 
@@ -54,6 +56,7 @@ public class DictationWorkerTests : IDisposable
         _persistenceServiceMock = new Mock<IDictationPersistenceService>();
         _hubContextMock = new Mock<IHubContext<DictationHub>>();
         _hubContextMock.Setup(x => x.Clients).Returns(Mock.Of<IHubClients>());
+        _cliAppDetectorMock = new Mock<ICliAppDetector>();
 
         _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
 
@@ -78,6 +81,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options));
     }
 
@@ -97,6 +101,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -114,6 +119,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -131,6 +137,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -148,6 +155,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             null!));
     }
 
@@ -165,6 +173,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -182,6 +191,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -199,6 +209,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -216,6 +227,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -233,6 +245,7 @@ public class DictationWorkerTests : IDisposable
             null!,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -250,6 +263,7 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             null!,
             _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             Options.Create(_options)));
     }
 
@@ -266,6 +280,25 @@ public class DictationWorkerTests : IDisposable
             _typingSoundMock.Object,
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
+            null!,
+            _cliAppDetectorMock.Object,
+            Options.Create(_options)));
+    }
+
+    [Fact]
+    public void Constructor_NullCliAppDetector_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
+            _loggerMock.Object,
+            _keyboardMonitorMock.Object,
+            _stateMachineMock.Object,
+            _recordingCoordinatorMock.Object,
+            _transcriptionServiceMock.Object,
+            _keyboardSimulationMock.Object,
+            _typingSoundMock.Object,
+            _cancelSoundMock.Object,
+            _scopeFactoryMock.Object,
+            _hubContextMock.Object,
             null!,
             Options.Create(_options)));
     }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

## Summary
- Quick-paste dictation into Claude Code bypasses the LLM correction pass, so Whisper's raw output lands on the clipboard as-is. Users habitually finish with `Děkuji.` or `Ahoj.`, and Whisper itself hallucinates subtitle-style sign-offs during silent tails (`Děkuji za titulky.`, `Děkuji za sledování.`). Both end up as the last sentence of the prompt — noise for the agent.
- Add `CivilityTrimmer` (pure static, Core) with a conservative whole-sentence match over a fixed phrase set derived from `voice_transcriptions` rows. Substring matches never trigger (`díky tomu…` mid-text is safe), comma-joined sentences stay intact (`Rozumím, děkuji.` → unchanged), and the trimmer iterates so chained trailers all come off.
- Wire it into `DictationWorker` only on the quick-paste branch, and only when `ICliAppDetector` reports `Claude Code` as the active CLI agent — per the request, `Děkuji.` must remain a legitimate message in WhatsApp/chat. Detection failure falls through to the untrimmed text. Empty-after-strip skips the paste instead of sending an empty keystroke.

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `dotnet test -c Release --filter "FullyQualifiedName!~IntegrationTests"` — 873 unit tests pass, including 24 new `CivilityTrimmerTests` and 1 new `Constructor_NullCliAppDetector` test
- [ ] After deploy, in a Claude Code tmux session: dictate a prompt ending with "Děkuji." via the quick-paste button, verify only the content is pasted
- [ ] Dictate a standalone "Děkuji." — nothing should be pasted (log line `transcription reduced to empty after civility trim`)
- [ ] In a non-Claude-Code terminal or GUI app: dictate "Hello. Děkuji." via quick-paste, verify "Děkuji." is preserved