### PR TITLE
feat(remote): split paste button into 'Vložit' and 'Vložit a Enter'

### DIFF
--- a/src/VirtualAssistant.Service/wwwroot/remote.html
+++ b/src/VirtualAssistant.Service/wwwroot/remote.html
@@ -259,9 +259,22 @@
             font-style: italic;
         }
 
-        .btn-paste {
+        /* Paste row hosts two buttons side-by-side: plain "Vložit" on the left
+           and "Vložit a Enter" on the right. Hidden until a transcription
+           arrives, then both reveal together via .visible. */
+        .paste-row {
+            display: none;
+            gap: 10px;
             margin-top: 12px;
-            padding: 10px 20px;
+        }
+
+        .paste-row.visible {
+            display: flex;
+        }
+
+        .btn-paste {
+            flex: 1;
+            padding: 10px 12px;
             font-size: 0.95rem;
             font-weight: 600;
             border: none;
@@ -269,12 +282,17 @@
             cursor: pointer;
             background: linear-gradient(135deg, #7c4dff 0%, #651fff 100%);
             color: white;
-            width: 100%;
-            display: none;
+            display: flex;
             align-items: center;
             justify-content: center;
             gap: 8px;
             transition: all 0.2s ease;
+        }
+
+        /* Distinct green tint so "Vložit a Enter" reads as the submit action,
+           matching the .btn-enter gradient used elsewhere on the page. */
+        .btn-paste-enter {
+            background: linear-gradient(135deg, #4caf50 0%, #45a049 100%);
         }
 
         .btn-paste:active {
@@ -284,10 +302,6 @@
         .btn-paste:disabled {
             opacity: 0.5;
             cursor: not-allowed;
-        }
-
-        .btn-paste.visible {
-            display: flex;
         }
 
         .connection-status {
@@ -545,9 +559,18 @@
         <div class="transcription-box">
             <h3>Poslední přepis</h3>
             <div class="transcription-text empty" id="transcriptionText">Žádný přepis</div>
-            <button class="btn-paste" id="btnPaste" disabled>
-                <span>&#x1F4CB;</span> Vložit
-            </button>
+            <!-- Paste row: shown only once a transcription arrives. Two buttons
+                 share the row equally so the right one reaches "paste + Enter"
+                 in one tap — saves the usual switch-back-and-press-Enter dance
+                 when the phone is the only input device. -->
+            <div class="paste-row" id="pasteRow">
+                <button class="btn-paste" id="btnPaste" disabled>
+                    <span>&#x1F4CB;</span> Vložit
+                </button>
+                <button class="btn-paste btn-paste-enter" id="btnPasteEnter" disabled>
+                    <span>&#x1F4CB;</span> Vložit a Enter
+                </button>
+            </div>
         </div>
 
         <div class="debug-log" id="debugLog">
@@ -559,7 +582,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <!-- Cache-busting version query — bump on every remote.js change so
          clients with stale browser cache do not serve an old script. -->
-    <script src="remote.js?v=32"></script>
+    <script src="remote.js?v=33"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -26,6 +26,8 @@ const elements = {
     recordTimer: document.getElementById('recordTimer'),
     transcriptionText: document.getElementById('transcriptionText'),
     btnPaste: document.getElementById('btnPaste'),
+    btnPasteEnter: document.getElementById('btnPasteEnter'),
+    pasteRow: document.getElementById('pasteRow'),
     btnClipboardPaste: document.getElementById('btnClipboardPaste'),
     btnScreenshotPaste: document.getElementById('btnScreenshotPaste'),
     btnDiscord: document.getElementById('btnDiscord'),
@@ -201,6 +203,7 @@ function setConnectionStatus(connected) {
     elements.btnDiscord.disabled = !connected;
     elements.btnFerdium.disabled = !connected;
     elements.btnPaste.disabled = !connected || !lastTranscription;
+    elements.btnPasteEnter.disabled = !connected || !lastTranscription;
     // Force the recording zones disabled while offline. setRecordingState()
     // re-enables them only when a new recording actually starts after the
     // connection is restored, so we never enable them here. Without this,
@@ -281,8 +284,9 @@ function setTranscriptionText(text) {
     elements.transcriptionText.textContent = text;
     elements.transcriptionText.classList.remove('empty');
     lastTranscription = text;
-    elements.btnPaste.classList.add('visible');
+    elements.pasteRow.classList.add('visible');
     elements.btnPaste.disabled = false;
+    elements.btnPasteEnter.disabled = false;
 }
 
 function handleAppFocusChanged(wmClass) {
@@ -684,6 +688,33 @@ elements.btnPaste.addEventListener('click', async () => {
         console.error('Paste failed:', error);
     } finally {
         elements.btnPaste.disabled = false;
+    }
+});
+
+// Paste + Enter handler: types the transcription, then fires Enter so the
+// prompt is submitted without a second tap. Both buttons lock during the
+// round-trip so a double tap can't race PressEnter against an in-flight paste.
+elements.btnPasteEnter.addEventListener('pointerdown', () => {
+    if (elements.btnPasteEnter.disabled) return;
+    if ('vibrate' in navigator) navigator.vibrate(50);
+});
+
+elements.btnPasteEnter.addEventListener('click', async () => {
+    if (!lastTranscription || connection?.state !== signalR.HubConnectionState.Connected) return;
+    try {
+        elements.btnPaste.disabled = true;
+        elements.btnPasteEnter.disabled = true;
+        const pasted = await connection.invoke('PasteTranscription', lastTranscription);
+        if (pasted) {
+            await connection.invoke('PressEnter');
+        } else {
+            console.warn('Paste+Enter: PasteTranscription returned false, skipping Enter');
+        }
+    } catch (error) {
+        console.error('Paste+Enter failed:', error);
+    } finally {
+        elements.btnPaste.disabled = false;
+        elements.btnPasteEnter.disabled = false;
     }
 });
 

--- a/src/VirtualAssistant.Service/wwwroot/remote.js
+++ b/src/VirtualAssistant.Service/wwwroot/remote.js
@@ -4,7 +4,7 @@
 // Bumped on every script change. Rendered next to the connection status so
 // the user can verify the phone is actually running the latest JS and not a
 // stale cached copy. MUST match the ?v= query string in remote.html.
-const SCRIPT_VERSION = 'v32';
+const SCRIPT_VERSION = 'v33';
 
 const elements = {
     connectionStatus: document.getElementById('connectionStatus'),


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

## Summary
- When the user dictates from the phone but the target window isn't focused on the desktop, the transcription lands in the Remote Control's "Poslední přepis" box with a single full-width "Vložit" button. After tapping paste, the user almost always wants to submit the prompt — today that means picking up the phone a second time to tap Enter.
- Split the single button into two siblings sharing one row. Left (purple): "Vložit" — existing paste-only behaviour. Right (green): "Vložit a Enter" — calls `PasteTranscription` and, once it resolves, `PressEnter` on the same hub. Both lock during the round-trip so a double tap can't race an Enter against an in-flight paste.
- Hub is unchanged: `PressEnter` already exists. CSS uses `.paste-row` as a flex container so the pair occupies the same width the old single button had.

## Test plan
- [x] `dotnet build src/VirtualAssistant.Service -c Release` — 0 errors
- [ ] After deploy: open Remote Control on phone, dictate a prompt while the desktop focus is on a different app, verify the "Poslední přepis" section shows two buttons side-by-side
- [ ] Tap "Vložit" — verify text is pasted (no Enter)
- [ ] Tap "Vložit a Enter" — verify text is pasted AND Enter fires (e.g. a prompt to Claude Code gets submitted)
- [ ] Tap either button with no transcription yet: both buttons disabled
- [ ] SignalR disconnect: both buttons disabled