### PR TITLE
refactor(llm): extract SystemPromptResolver from LlmProviderBase

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -273,50 +273,43 @@ public static class VoiceServicesExtensions
         services.AddHttpClient("Zen");
         services.AddHttpClient("Mercury");
 
+        // SystemPromptResolver encapsulates the CLI-app / window-pattern / default
+        // prompt priority cascade that every provider needs. Registered once so all
+        // three providers share the same logic + caching semantics.
+        services.AddSingleton<ISystemPromptResolver, SystemPromptResolver>();
+
         // Register MistralProvider
         services.AddSingleton<ILlmProvider, MistralProvider>(sp =>
-        {
-            var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
-            var httpClient = httpClientFactory.CreateClient("Mistral");
-            var options = sp.GetRequiredService<IOptions<MistralOptions>>();
-            var promptCache = sp.GetRequiredService<IPromptCache>();
-            var logger = sp.GetRequiredService<ILogger<MistralProvider>>();
-            var desktopContextService = sp.GetRequiredService<IDesktopContextService>();
-            var queryProcessor = sp.GetRequiredService<IQueryProcessor>();
-            var cliAppDetector = sp.GetRequiredService<ICliAppDetector>();
-            var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
-            return new MistralProvider(httpClient, options, promptCache, logger, desktopContextService, queryProcessor, cliAppDetector, scopeFactory);
-        });
+            new MistralProvider(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient("Mistral"),
+                sp.GetRequiredService<IOptions<MistralOptions>>(),
+                sp.GetRequiredService<IPromptCache>(),
+                sp.GetRequiredService<ILogger<MistralProvider>>(),
+                sp.GetRequiredService<IQueryProcessor>(),
+                sp.GetRequiredService<ISystemPromptResolver>(),
+                sp.GetRequiredService<IServiceScopeFactory>()));
 
         // Register ZenProvider
         services.AddSingleton<ILlmProvider, ZenProvider>(sp =>
-        {
-            var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
-            var httpClient = httpClientFactory.CreateClient("Zen");
-            var options = sp.GetRequiredService<IOptions<ZenOptions>>();
-            var promptCache = sp.GetRequiredService<IPromptCache>();
-            var logger = sp.GetRequiredService<ILogger<ZenProvider>>();
-            var desktopContextService = sp.GetRequiredService<IDesktopContextService>();
-            var queryProcessor = sp.GetRequiredService<IQueryProcessor>();
-            var cliAppDetector = sp.GetRequiredService<ICliAppDetector>();
-            var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
-            return new ZenProvider(httpClient, options, promptCache, logger, desktopContextService, queryProcessor, cliAppDetector, scopeFactory);
-        });
+            new ZenProvider(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient("Zen"),
+                sp.GetRequiredService<IOptions<ZenOptions>>(),
+                sp.GetRequiredService<IPromptCache>(),
+                sp.GetRequiredService<ILogger<ZenProvider>>(),
+                sp.GetRequiredService<IQueryProcessor>(),
+                sp.GetRequiredService<ISystemPromptResolver>(),
+                sp.GetRequiredService<IServiceScopeFactory>()));
 
         // Register MercuryProvider
         services.AddSingleton<ILlmProvider, MercuryProvider>(sp =>
-        {
-            var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
-            var httpClient = httpClientFactory.CreateClient("Mercury");
-            var options = sp.GetRequiredService<IOptions<MercuryOptions>>();
-            var promptCache = sp.GetRequiredService<IPromptCache>();
-            var logger = sp.GetRequiredService<ILogger<MercuryProvider>>();
-            var desktopContextService = sp.GetRequiredService<IDesktopContextService>();
-            var queryProcessor = sp.GetRequiredService<IQueryProcessor>();
-            var cliAppDetector = sp.GetRequiredService<ICliAppDetector>();
-            var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
-            return new MercuryProvider(httpClient, options, promptCache, logger, desktopContextService, queryProcessor, cliAppDetector, scopeFactory);
-        });
+            new MercuryProvider(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient("Mercury"),
+                sp.GetRequiredService<IOptions<MercuryOptions>>(),
+                sp.GetRequiredService<IPromptCache>(),
+                sp.GetRequiredService<ILogger<MercuryProvider>>(),
+                sp.GetRequiredService<IQueryProcessor>(),
+                sp.GetRequiredService<ISystemPromptResolver>(),
+                sp.GetRequiredService<IServiceScopeFactory>()));
 
         // Register LlmProviderFactory
         services.AddSingleton<ILlmProviderFactory, LlmProviderFactory>();

--- a/src/VirtualAssistant.Voice/Services/ISystemPromptResolver.cs
+++ b/src/VirtualAssistant.Voice/Services/ISystemPromptResolver.cs
@@ -1,0 +1,26 @@
+namespace Olbrasoft.VirtualAssistant.Voice.Services;
+
+/// <summary>
+/// Resolves the system prompt that an LLM provider should use for the current
+/// desktop context. Extracted from <see cref="LlmProviderBase"/> so every
+/// provider shares the same priority-cascade logic and so the 85-line method
+/// no longer lives on the abstract base.
+/// </summary>
+/// <remarks>
+/// Priority cascade:
+/// 1. CLI app running in the focused terminal (Claude Code, OpenCode, Gemini) →
+///    prompt keyed by <c>CliAppDescriptor.PromptFileName</c>.
+/// 2. Window-title / application-ID pattern match in the <c>prompts</c> table.
+/// 3. Default prompt (AppIdPattern = "*").
+/// 4. Hardcoded "DefaultCorrection" cache lookup + ID 4 fallback (last-resort
+///    when the default prompt row is missing).
+/// </remarks>
+public interface ISystemPromptResolver
+{
+    /// <summary>
+    /// Resolves the system prompt for the currently focused window.
+    /// </summary>
+    /// <returns>Tuple of (prompt text, prompt ID). Never returns null; falls
+    /// back to a hardcoded prompt if every priority level fails.</returns>
+    Task<(string PromptText, int PromptId)> ResolveAsync(CancellationToken cancellationToken = default);
+}

--- a/src/VirtualAssistant.Voice/Services/LlmProviderBase.cs
+++ b/src/VirtualAssistant.Voice/Services/LlmProviderBase.cs
@@ -18,9 +18,8 @@ public abstract class LlmProviderBase : ILlmProvider
     protected readonly HttpClient HttpClient;
     protected readonly ILogger Logger;
     protected readonly IPromptCache PromptCache;
-    protected readonly IDesktopContextService DesktopContextService;
     protected readonly IQueryProcessor QueryProcessor;
-    protected readonly ICliAppDetector CliAppDetector;
+    private readonly ISystemPromptResolver _promptResolver;
     private readonly IServiceScopeFactory _scopeFactory;
 
     private Dictionary<string, string> _lastRateLimitHeaders = new();
@@ -61,87 +60,27 @@ public abstract class LlmProviderBase : ILlmProvider
         HttpClient httpClient,
         IPromptCache promptCache,
         ILogger logger,
-        IDesktopContextService desktopContextService,
         IQueryProcessor queryProcessor,
-        ICliAppDetector cliAppDetector,
+        ISystemPromptResolver promptResolver,
         IServiceScopeFactory scopeFactory,
         bool initialEnabled)
     {
         HttpClient = httpClient;
         PromptCache = promptCache ?? throw new ArgumentNullException(nameof(promptCache));
         Logger = logger;
-        DesktopContextService = desktopContextService ?? throw new ArgumentNullException(nameof(desktopContextService));
         QueryProcessor = queryProcessor ?? throw new ArgumentNullException(nameof(queryProcessor));
-        CliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+        _promptResolver = promptResolver ?? throw new ArgumentNullException(nameof(promptResolver));
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _runtimeEnabled = initialEnabled;
     }
 
     /// <summary>
     /// Gets the system prompt based on current desktop context.
-    /// Priority: 1) CLI app detection (Claude Code, OpenCode), 2) Window title/app pattern, 3) Default prompt.
-    /// Returns (promptText, promptId) tuple.
+    /// Delegates to the injected <see cref="ISystemPromptResolver"/> — see that
+    /// type for the priority cascade (CLI app → window pattern → default).
     /// </summary>
-    protected async Task<(string PromptText, int PromptId)> GetSystemPromptAsync(CancellationToken ct)
-    {
-        try
-        {
-            var context = await DesktopContextService.GetCurrentContextAsync(ct);
-
-            // Priority 1: Check for CLI apps running in terminals (e.g., Claude Code, OpenCode)
-            // This handles cases where CLI apps run in terminal but don't change window title
-            var cliApp = await CliAppDetector.DetectCliAppAsync(ct);
-            if (cliApp != null)
-            {
-                Logger.LogDebug("CLI app detected: {AppName} → using prompt '{Prompt}'",
-                    cliApp.AppName, cliApp.PromptFileName);
-
-                // Get prompt ID from database by file name
-                var cliPrompt = await QueryProcessor.ProcessAsync(
-                    new GetPromptByFileNameQuery(cliApp.PromptFileName), ct);
-
-                if (cliPrompt != null)
-                {
-                    var cliPromptText = PromptCache.GetPrompt(cliPrompt.PromptFileName);
-                    Logger.LogDebug("Using prompt '{Prompt}' (ID: {Id}) for CLI app '{App}'",
-                        cliPrompt.PromptFileName, cliPrompt.Id, cliApp.AppName);
-                    return (cliPromptText, cliPrompt.Id);
-                }
-
-                // CLI app detected but no matching prompt in DB - use prompt file directly with ID 0
-                Logger.LogWarning("CLI app '{App}' detected but prompt '{Prompt}' not found in database",
-                    cliApp.AppName, cliApp.PromptFileName);
-            }
-
-            // Priority 2: Match by window title or application pattern
-            Logger.LogDebug("Active window: '{Title}', app: '{App}', looking for matching prompt pattern",
-                context.ActiveWindowTitle, context.ActiveApplication);
-
-            var prompt = await QueryProcessor.ProcessAsync(
-                new GetPromptByAppIdPatternQuery(context.ActiveWindowTitle, context.ActiveApplication), ct);
-
-            // Priority 3: Default prompt
-            prompt ??= await QueryProcessor.ProcessAsync(new GetDefaultPromptQuery(), ct);
-
-            if (prompt == null)
-            {
-                Logger.LogError("CRITICAL: No default prompt found in database - using hardcoded fallback");
-                return (PromptCache.GetPrompt("DefaultCorrection"), 4);
-            }
-
-            var promptText = PromptCache.GetPrompt(prompt.PromptFileName);
-
-            Logger.LogDebug("Using prompt '{Prompt}' (ID: {Id}) for window '{Title}'",
-                prompt.PromptFileName, prompt.Id, context.ActiveWindowTitle);
-
-            return (promptText, prompt.Id);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error getting context-aware prompt, falling back to DefaultCorrection (ID 4)");
-            return (PromptCache.GetPrompt("DefaultCorrection"), 4);
-        }
-    }
+    protected Task<(string PromptText, int PromptId)> GetSystemPromptAsync(CancellationToken ct)
+        => _promptResolver.ResolveAsync(ct);
 
     /// <summary>
     /// Gets the ModelId from database based on configured ModelIdentifier.

--- a/src/VirtualAssistant.Voice/Services/MercuryProvider.cs
+++ b/src/VirtualAssistant.Voice/Services/MercuryProvider.cs
@@ -33,11 +33,10 @@ public class MercuryProvider : LlmProviderBase
         IOptions<MercuryOptions> options,
         IPromptCache promptCache,
         ILogger<MercuryProvider> logger,
-        IDesktopContextService desktopContextService,
         IQueryProcessor queryProcessor,
-        ICliAppDetector cliAppDetector,
+        ISystemPromptResolver promptResolver,
         IServiceScopeFactory scopeFactory)
-        : base(httpClient, promptCache, logger, desktopContextService, queryProcessor, cliAppDetector, scopeFactory, options.Value.Enabled)
+        : base(httpClient, promptCache, logger, queryProcessor, promptResolver, scopeFactory, options.Value.Enabled)
     {
         _options = options.Value;
 

--- a/src/VirtualAssistant.Voice/Services/MistralProvider.cs
+++ b/src/VirtualAssistant.Voice/Services/MistralProvider.cs
@@ -30,11 +30,10 @@ public class MistralProvider : LlmProviderBase
         IOptions<MistralOptions> options,
         IPromptCache promptCache,
         ILogger<MistralProvider> logger,
-        IDesktopContextService desktopContextService,
         IQueryProcessor queryProcessor,
-        ICliAppDetector cliAppDetector,
+        ISystemPromptResolver promptResolver,
         IServiceScopeFactory scopeFactory)
-        : base(httpClient, promptCache, logger, desktopContextService, queryProcessor, cliAppDetector, scopeFactory, options.Value.Enabled)
+        : base(httpClient, promptCache, logger, queryProcessor, promptResolver, scopeFactory, options.Value.Enabled)
     {
         _options = options.Value;
 

--- a/src/VirtualAssistant.Voice/Services/SystemPromptResolver.cs
+++ b/src/VirtualAssistant.Voice/Services/SystemPromptResolver.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+using Olbrasoft.Data.Cqrs;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+using Olbrasoft.VirtualAssistant.Data.Queries.PromptQueries;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Services;
+
+/// <inheritdoc />
+public sealed class SystemPromptResolver : ISystemPromptResolver
+{
+    // Last-resort fallback when every DB priority level misses. The cache
+    // key and ID are historical (baked into the seed migrations), so changes
+    // here must match the default row in the prompts table.
+    private const string FallbackPromptKey = "DefaultCorrection";
+    private const int FallbackPromptId = 4;
+
+    private readonly IPromptCache _promptCache;
+    private readonly IDesktopContextService _desktopContextService;
+    private readonly IQueryProcessor _queryProcessor;
+    private readonly ICliAppDetector _cliAppDetector;
+    private readonly ILogger<SystemPromptResolver> _logger;
+
+    public SystemPromptResolver(
+        IPromptCache promptCache,
+        IDesktopContextService desktopContextService,
+        IQueryProcessor queryProcessor,
+        ICliAppDetector cliAppDetector,
+        ILogger<SystemPromptResolver> logger)
+    {
+        _promptCache = promptCache ?? throw new ArgumentNullException(nameof(promptCache));
+        _desktopContextService = desktopContextService ?? throw new ArgumentNullException(nameof(desktopContextService));
+        _queryProcessor = queryProcessor ?? throw new ArgumentNullException(nameof(queryProcessor));
+        _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<(string PromptText, int PromptId)> ResolveAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var context = await _desktopContextService.GetCurrentContextAsync(cancellationToken);
+
+            if (await TryResolveCliAppPromptAsync(cancellationToken) is { } cliPrompt)
+            {
+                return cliPrompt;
+            }
+
+            _logger.LogDebug("Active window: '{Title}', app: '{App}', looking for matching prompt pattern",
+                context.ActiveWindowTitle, context.ActiveApplication);
+
+            var prompt = await _queryProcessor.ProcessAsync(
+                new GetPromptByAppIdPatternQuery(context.ActiveWindowTitle, context.ActiveApplication),
+                cancellationToken);
+
+            prompt ??= await _queryProcessor.ProcessAsync(new GetDefaultPromptQuery(), cancellationToken);
+
+            if (prompt == null)
+            {
+                _logger.LogError("CRITICAL: No default prompt found in database — using hardcoded fallback");
+                return (_promptCache.GetPrompt(FallbackPromptKey), FallbackPromptId);
+            }
+
+            var promptText = _promptCache.GetPrompt(prompt.PromptFileName);
+            _logger.LogDebug("Using prompt '{Prompt}' (ID: {Id}) for window '{Title}'",
+                prompt.PromptFileName, prompt.Id, context.ActiveWindowTitle);
+
+            return (promptText, prompt.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error resolving context-aware prompt, falling back to {Fallback} (ID {Id})",
+                FallbackPromptKey, FallbackPromptId);
+            return (_promptCache.GetPrompt(FallbackPromptKey), FallbackPromptId);
+        }
+    }
+
+    private async Task<(string PromptText, int PromptId)?> TryResolveCliAppPromptAsync(CancellationToken cancellationToken)
+    {
+        var cliApp = await _cliAppDetector.DetectCliAppAsync(cancellationToken);
+        if (cliApp == null)
+        {
+            return null;
+        }
+
+        _logger.LogDebug("CLI app detected: {AppName} → using prompt '{Prompt}'",
+            cliApp.AppName, cliApp.PromptFileName);
+
+        var cliPrompt = await _queryProcessor.ProcessAsync(
+            new GetPromptByFileNameQuery(cliApp.PromptFileName),
+            cancellationToken);
+
+        if (cliPrompt == null)
+        {
+            _logger.LogWarning("CLI app '{App}' detected but prompt '{Prompt}' not found in database",
+                cliApp.AppName, cliApp.PromptFileName);
+            return null;
+        }
+
+        var cliPromptText = _promptCache.GetPrompt(cliPrompt.PromptFileName);
+        _logger.LogDebug("Using prompt '{Prompt}' (ID: {Id}) for CLI app '{App}'",
+            cliPrompt.PromptFileName, cliPrompt.Id, cliApp.AppName);
+        return (cliPromptText, cliPrompt.Id);
+    }
+}

--- a/src/VirtualAssistant.Voice/Services/SystemPromptResolver.cs
+++ b/src/VirtualAssistant.Voice/Services/SystemPromptResolver.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Olbrasoft.Data.Cqrs;
 using Olbrasoft.VirtualAssistant.Core.Services;
@@ -17,21 +18,29 @@ public sealed class SystemPromptResolver : ISystemPromptResolver
 
     private readonly IPromptCache _promptCache;
     private readonly IDesktopContextService _desktopContextService;
-    private readonly IQueryProcessor _queryProcessor;
     private readonly ICliAppDetector _cliAppDetector;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<SystemPromptResolver> _logger;
 
+    /// <summary>
+    /// Registered as a Singleton, so we cannot capture the scoped
+    /// <see cref="IQueryProcessor"/> (which transitively owns the EF Core
+    /// DbContext) — that would be the captive-dependency bug that #972 already
+    /// taught us about. Each <see cref="ResolveAsync"/> call instead creates
+    /// a short-lived scope and pulls IQueryProcessor from it, matching the
+    /// pattern established in <c>PromptResolver</c>.
+    /// </summary>
     public SystemPromptResolver(
         IPromptCache promptCache,
         IDesktopContextService desktopContextService,
-        IQueryProcessor queryProcessor,
         ICliAppDetector cliAppDetector,
+        IServiceScopeFactory scopeFactory,
         ILogger<SystemPromptResolver> logger)
     {
         _promptCache = promptCache ?? throw new ArgumentNullException(nameof(promptCache));
         _desktopContextService = desktopContextService ?? throw new ArgumentNullException(nameof(desktopContextService));
-        _queryProcessor = queryProcessor ?? throw new ArgumentNullException(nameof(queryProcessor));
         _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -41,7 +50,10 @@ public sealed class SystemPromptResolver : ISystemPromptResolver
         {
             var context = await _desktopContextService.GetCurrentContextAsync(cancellationToken);
 
-            if (await TryResolveCliAppPromptAsync(cancellationToken) is { } cliPrompt)
+            using var scope = _scopeFactory.CreateScope();
+            var queryProcessor = scope.ServiceProvider.GetRequiredService<IQueryProcessor>();
+
+            if (await TryResolveCliAppPromptAsync(queryProcessor, cancellationToken) is { } cliPrompt)
             {
                 return cliPrompt;
             }
@@ -49,11 +61,11 @@ public sealed class SystemPromptResolver : ISystemPromptResolver
             _logger.LogDebug("Active window: '{Title}', app: '{App}', looking for matching prompt pattern",
                 context.ActiveWindowTitle, context.ActiveApplication);
 
-            var prompt = await _queryProcessor.ProcessAsync(
+            var prompt = await queryProcessor.ProcessAsync(
                 new GetPromptByAppIdPatternQuery(context.ActiveWindowTitle, context.ActiveApplication),
                 cancellationToken);
 
-            prompt ??= await _queryProcessor.ProcessAsync(new GetDefaultPromptQuery(), cancellationToken);
+            prompt ??= await queryProcessor.ProcessAsync(new GetDefaultPromptQuery(), cancellationToken);
 
             if (prompt == null)
             {
@@ -67,6 +79,12 @@ public sealed class SystemPromptResolver : ISystemPromptResolver
 
             return (promptText, prompt.Id);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Propagate user cancellation — a cancelled caller must not silently
+            // get the fallback prompt (matches PromptResolver's behavior).
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error resolving context-aware prompt, falling back to {Fallback} (ID {Id})",
@@ -75,7 +93,9 @@ public sealed class SystemPromptResolver : ISystemPromptResolver
         }
     }
 
-    private async Task<(string PromptText, int PromptId)?> TryResolveCliAppPromptAsync(CancellationToken cancellationToken)
+    private async Task<(string PromptText, int PromptId)?> TryResolveCliAppPromptAsync(
+        IQueryProcessor queryProcessor,
+        CancellationToken cancellationToken)
     {
         var cliApp = await _cliAppDetector.DetectCliAppAsync(cancellationToken);
         if (cliApp == null)
@@ -86,7 +106,7 @@ public sealed class SystemPromptResolver : ISystemPromptResolver
         _logger.LogDebug("CLI app detected: {AppName} → using prompt '{Prompt}'",
             cliApp.AppName, cliApp.PromptFileName);
 
-        var cliPrompt = await _queryProcessor.ProcessAsync(
+        var cliPrompt = await queryProcessor.ProcessAsync(
             new GetPromptByFileNameQuery(cliApp.PromptFileName),
             cancellationToken);
 

--- a/src/VirtualAssistant.Voice/Services/ZenProvider.cs
+++ b/src/VirtualAssistant.Voice/Services/ZenProvider.cs
@@ -31,11 +31,10 @@ public class ZenProvider : LlmProviderBase
         IOptions<ZenOptions> options,
         IPromptCache promptCache,
         ILogger<ZenProvider> logger,
-        IDesktopContextService desktopContextService,
         IQueryProcessor queryProcessor,
-        ICliAppDetector cliAppDetector,
+        ISystemPromptResolver promptResolver,
         IServiceScopeFactory scopeFactory)
-        : base(httpClient, promptCache, logger, desktopContextService, queryProcessor, cliAppDetector, scopeFactory, options.Value.Enabled)
+        : base(httpClient, promptCache, logger, queryProcessor, promptResolver, scopeFactory, options.Value.Enabled)
     {
         _options = options.Value;
 

--- a/tests/VirtualAssistant.Voice.Tests/Services/LlmProviderBaseDynamicMaxTokensTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/LlmProviderBaseDynamicMaxTokensTests.cs
@@ -146,9 +146,8 @@ public class LlmProviderBaseDynamicMaxTokensTests
             httpClient,
             Mock.Of<IPromptCache>(),
             Mock.Of<ILogger>(),
-            Mock.Of<IDesktopContextService>(),
             Mock.Of<IQueryProcessor>(),
-            Mock.Of<ICliAppDetector>(),
+            Mock.Of<ISystemPromptResolver>(),
             Mock.Of<IServiceScopeFactory>());
     }
 
@@ -162,11 +161,10 @@ public class LlmProviderBaseDynamicMaxTokensTests
             HttpClient httpClient,
             IPromptCache promptCache,
             ILogger logger,
-            IDesktopContextService desktopContextService,
             IQueryProcessor queryProcessor,
-            ICliAppDetector cliAppDetector,
+            ISystemPromptResolver promptResolver,
             IServiceScopeFactory scopeFactory)
-            : base(httpClient, promptCache, logger, desktopContextService, queryProcessor, cliAppDetector, scopeFactory, initialEnabled: true)
+            : base(httpClient, promptCache, logger, queryProcessor, promptResolver, scopeFactory, initialEnabled: true)
         {
         }
 

--- a/tests/VirtualAssistant.Voice.Tests/Services/SystemPromptResolverTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/SystemPromptResolverTests.cs
@@ -1,0 +1,172 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.Data.Cqrs;
+using Olbrasoft.VirtualAssistant.Core.Models;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+using Olbrasoft.VirtualAssistant.Data.Entities;
+using Olbrasoft.VirtualAssistant.Data.Queries.PromptQueries;
+using Olbrasoft.VirtualAssistant.Voice.Services;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Tests.Services;
+
+/// <summary>
+/// Unit tests for the priority cascade in <see cref="SystemPromptResolver"/>.
+/// Previously this logic was embedded in LlmProviderBase.GetSystemPromptAsync
+/// and exercised indirectly through provider tests; now that the resolver is
+/// its own service, each branch deserves a dedicated test.
+/// </summary>
+public class SystemPromptResolverTests : IDisposable
+{
+    private readonly Mock<IPromptCache> _promptCacheMock = new();
+    private readonly Mock<IDesktopContextService> _desktopContextServiceMock = new();
+    private readonly Mock<ICliAppDetector> _cliAppDetectorMock = new();
+    private readonly Mock<IQueryProcessor> _queryProcessorMock = new();
+    private readonly Mock<ILogger<SystemPromptResolver>> _loggerMock = new();
+    private readonly ServiceProvider _serviceProvider;
+    private readonly SystemPromptResolver _sut;
+
+    public SystemPromptResolverTests()
+    {
+        _desktopContextServiceMock
+            .Setup(x => x.GetCurrentContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DesktopContext(0, 1, "window", "cls", "app", DateTime.UtcNow));
+
+        // Real scope factory that resolves the mocked IQueryProcessor per-scope —
+        // same shape as production so the captive-dependency fix is actually exercised.
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _queryProcessorMock.Object);
+        _serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
+
+        _sut = new SystemPromptResolver(
+            _promptCacheMock.Object,
+            _desktopContextServiceMock.Object,
+            _cliAppDetectorMock.Object,
+            _serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            _loggerMock.Object);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    [Fact]
+    public async Task ResolveAsync_CliAppDetected_ReturnsCliAppPrompt()
+    {
+        var cliApp = new CliAppDetectionResult(AppName: "Claude Code", PromptFileName: "ClaudeCodeCorrection");
+        _cliAppDetectorMock.Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>())).ReturnsAsync(cliApp);
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.Is<GetPromptByFileNameQuery>(q => q.PromptFileName == "ClaudeCodeCorrection"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Prompt { Id = 42, PromptFileName = "ClaudeCodeCorrection" });
+        _promptCacheMock.Setup(x => x.GetPrompt("ClaudeCodeCorrection")).Returns("cli prompt text");
+
+        var (text, id) = await _sut.ResolveAsync();
+
+        Assert.Equal("cli prompt text", text);
+        Assert.Equal(42, id);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CliAppDetectedButPromptMissingFromDb_FallsThroughToWindowPattern()
+    {
+        var cliApp = new CliAppDetectionResult(AppName: "Claude Code", PromptFileName: "ClaudeCodeCorrection");
+        _cliAppDetectorMock.Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>())).ReturnsAsync(cliApp);
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<GetPromptByFileNameQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Prompt?)null);
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<GetPromptByAppIdPatternQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Prompt { Id = 7, PromptFileName = "WindowPattern" });
+        _promptCacheMock.Setup(x => x.GetPrompt("WindowPattern")).Returns("window pattern text");
+
+        var (text, id) = await _sut.ResolveAsync();
+
+        Assert.Equal("window pattern text", text);
+        Assert.Equal(7, id);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoCliApp_ReturnsWindowPatternPrompt()
+    {
+        _cliAppDetectorMock.Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>())).ReturnsAsync((CliAppDetectionResult?)null);
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<GetPromptByAppIdPatternQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Prompt { Id = 5, PromptFileName = "EditorCorrection" });
+        _promptCacheMock.Setup(x => x.GetPrompt("EditorCorrection")).Returns("editor prompt");
+
+        var (text, id) = await _sut.ResolveAsync();
+
+        Assert.Equal("editor prompt", text);
+        Assert.Equal(5, id);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoCliAppNoWindowMatch_ReturnsDefaultPrompt()
+    {
+        _cliAppDetectorMock.Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>())).ReturnsAsync((CliAppDetectionResult?)null);
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<GetPromptByAppIdPatternQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Prompt?)null);
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<GetDefaultPromptQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Prompt { Id = 1, PromptFileName = "DefaultCorrection" });
+        _promptCacheMock.Setup(x => x.GetPrompt("DefaultCorrection")).Returns("default");
+
+        var (text, id) = await _sut.ResolveAsync();
+
+        Assert.Equal("default", text);
+        Assert.Equal(1, id);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_AllDbLookupsFail_UsesHardcodedFallback()
+    {
+        _cliAppDetectorMock.Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>())).ReturnsAsync((CliAppDetectionResult?)null);
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<GetPromptByAppIdPatternQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Prompt?)null);
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<GetDefaultPromptQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Prompt?)null);
+        _promptCacheMock.Setup(x => x.GetPrompt("DefaultCorrection")).Returns("hardcoded fallback");
+
+        var (text, id) = await _sut.ResolveAsync();
+
+        Assert.Equal("hardcoded fallback", text);
+        Assert.Equal(4, id); // documented fallback ID
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CancellationRequested_PropagatesOperationCanceledException()
+    {
+        // Cancellation must not silently return the fallback prompt — the caller
+        // explicitly asked to stop, and should see OperationCanceledException.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _cliAppDetectorMock
+            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => _sut.ResolveAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NonCancellationException_FallsBackToDefault()
+    {
+        // Unexpected errors should still be caught and the fallback returned
+        // — dictation must not crash because of a transient DB hiccup.
+        _cliAppDetectorMock
+            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB blew up"));
+        _promptCacheMock.Setup(x => x.GetPrompt("DefaultCorrection")).Returns("hardcoded fallback");
+
+        var (text, id) = await _sut.ResolveAsync();
+
+        Assert.Equal("hardcoded fallback", text);
+        Assert.Equal(4, id);
+    }
+}

--- a/tests/VirtualAssistant.Voice.Tests/Services/ZenProviderTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/ZenProviderTests.cs
@@ -213,21 +213,12 @@ public class ZenProviderTests
 
     private void SetupMocksForCorrection(Mock<HttpMessageHandler> handlerMock, string responseText = "Corrected text")
     {
-        _desktopContextServiceMock
-            .Setup(x => x.GetCurrentContextAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new DesktopContext(0, 1, "test", "test", "test", DateTime.UtcNow));
-
-        _cliAppDetectorMock
-            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync((CliAppDetectionResult?)null);
-
-        _queryProcessorMock
-            .Setup(x => x.ProcessAsync(It.IsAny<GetPromptByAppIdPatternQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Prompt { Id = 1, PromptFileName = "Test.md" });
-
-        _promptCacheMock
-            .Setup(x => x.GetPrompt("Test.md"))
-            .Returns("System prompt");
+        // Prompt resolution now lives behind ISystemPromptResolver — the old
+        // desktop-context / CLI-app / pattern-query mock setup is no longer on
+        // the Zen code path (it's covered by SystemPromptResolverTests instead).
+        _promptResolverMock
+            .Setup(r => r.ResolveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(("System prompt", 1));
 
         _queryProcessorMock
             .Setup(x => x.ProcessAsync(It.IsAny<GetLlmModelByIdentifierQuery>(), It.IsAny<CancellationToken>()))

--- a/tests/VirtualAssistant.Voice.Tests/Services/ZenProviderTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/ZenProviderTests.cs
@@ -25,6 +25,7 @@ public class ZenProviderTests
     private readonly Mock<IDesktopContextService> _desktopContextServiceMock;
     private readonly Mock<IQueryProcessor> _queryProcessorMock;
     private readonly Mock<ICliAppDetector> _cliAppDetectorMock;
+    private readonly Mock<ISystemPromptResolver> _promptResolverMock;
     private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
     private readonly ZenOptions _options;
 
@@ -50,6 +51,10 @@ public class ZenProviderTests
         _desktopContextServiceMock = new Mock<IDesktopContextService>();
         _queryProcessorMock = new Mock<IQueryProcessor>();
         _cliAppDetectorMock = new Mock<ICliAppDetector>();
+        _promptResolverMock = new Mock<ISystemPromptResolver>();
+        _promptResolverMock
+            .Setup(r => r.ResolveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(("default prompt text", 4));
 
         var scopeMock = new Mock<IServiceScope>();
         var spMock = new Mock<IServiceProvider>();
@@ -67,9 +72,8 @@ public class ZenProviderTests
             _optionsMock.Object,
             _promptCacheMock.Object,
             _loggerMock.Object,
-            _desktopContextServiceMock.Object,
             _queryProcessorMock.Object,
-            _cliAppDetectorMock.Object,
+            _promptResolverMock.Object,
             _scopeFactoryMock.Object);
     }
 
@@ -200,9 +204,8 @@ public class ZenProviderTests
             _optionsMock.Object,
             _promptCacheMock.Object,
             _loggerMock.Object,
-            _desktopContextServiceMock.Object,
             _queryProcessorMock.Object,
-            _cliAppDetectorMock.Object,
+            _promptResolverMock.Object,
             _scopeFactoryMock.Object);
 
         return (sut, handlerMock);
@@ -318,60 +321,52 @@ public class ZenProviderTests
     [Fact]
     public void Constructor_ThrowsOnNullPromptCache()
     {
-        // Arrange & Act & Assert
         Assert.Throws<ArgumentNullException>(() => new ZenProvider(
             new HttpClient(),
             _optionsMock.Object,
             null!,
             _loggerMock.Object,
-            _desktopContextServiceMock.Object,
             _queryProcessorMock.Object,
-            _cliAppDetectorMock.Object,
-            _scopeFactoryMock.Object));
-    }
-
-    [Fact]
-    public void Constructor_ThrowsOnNullDesktopContextService()
-    {
-        // Arrange & Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new ZenProvider(
-            new HttpClient(),
-            _optionsMock.Object,
-            _promptCacheMock.Object,
-            _loggerMock.Object,
-            null!,
-            _queryProcessorMock.Object,
-            _cliAppDetectorMock.Object,
+            _promptResolverMock.Object,
             _scopeFactoryMock.Object));
     }
 
     [Fact]
     public void Constructor_ThrowsOnNullQueryProcessor()
     {
-        // Arrange & Act & Assert
         Assert.Throws<ArgumentNullException>(() => new ZenProvider(
             new HttpClient(),
             _optionsMock.Object,
             _promptCacheMock.Object,
             _loggerMock.Object,
-            _desktopContextServiceMock.Object,
             null!,
-            _cliAppDetectorMock.Object,
+            _promptResolverMock.Object,
             _scopeFactoryMock.Object));
     }
 
     [Fact]
-    public void Constructor_ThrowsOnNullCliAppDetector()
+    public void Constructor_ThrowsOnNullPromptResolver()
     {
-        // Arrange & Act & Assert
         Assert.Throws<ArgumentNullException>(() => new ZenProvider(
             new HttpClient(),
             _optionsMock.Object,
             _promptCacheMock.Object,
             _loggerMock.Object,
-            _desktopContextServiceMock.Object,
             _queryProcessorMock.Object,
             null!,
             _scopeFactoryMock.Object));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullScopeFactory()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ZenProvider(
+            new HttpClient(),
+            _optionsMock.Object,
+            _promptCacheMock.Object,
+            _loggerMock.Object,
+            _queryProcessorMock.Object,
+            _promptResolverMock.Object,
+            null!));
     }
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #975 (partial — SystemPromptResolver extraction; LlmModelCache / LlmResponseValidator / RateLimitTracker follow-ups stay open for separate PRs)

## Summary
- New `ISystemPromptResolver` + `SystemPromptResolver` — owns the 5-way priority cascade (CLI app → window pattern → default prompt → hardcoded fallback)
- `LlmProviderBase.GetSystemPromptAsync` shrinks from 85 LOC to a one-liner delegate
- Concrete providers (Mistral / Mercury / Zen) drop `IDesktopContextService` + `ICliAppDetector` from their ctors; those deps now only live on the resolver
- DI registration in `VoiceServicesExtensions.AddVoiceLlmServices` — Singleton, shared across providers

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 290 Voice + 307 Service + 115 EF + 71 Core + 32 LlmChain = 815 pass, 0 fail
- [ ] CI green
- [ ] Smoke test: dictation LLM correction still uses Claude Code prompt when focused on Claude terminal