### PR TITLE
security(#978): fail-closed GitHub webhook + documented anonymous-endpoints auth policy

### DIFF
--- a/src/VirtualAssistant.Service/Controllers/GitHubWebhooksController.cs
+++ b/src/VirtualAssistant.Service/Controllers/GitHubWebhooksController.cs
@@ -49,15 +49,30 @@ public class GitHubWebhooksController : ControllerBase
         using var reader = new StreamReader(Request.Body);
         var body = await reader.ReadToEndAsync();
 
-        // Verify signature if secret is configured
+        // Fail-closed signature verification: require a configured secret AND a
+        // valid signature header on every request. Previously the check was opt-in
+        // (only ran if both the secret and the signature header were present) — a
+        // deployment with no secret would happily accept forged webhooks.
         var webhookSecret = _configuration["GitHub:WebhookSecret"];
-        if (!string.IsNullOrEmpty(webhookSecret) && !string.IsNullOrEmpty(signature))
+        if (string.IsNullOrEmpty(webhookSecret))
         {
-            if (!VerifySignature(body, signature, webhookSecret))
-            {
-                _logger.LogWarning("Invalid webhook signature for delivery {Delivery}", delivery);
-                return Unauthorized("Invalid signature");
-            }
+            _logger.LogError(
+                "GitHub:WebhookSecret is not configured — rejecting webhook delivery {Delivery}. " +
+                "Set the secret in SecureStore to enable this endpoint.",
+                delivery);
+            return Unauthorized("Webhook secret not configured");
+        }
+
+        if (string.IsNullOrEmpty(signature))
+        {
+            _logger.LogWarning("Missing X-Hub-Signature-256 header on delivery {Delivery}", delivery);
+            return Unauthorized("Missing signature");
+        }
+
+        if (!VerifySignature(body, signature, webhookSecret))
+        {
+            _logger.LogWarning("Invalid webhook signature for delivery {Delivery}", delivery);
+            return Unauthorized("Invalid signature");
         }
 
         // Handle different event types

--- a/src/VirtualAssistant.Service/Extensions/HostingExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/HostingExtensions.cs
@@ -45,17 +45,29 @@ public static class HostingExtensions
     /// <summary>
     /// Configures Kestrel to listen on all interfaces.
     /// </summary>
+    /// <remarks>
+    /// **Auth policy (decided 2026-04-18 as part of code review #978):**
+    ///
+    /// The service binds to 0.0.0.0 because Remote Control must be reachable from
+    /// the user's phone on the LAN. All non-webhook endpoints are therefore
+    /// deliberately anonymous and rely on three layers of defense:
+    ///
+    /// 1. Trusted LAN. The user runs this service on a home/office network behind
+    ///    NAT; the port is not internet-exposed. If you operate on an untrusted
+    ///    network, configure a firewall rule or a reverse proxy with auth.
+    ///
+    /// 2. Input bounds on state-mutating endpoints (see e.g. NotificationsController
+    ///    text-length / issue-id caps added under #984).
+    ///
+    /// 3. GitHub webhook endpoint has mandatory signature validation — see
+    ///    GitHubWebhooksController (fail-closed behavior added under #978).
+    ///
+    /// If you add new state-mutating endpoints, either decorate them with
+    /// [AllowAnonymous] and cite this block, or add a specific auth scheme.
+    /// </remarks>
     private static void ConfigureKestrel(this WebApplicationBuilder builder)
     {
         var listenerPort = builder.Configuration.GetValue("ListenerApiPort", 5055);
-
-        // SECURITY WARNING: Binding to 0.0.0.0 exposes the service to all network interfaces,
-        // including external networks. This service currently has NO authentication.
-        // For production use on untrusted networks, consider:
-        // 1. Binding to localhost only (127.0.0.1) for local-only access
-        // 2. Adding authentication middleware (API keys, OAuth, etc.)
-        // 3. Using a reverse proxy (nginx) with access control
-        // 4. Configuring firewall rules to restrict access
         var remotePort = builder.Configuration.GetValue("RemoteControlPort", 5050);
         builder.WebHost.UseUrls($"http://0.0.0.0:{listenerPort}", $"http://0.0.0.0:{remotePort}");
     }

--- a/tests/VirtualAssistant.Service.Tests/Controllers/GitHubWebhooksControllerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Controllers/GitHubWebhooksControllerTests.cs
@@ -15,6 +15,8 @@ namespace Olbrasoft.VirtualAssistant.Service.Tests.Controllers;
 /// </summary>
 public class GitHubWebhooksControllerTests
 {
+    private const string TestSecret = "test-secret";
+
     private readonly Mock<ILogger<GitHubWebhooksController>> _loggerMock;
     private readonly Mock<IConfiguration> _configurationMock;
     private readonly GitHubWebhooksController _controller;
@@ -23,7 +25,9 @@ public class GitHubWebhooksControllerTests
     {
         _loggerMock = new Mock<ILogger<GitHubWebhooksController>>();
         _configurationMock = new Mock<IConfiguration>();
-        _configurationMock.Setup(x => x["GitHub:WebhookSecret"]).Returns((string?)null);
+        // Default: secret configured so happy-path tests that pass a valid signature work;
+        // tests exercising the no-secret branch override this setup explicitly.
+        _configurationMock.Setup(x => x["GitHub:WebhookSecret"]).Returns(TestSecret);
 
         _controller = new GitHubWebhooksController(
             _loggerMock.Object,
@@ -35,7 +39,7 @@ public class GitHubWebhooksControllerTests
     {
         // Arrange
         var pingPayload = @"{""zen"": ""Anything added dilutes everything else.""}";
-        SetupControllerContext("ping", "delivery-123", null, pingPayload);
+        SetupControllerContext("ping", "delivery-123", ComputeSignature(pingPayload, TestSecret), pingPayload);
 
         // Act
         var result = await _controller.HandleGitHubWebhook();
@@ -54,7 +58,7 @@ public class GitHubWebhooksControllerTests
             ""repository"": { ""name"": ""VirtualAssistant"" },
             ""pusher"": { ""name"": ""test-user"" }
         }";
-        SetupControllerContext("push", "delivery-456", null, pushPayload);
+        SetupControllerContext("push", "delivery-456", ComputeSignature(pushPayload, TestSecret), pushPayload);
 
         // Act
         var result = await _controller.HandleGitHubWebhook();
@@ -72,7 +76,7 @@ public class GitHubWebhooksControllerTests
     {
         // Arrange
         var unknownPayload = @"{}";
-        SetupControllerContext("unknown_event", "delivery-789", null, unknownPayload);
+        SetupControllerContext("unknown_event", "delivery-789", ComputeSignature(unknownPayload, TestSecret), unknownPayload);
 
         // Act
         var result = await _controller.HandleGitHubWebhook();
@@ -89,16 +93,11 @@ public class GitHubWebhooksControllerTests
     public async Task HandleGitHubWebhook_WithInvalidSignature_ReturnsUnauthorized()
     {
         // Arrange
-        var webhookSecret = "test-secret";
-        _configurationMock.Setup(x => x["GitHub:WebhookSecret"]).Returns(webhookSecret);
-
-        var controller = new GitHubWebhooksController(_loggerMock.Object, _configurationMock.Object);
-
         var pingPayload = @"{""zen"": ""Test""}";
-        SetupControllerContext("ping", "delivery-000", "sha256=invalid_signature", pingPayload, controller);
+        SetupControllerContext("ping", "delivery-000", "sha256=invalid_signature", pingPayload);
 
         // Act
-        var result = await controller.HandleGitHubWebhook();
+        var result = await _controller.HandleGitHubWebhook();
 
         // Assert
         var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result);
@@ -109,21 +108,48 @@ public class GitHubWebhooksControllerTests
     public async Task HandleGitHubWebhook_WithValidSignature_ProcessesEvent()
     {
         // Arrange
-        var webhookSecret = "test-secret";
-        _configurationMock.Setup(x => x["GitHub:WebhookSecret"]).Returns(webhookSecret);
+        var pingPayload = @"{""zen"": ""Test""}";
+        SetupControllerContext("ping", "delivery-001", ComputeSignature(pingPayload, TestSecret), pingPayload);
 
+        // Act
+        var result = await _controller.HandleGitHubWebhook();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+    }
+
+    [Fact]
+    public async Task HandleGitHubWebhook_WithoutConfiguredSecret_ReturnsUnauthorized()
+    {
+        // Arrange — no secret configured (fail-closed under #978)
+        _configurationMock.Setup(x => x["GitHub:WebhookSecret"]).Returns((string?)null);
         var controller = new GitHubWebhooksController(_loggerMock.Object, _configurationMock.Object);
 
         var pingPayload = @"{""zen"": ""Test""}";
-        var signature = ComputeSignature(pingPayload, webhookSecret);
-        SetupControllerContext("ping", "delivery-001", signature, pingPayload, controller);
+        SetupControllerContext("ping", "delivery-no-secret", "sha256=any", pingPayload, controller);
 
         // Act
         var result = await controller.HandleGitHubWebhook();
 
         // Assert
-        var okResult = Assert.IsType<OkObjectResult>(result);
-        Assert.NotNull(okResult.Value);
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result);
+        Assert.Equal("Webhook secret not configured", unauthorized.Value);
+    }
+
+    [Fact]
+    public async Task HandleGitHubWebhook_WithoutSignatureHeader_ReturnsUnauthorized()
+    {
+        // Arrange — secret is configured, but the caller omitted the signature header
+        var pingPayload = @"{""zen"": ""Test""}";
+        SetupControllerContext("ping", "delivery-no-sig", signature: null, body: pingPayload);
+
+        // Act
+        var result = await _controller.HandleGitHubWebhook();
+
+        // Assert
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result);
+        Assert.Equal("Missing signature", unauthorized.Value);
     }
 
     [Fact]
@@ -135,7 +161,7 @@ public class GitHubWebhooksControllerTests
             ""repository"": { ""name"": ""UnknownRepo"" },
             ""pusher"": { ""name"": ""test-user"" }
         }";
-        SetupControllerContext("push", "delivery-unknown", null, pushPayload);
+        SetupControllerContext("push", "delivery-unknown", ComputeSignature(pushPayload, TestSecret), pushPayload);
 
         // Act
         var result = await _controller.HandleGitHubWebhook();
@@ -153,7 +179,7 @@ public class GitHubWebhooksControllerTests
     {
         // Arrange - malformed JSON should still return pong
         var malformedPayload = @"not valid json";
-        SetupControllerContext("ping", "delivery-bad", null, malformedPayload);
+        SetupControllerContext("ping", "delivery-bad", ComputeSignature(malformedPayload, TestSecret), malformedPayload);
 
         // Act
         var result = await _controller.HandleGitHubWebhook();
@@ -168,7 +194,7 @@ public class GitHubWebhooksControllerTests
     {
         // Arrange
         var malformedPayload = @"not valid json";
-        SetupControllerContext("push", "delivery-bad-push", null, malformedPayload);
+        SetupControllerContext("push", "delivery-bad-push", ComputeSignature(malformedPayload, TestSecret), malformedPayload);
 
         // Act
         var result = await _controller.HandleGitHubWebhook();


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #978

## Summary
**Real fix:**
- `GitHubWebhooksController` fails closed — a deployment with no `GitHub:WebhookSecret` now returns **401** instead of silently accepting unsigned payloads. Missing `X-Hub-Signature-256` also returns 401. Previously both were silently skipped.

**Policy decision (explicit):**
- The service binds to `0.0.0.0` because Remote Control must reach it from the user's phone on the LAN — 127.0.0.1-only is incompatible with the product. Non-webhook endpoints stay anonymous on purpose.
- New authoritative comment in `HostingExtensions.ConfigureKestrel` lists the three defense layers (trusted LAN, input bounds, webhook signature) and tells future-you what to do when adding a new state-mutating endpoint.

## Test plan
- [x] `dotnet test GitHubWebhooksControllerTests` — 10/10 (including two new negative-path tests: missing secret / missing signature)
- [ ] CI green
- [ ] Smoke test: real GitHub webhook still delivers after deploy