### PR TITLE
security(keyboard): replace bash -c interpolation with direct dotool stdin + whitelist

### DIFF
--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -106,24 +106,25 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             await dotoolProcess.StandardInput.WriteLineAsync($"key {pasteShortcut}");
             dotoolProcess.StandardInput.Close();
 
-            // Add timeout to prevent hanging (max 5 seconds for paste)
+            // Use an independent timeout CTS. Binding the timer to `cancellationToken`
+            // would conflate "user cancelled" with "dotool hung 5 s", and the timeout
+            // branch below would log a fake timeout when the real cause was cancellation.
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             var dotoolTask = dotoolProcess.WaitForExitAsync(cancellationToken);
-            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            var timeoutTask = Task.Delay(Timeout.InfiniteTimeSpan, timeoutCts.Token);
             var completedTask = await Task.WhenAny(dotoolTask, timeoutTask);
 
             if (completedTask == timeoutTask)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 _logger.LogError("dotool paste timeout after 5 seconds, killing process");
-                try
-                {
-                    dotoolProcess.Kill();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to kill dotool process");
-                }
+                TryKillProcess(dotoolProcess);
                 return false;
             }
+
+            // Surface cancellation as OperationCanceledException (caught below) rather
+            // than as a silent "timeout" false-positive.
+            await dotoolTask;
 
             if (dotoolProcess.ExitCode != 0)
             {

--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -29,6 +29,15 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    // Defense-in-depth: paste shortcuts are never passed to a shell, but the
+    // value is still used as dotool input. Keep the allowed set explicit so a
+    // future refactor that changes the source of this value cannot slip in
+    // something unexpected.
+    private static readonly HashSet<string> AllowedPasteShortcuts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ctrl+v", "ctrl+shift+v", "shift+insert"
+    };
+
     /// <summary>
     /// Types text into the active window using clipboard + dotool paste.
     /// For terminal CLI agents (Claude Code, OpenCode, Gemini) the text is
@@ -76,12 +85,16 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             _logger.LogInformation("Simulating paste with shortcut: {Shortcut} (selection: {Selection})",
                 pasteShortcut, usePrimary ? "PRIMARY" : "CLIPBOARD");
 
-            var dotoolProcess = new Process
+            // Invoke dotool directly and pipe the command over stdin. The previous
+            // implementation composed a `bash -c "echo 'key …' | dotool"` string with
+            // string interpolation — safe only because pasteShortcut came from a
+            // hardcoded set, but a shell-injection foot-gun if that ever changes.
+            using var dotoolProcess = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "/bin/bash",
-                    Arguments = $"-c \"echo 'key {pasteShortcut}' | dotool\"",
+                    FileName = "dotool",
+                    RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
@@ -90,6 +103,8 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             };
 
             dotoolProcess.Start();
+            await dotoolProcess.StandardInput.WriteLineAsync($"key {pasteShortcut}");
+            dotoolProcess.StandardInput.Close();
 
             // Add timeout to prevent hanging (max 5 seconds for paste)
             var dotoolTask = dotoolProcess.WaitForExitAsync(cancellationToken);
@@ -452,7 +467,7 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             _logger.LogInformation(
                 "Using paste shortcut: shift+insert (CLI app: {AppName} — Ctrl+Shift+V would be hijacked)",
                 cliApp.AppName);
-            return "shift+insert";
+            return EnsureAllowedShortcut("shift+insert");
         }
 
         var isTerminal = await _terminalDetector.IsTerminalActiveAsync(cancellationToken);
@@ -461,6 +476,17 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
         _logger.LogInformation("Using paste shortcut: {Shortcut} (terminal: {IsTerminal})",
             pasteShortcut, isTerminal);
 
-        return pasteShortcut;
+        return EnsureAllowedShortcut(pasteShortcut);
+    }
+
+    private static string EnsureAllowedShortcut(string shortcut)
+    {
+        if (!AllowedPasteShortcuts.Contains(shortcut))
+        {
+            throw new InvalidOperationException(
+                $"Paste shortcut '{shortcut}' is not in the allowed set. " +
+                "Refusing to pass an unvetted value to dotool.");
+        }
+        return shortcut;
     }
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #971

## Summary
- `TypeIntoActiveWindowAsync` composed its dotool call as `/bin/bash -c "echo 'key {pasteShortcut}' | dotool"` via string interpolation
- Replace the shell round-trip with direct `dotool` + stdin piping (same pattern `FastPasteAsync` already uses)
- Add explicit whitelist (`AllowedPasteShortcuts`) + guard (`EnsureAllowedShortcut`) so a future refactor that returns an unvetted shortcut fails loudly
- Wrap the `Process` in `using` (was leaked via local variable)

## Why
Identified during the comprehensive code review (#967) as a Critical-severity security finding. Live code was safe (shortcut always came from a fixed set), but the pattern would turn into a shell-injection vulnerability the moment user-controlled data reached the variable.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test VirtualAssistant.Core.Tests` — 71/71 pass
- [ ] CI green
- [ ] Smoke test: post-deploy manual paste from Remote Control into Claude Code still works