### PR TITLE
fix(async): DesktopContextService sync-wait on Semaphore → Monitor lock

### DIFF
--- a/src/VirtualAssistant.Desktop/Services/DesktopContextService.cs
+++ b/src/VirtualAssistant.Desktop/Services/DesktopContextService.cs
@@ -55,6 +55,11 @@ public class DesktopContextService : IDesktopContextService, IAsyncDisposable
         {
             lock (_stateLock)
             {
+                // Re-check inside the lock — DisposeAsync can flip _disposed
+                // between the outer check and this point, and OnNext-ing into
+                // a completed Subject would throw.
+                if (_disposed) return;
+
                 if (_lastContext == null)
                 {
                     _lastContext = newContext;
@@ -136,14 +141,15 @@ public class DesktopContextService : IDesktopContextService, IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
-        if (_disposed) return ValueTask.CompletedTask;
-        _disposed = true;
-
-        // Unsubscribe from BackgroundService events
+        // Unsubscribe from BackgroundService events first so no new callbacks
+        // enter OnContextUpdate after _disposed flips.
         _contextSubscription?.Dispose();
 
         lock (_stateLock)
         {
+            if (_disposed) return ValueTask.CompletedTask;
+            _disposed = true;
+
             _contextChanges.OnCompleted();
             _contextChanges.Dispose();
 

--- a/src/VirtualAssistant.Desktop/Services/DesktopContextService.cs
+++ b/src/VirtualAssistant.Desktop/Services/DesktopContextService.cs
@@ -14,7 +14,13 @@ public class DesktopContextService : IDesktopContextService, IAsyncDisposable
     private readonly IDesktopMonitorBackgroundService? _monitor;
     private readonly ILogger<DesktopContextService> _logger;
     private readonly Subject<DesktopContextChange> _contextChanges = new();
-    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    // Plain monitor instead of SemaphoreSlim — OnContextUpdate runs synchronously
+    // from the Subject subscription, so SemaphoreSlim.Wait() was a sync-over-async
+    // smell and the async variant would need the callback to go async anyway.
+    // No async work is done while the lock is held, so `lock(_stateLock)` is both
+    // correct and avoids the disposable lifetime concerns.
+    private readonly object _stateLock = new();
     private IDisposable? _contextSubscription;
 
     private DesktopContext? _lastContext;
@@ -47,8 +53,7 @@ public class DesktopContextService : IDesktopContextService, IAsyncDisposable
 
         try
         {
-            _lock.Wait();
-            try
+            lock (_stateLock)
             {
                 if (_lastContext == null)
                 {
@@ -87,10 +92,6 @@ public class DesktopContextService : IDesktopContextService, IAsyncDisposable
                     _lastContext = newContext;
                     _contextChanges.OnNext(change);
                 }
-            }
-            finally
-            {
-                _lock.Release();
             }
         }
         catch (Exception ex)
@@ -133,27 +134,22 @@ public class DesktopContextService : IDesktopContextService, IAsyncDisposable
         Timestamp: DateTime.UtcNow
     );
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        if (_disposed) return;
+        if (_disposed) return ValueTask.CompletedTask;
         _disposed = true;
 
         // Unsubscribe from BackgroundService events
         _contextSubscription?.Dispose();
 
-        await _lock.WaitAsync();
-        try
+        lock (_stateLock)
         {
             _contextChanges.OnCompleted();
             _contextChanges.Dispose();
 
             _logger.LogInformation("DesktopContextService disposed");
         }
-        finally
-        {
-            _lock.Release();
-        }
 
-        _lock.Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/VirtualAssistant.Voice/Filters/DatabaseCorrectionFilterStrategy.cs
+++ b/src/VirtualAssistant.Voice/Filters/DatabaseCorrectionFilterStrategy.cs
@@ -44,7 +44,12 @@ public class DatabaseCorrectionFilterStrategy : ITextFilterStrategy
         if (string.IsNullOrWhiteSpace(text))
             return text;
 
-        // Refresh database corrections cache if needed
+        // Refresh database corrections cache if needed. The sync-over-async here
+        // is accepted: DatabaseCorrectionCacheWarmupService pre-loads the cache
+        // on startup and refreshes periodically, so this synchronous fallback
+        // only fires on cold start before warmup completes, or immediately after
+        // InvalidateCache() is called from the tray-menu "Obnovit cache" button —
+        // and in that case the user explicitly wants a blocking refresh.
         RefreshCorrectionsCache();
 
         if (_cachedCorrections.Count == 0)


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Partially addresses #976

## Summary
- `DesktopContextService.OnContextUpdate` was calling `_lock.Wait()` on a `SemaphoreSlim` from a synchronous Rx subscription callback — classic sync-over-async
- No async work happens while the lock is held; swap the semaphore for a plain `Monitor` lock
- `DisposeAsync` simplified; no more semaphore to dispose

## Also
- Added a comment to `DatabaseCorrectionFilterStrategy.Apply` explaining why the existing sync-over-async there is accepted (pre-warmup + manual-invalidation semantics)

## Scope note
Remaining sync-over-async sites per #976 (`AudioRecordingCoordinator.Dispose`, two `DesktopServiceExtensions` factory lambdas, `SpeechTranscriberFactory` startup cache) are all one-shot startup/shutdown paths with existing justifying comments. Each requires rethinking its hosting pattern (`IHostedService` / `IAsyncDisposable`) and is out of scope for this PR.

## Test plan
- [x] `dotnet test` — 593 pass
- [ ] CI green
- [ ] Smoke test: workspace/app focus change still triggers context updates after deploy