### PR TITLE
refactor(stt): replace provider-name switch with self-registering registry

### DIFF
--- a/src/VirtualAssistant.Core/Speech/ISpeechTranscriber.cs
+++ b/src/VirtualAssistant.Core/Speech/ISpeechTranscriber.cs
@@ -6,6 +6,20 @@ namespace Olbrasoft.VirtualAssistant.Core.Speech;
 public interface ISpeechTranscriber : IDisposable
 {
     /// <summary>
+    /// Gets the provider key used in configuration (lowercase, e.g. "whisper", "google").
+    /// Acts as the identity by which the factory maps a requested provider name to an instance,
+    /// without any switch statement coupled to the set of available providers.
+    /// </summary>
+    string ProviderKey { get; }
+
+    /// <summary>
+    /// Gets the provider name as stored in the <c>providers</c> database table (e.g.,
+    /// "Whisper Local", "Google Speech-to-Text"). Used only for tracking — database
+    /// rows stay human-readable while the factory lookup stays key-driven.
+    /// </summary>
+    string DatabaseName { get; }
+
+    /// <summary>
     /// Gets the language code for transcription (e.g., "cs" for Czech).
     /// </summary>
     string Language { get; }

--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -125,7 +125,15 @@ public static class VoiceServicesExtensions
 
         // Register STT provider factory with the full ISpeechTranscriber collection.
         // Each provider self-declares its ProviderKey/DatabaseName, so adding a new
-        // provider only requires the DI registration — factory stays untouched.
+        // provider is a factory-free change — just register the concrete provider
+        // here and add it to this array.
+        //
+        // NOTE: we cannot use sp.GetServices<ISpeechTranscriber>() here because the
+        // downstream AddSingleton<ISpeechTranscriber>(...) (FallbackSpeechTranscriber
+        // wrapper) shares the same interface and depends transitively on the factory
+        // — auto-discovery would create a circular DI dependency. The factory is
+        // still registry-driven (no switch statement); this array is the one place
+        // where primary providers are enumerated.
         services.AddSingleton<ISpeechTranscriberFactory>(sp =>
         {
             IEnumerable<ISpeechTranscriber> providers = new ISpeechTranscriber[]

--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -123,16 +123,20 @@ public static class VoiceServicesExtensions
             return new GoogleSpeechTranscriber(httpClient, options, logger);
         });
 
-        // Register STT provider factory with explicit provider injection (no service locator)
-        // Cast to ISpeechTranscriber to match factory constructor signature
+        // Register STT provider factory with the full ISpeechTranscriber collection.
+        // Each provider self-declares its ProviderKey/DatabaseName, so adding a new
+        // provider only requires the DI registration — factory stays untouched.
         services.AddSingleton<ISpeechTranscriberFactory>(sp =>
         {
-            ISpeechTranscriber whisper = sp.GetRequiredService<WhisperSpeechTranscriber>();
-            ISpeechTranscriber google = sp.GetRequiredService<GoogleSpeechTranscriber>();
+            IEnumerable<ISpeechTranscriber> providers = new ISpeechTranscriber[]
+            {
+                sp.GetRequiredService<WhisperSpeechTranscriber>(),
+                sp.GetRequiredService<GoogleSpeechTranscriber>()
+            };
             var queryProcessor = sp.GetRequiredService<IQueryProcessor>();
             var settings = sp.GetRequiredService<IOptions<SpeechProviderSettings>>();
             var logger = sp.GetRequiredService<ILogger<SpeechTranscriberFactory>>();
-            return new SpeechTranscriberFactory(whisper, google, queryProcessor, settings, logger);
+            return new SpeechTranscriberFactory(providers, queryProcessor, settings, logger);
         });
 
         // Register FallbackSpeechTranscriber or single provider based on settings.

--- a/src/VirtualAssistant.Voice/Services/FallbackSpeechTranscriber.cs
+++ b/src/VirtualAssistant.Voice/Services/FallbackSpeechTranscriber.cs
@@ -29,6 +29,9 @@ public sealed class FallbackSpeechTranscriber : ISpeechTranscriber
         private set => System.Threading.Interlocked.Exchange(ref _lastUsedProviderId, value);
     }
 
+    public string ProviderKey => _primary.ProviderKey;
+    public string DatabaseName => _primary.DatabaseName;
+
     /// <summary>
     /// Gets the language code from the primary provider.
     /// </summary>

--- a/src/VirtualAssistant.Voice/Services/GoogleSpeechTranscriber.cs
+++ b/src/VirtualAssistant.Voice/Services/GoogleSpeechTranscriber.cs
@@ -20,6 +20,9 @@ public sealed class GoogleSpeechTranscriber : ISpeechTranscriber
     private readonly ILogger<GoogleSpeechTranscriber> _logger;
     private bool _disposed;
 
+    public string ProviderKey => "google";
+    public string DatabaseName => "Google Speech-to-Text";
+
     /// <summary>
     /// Gets the language code for transcription.
     /// </summary>

--- a/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
+++ b/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
@@ -14,8 +14,7 @@ namespace Olbrasoft.VirtualAssistant.Voice.Services;
 /// </summary>
 public class SpeechTranscriberFactory : ISpeechTranscriberFactory
 {
-    private readonly ISpeechTranscriber _whisperProvider;
-    private readonly ISpeechTranscriber _googleProvider;
+    private readonly IReadOnlyDictionary<string, ISpeechTranscriber> _providersByKey;
     private readonly IQueryProcessor _queryProcessor;
     private readonly SpeechProviderSettings _settings;
     private readonly ILogger<SpeechTranscriberFactory> _logger;
@@ -26,30 +25,35 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
 
     /// <summary>
     /// Initializes a new instance of <see cref="SpeechTranscriberFactory"/>.
-    /// Providers are injected explicitly to avoid .NET keyed services bugs.
+    /// Providers self-declare their <see cref="ISpeechTranscriber.ProviderKey"/> and
+    /// <see cref="ISpeechTranscriber.DatabaseName"/> — the factory just indexes them,
+    /// so adding a new STT provider requires no edits here.
     /// </summary>
-    /// <param name="whisperProvider">The Whisper speech transcriber instance.</param>
-    /// <param name="googleProvider">The Google speech transcriber instance.</param>
-    /// <param name="queryProcessor">Query processor for database access.</param>
-    /// <param name="settings">Speech provider configuration settings.</param>
-    /// <param name="logger">Logger instance.</param>
     public SpeechTranscriberFactory(
-        ISpeechTranscriber whisperProvider,
-        ISpeechTranscriber googleProvider,
+        IEnumerable<ISpeechTranscriber> providers,
         IQueryProcessor queryProcessor,
         IOptions<SpeechProviderSettings> settings,
         ILogger<SpeechTranscriberFactory> logger)
     {
-        _whisperProvider = whisperProvider ?? throw new ArgumentNullException(nameof(whisperProvider));
-        _googleProvider = googleProvider ?? throw new ArgumentNullException(nameof(googleProvider));
+        ArgumentNullException.ThrowIfNull(providers);
         _queryProcessor = queryProcessor ?? throw new ArgumentNullException(nameof(queryProcessor));
         _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
+        _providersByKey = providers.ToDictionary(
+            p => p.ProviderKey,
+            p => p,
+            StringComparer.OrdinalIgnoreCase);
+
+        if (_providersByKey.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "SpeechTranscriberFactory requires at least one ISpeechTranscriber registration.");
+        }
+
         _logger.LogInformation(
-            "SpeechTranscriberFactory initialized with Whisper={Whisper}, Google={Google}",
-            _whisperProvider.GetType().Name,
-            _googleProvider.GetType().Name);
+            "SpeechTranscriberFactory initialized with providers: {Providers}",
+            string.Join(", ", _providersByKey.Select(p => $"{p.Key}={p.Value.GetType().Name}")));
     }
 
     /// <summary>
@@ -63,41 +67,30 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     }
 
     /// <summary>
-    /// Gets a specific provider by name.
-    /// Returns the explicitly injected provider instance - no service locator pattern.
+    /// Gets a specific provider by name. Returns null when no matching provider is registered.
+    /// Lookup is case-insensitive on <see cref="ISpeechTranscriber.ProviderKey"/>.
     /// </summary>
-    /// <param name="providerName">The provider name ("whisper" or "google").</param>
-    /// <returns>The provider instance, or null if not found.</returns>
     public ISpeechTranscriber? GetProvider(string providerName)
     {
         if (string.IsNullOrEmpty(providerName))
             return null;
 
-        var provider = providerName.ToLowerInvariant() switch
-        {
-            "whisper" => (ISpeechTranscriber)_whisperProvider,
-            "google" => _googleProvider,
-            _ => null
-        };
-
-        if (provider != null)
+        if (_providersByKey.TryGetValue(providerName, out var provider))
         {
             _logger.LogDebug(
                 "GetProvider({ProviderName}) returning {ProviderType}",
                 providerName,
                 provider.GetType().Name);
+            return provider;
         }
 
-        return provider;
+        return null;
     }
 
     /// <summary>
-    /// Gets all available provider names.
+    /// Gets all available provider keys.
     /// </summary>
-    public IReadOnlyCollection<string> GetAvailableProviders()
-    {
-        return ["whisper", "google"];
-    }
+    public IReadOnlyCollection<string> GetAvailableProviders() => _providersByKey.Keys.ToArray();
 
     /// <summary>
     /// Gets the database provider ID for tracking.
@@ -107,21 +100,23 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     {
         EnsureProviderIdCacheLoaded();
 
-        // Map friendly names to database names
-        var dbName = providerName.ToLowerInvariant() switch
+        // Provider implementations expose their own DatabaseName so the mapping
+        // has a single source of truth and new providers don't require factory edits.
+        if (!_providersByKey.TryGetValue(providerName, out var provider))
         {
-            "whisper" => "Whisper Local",
-            "google" => "Google Speech-to-Text",
-            _ => providerName
-        };
+            throw new ArgumentException(
+                $"Unknown STT provider: '{providerName}'. Available: {string.Join(", ", _providersByKey.Keys)}",
+                nameof(providerName));
+        }
 
-        if (_providerIdCache!.TryGetValue(dbName, out var id))
+        if (_providerIdCache!.TryGetValue(provider.DatabaseName, out var id))
         {
             return id;
         }
 
         throw new ArgumentException(
-            $"Unknown STT provider: '{providerName}'. Available: {string.Join(", ", _providerIdCache.Keys)}",
+            $"Provider '{providerName}' has DatabaseName '{provider.DatabaseName}' which is not in the providers table. " +
+            $"Known rows: {string.Join(", ", _providerIdCache.Keys)}",
             nameof(providerName));
     }
 

--- a/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
+++ b/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
@@ -40,20 +40,44 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
         _settings = settings?.Value ?? throw new ArgumentNullException(nameof(settings));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-        _providersByKey = providers.ToDictionary(
-            p => p.ProviderKey,
-            p => p,
-            StringComparer.OrdinalIgnoreCase);
+        _providersByKey = BuildProviderDictionary(providers);
 
-        if (_providersByKey.Count == 0)
+        _logger.LogInformation(
+            "SpeechTranscriberFactory initialized with providers: {Providers}",
+            string.Join(", ", _providersByKey.Select(p => $"{p.Key}={p.Value.GetType().Name}")));
+    }
+
+    private static IReadOnlyDictionary<string, ISpeechTranscriber> BuildProviderDictionary(
+        IEnumerable<ISpeechTranscriber> providers)
+    {
+        var result = new Dictionary<string, ISpeechTranscriber>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var provider in providers)
+        {
+            if (string.IsNullOrWhiteSpace(provider.ProviderKey))
+            {
+                throw new InvalidOperationException(
+                    $"Provider '{provider.GetType().FullName}' returned a null/empty ProviderKey. " +
+                    "Each ISpeechTranscriber implementation must expose a non-empty identifier.");
+            }
+
+            if (result.ContainsKey(provider.ProviderKey))
+            {
+                throw new InvalidOperationException(
+                    $"Duplicate ISpeechTranscriber.ProviderKey '{provider.ProviderKey}' " +
+                    $"(clash between {result[provider.ProviderKey].GetType().FullName} and {provider.GetType().FullName}).");
+            }
+
+            result.Add(provider.ProviderKey, provider);
+        }
+
+        if (result.Count == 0)
         {
             throw new InvalidOperationException(
                 "SpeechTranscriberFactory requires at least one ISpeechTranscriber registration.");
         }
 
-        _logger.LogInformation(
-            "SpeechTranscriberFactory initialized with providers: {Providers}",
-            string.Join(", ", _providersByKey.Select(p => $"{p.Key}={p.Value.GetType().Name}")));
+        return result;
     }
 
     /// <summary>
@@ -98,6 +122,11 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     /// </summary>
     public int GetProviderId(string providerName)
     {
+        if (string.IsNullOrWhiteSpace(providerName))
+        {
+            throw new ArgumentException("Provider name must be a non-empty string.", nameof(providerName));
+        }
+
         EnsureProviderIdCacheLoaded();
 
         // Provider implementations expose their own DatabaseName so the mapping

--- a/src/VirtualAssistant.Voice/Services/WhisperSpeechTranscriber.cs
+++ b/src/VirtualAssistant.Voice/Services/WhisperSpeechTranscriber.cs
@@ -23,6 +23,8 @@ public sealed class WhisperSpeechTranscriber : ISpeechTranscriber
 
     private const int SampleRate = 16000;
 
+    public string ProviderKey => "whisper";
+    public string DatabaseName => "Whisper Local";
     public string Language => _options.WhisperLanguage;
 
     /// <summary>

--- a/tests/VirtualAssistant.Voice.Tests/Services/SpeechTranscriberFactoryTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/SpeechTranscriberFactoryTests.cs
@@ -19,9 +19,13 @@ public class SpeechTranscriberFactoryTests
 
     public SpeechTranscriberFactoryTests()
     {
-        // Create mocks for ISpeechTranscriber interface
         _whisperMock = new Mock<ISpeechTranscriber>();
+        _whisperMock.SetupGet(x => x.ProviderKey).Returns("whisper");
+        _whisperMock.SetupGet(x => x.DatabaseName).Returns("Whisper Local");
+
         _googleMock = new Mock<ISpeechTranscriber>();
+        _googleMock.SetupGet(x => x.ProviderKey).Returns("google");
+        _googleMock.SetupGet(x => x.DatabaseName).Returns("Google Speech-to-Text");
 
         _queryProcessorMock = new Mock<IQueryProcessor>();
         _loggerMock = new Mock<ILogger<SpeechTranscriberFactory>>();
@@ -38,8 +42,7 @@ public class SpeechTranscriberFactoryTests
         var options = Options.Create(settings);
 
         return new SpeechTranscriberFactory(
-            _whisperMock.Object,
-            _googleMock.Object,
+            new[] { _whisperMock.Object, _googleMock.Object },
             _queryProcessorMock.Object,
             options,
             _loggerMock.Object);
@@ -178,7 +181,7 @@ public class SpeechTranscriberFactoryTests
     }
 
     [Fact]
-    public void Constructor_WithNullWhisperProvider_ThrowsArgumentNullException()
+    public void Constructor_WithNullProviders_ThrowsArgumentNullException()
     {
         // Arrange
         var settings = Options.Create(new SpeechProviderSettings());
@@ -186,22 +189,20 @@ public class SpeechTranscriberFactoryTests
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new SpeechTranscriberFactory(
             null!,
-            _googleMock.Object,
             _queryProcessorMock.Object,
             settings,
             _loggerMock.Object));
     }
 
     [Fact]
-    public void Constructor_WithNullGoogleProvider_ThrowsArgumentNullException()
+    public void Constructor_WithEmptyProviders_ThrowsInvalidOperationException()
     {
         // Arrange
         var settings = Options.Create(new SpeechProviderSettings());
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new SpeechTranscriberFactory(
-            _whisperMock.Object,
-            null!,
+        Assert.Throws<InvalidOperationException>(() => new SpeechTranscriberFactory(
+            Array.Empty<ISpeechTranscriber>(),
             _queryProcessorMock.Object,
             settings,
             _loggerMock.Object));
@@ -215,8 +216,7 @@ public class SpeechTranscriberFactoryTests
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new SpeechTranscriberFactory(
-            _whisperMock.Object,
-            _googleMock.Object,
+            new[] { _whisperMock.Object, _googleMock.Object },
             null!,
             settings,
             _loggerMock.Object));
@@ -227,8 +227,7 @@ public class SpeechTranscriberFactoryTests
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new SpeechTranscriberFactory(
-            _whisperMock.Object,
-            _googleMock.Object,
+            new[] { _whisperMock.Object, _googleMock.Object },
             _queryProcessorMock.Object,
             null!,
             _loggerMock.Object));
@@ -242,8 +241,7 @@ public class SpeechTranscriberFactoryTests
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new SpeechTranscriberFactory(
-            _whisperMock.Object,
-            _googleMock.Object,
+            new[] { _whisperMock.Object, _googleMock.Object },
             _queryProcessorMock.Object,
             settings,
             null!));


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #982

## Summary
- `SpeechTranscriberFactory` previously had two switch statements coupled to the provider set (`GetProvider` + `GetProviderId`) — adding a new provider meant editing the factory
- Providers now self-declare `ProviderKey` (for the factory map) and `DatabaseName` (for the providers-table lookup) via new `ISpeechTranscriber` members
- Factory injects `IEnumerable<ISpeechTranscriber>` and builds a case-insensitive dictionary once at construction — both switches gone
- DI registration passes the providers as an array; adding a new STT provider is now a pure DI edit

## Why
Identified during the comprehensive code review (#967) as a Medium-severity OCP violation. Keeps the factory closed for modification while open for extension.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test SpeechTranscriberFactoryTests` — 18/18 pass
- [ ] CI green
- [ ] Smoke test: STT primary + fallback still work after deploy