### PR TITLE
security(webhook): use CryptographicOperations.FixedTimeEquals for HMAC compare

### DIFF
--- a/src/VirtualAssistant.Service/Controllers/GitHubWebhooksController.cs
+++ b/src/VirtualAssistant.Service/Controllers/GitHubWebhooksController.cs
@@ -241,14 +241,27 @@ public class GitHubWebhooksController : ControllerBase
 
     private static bool VerifySignature(string payload, string signature, string secret)
     {
-        if (!signature.StartsWith("sha256="))
+        // GitHub always sends the "sha256=" prefix — reject anything else.
+        const string Prefix = "sha256=";
+        if (!signature.StartsWith(Prefix, StringComparison.Ordinal))
             return false;
 
-        var expectedSignature = signature[7..];
-        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
-        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(payload));
-        var actualSignature = Convert.ToHexString(hash).ToLowerInvariant();
+        // Parse the provided hex digest. Malformed input (odd length, non-hex chars) → fail closed.
+        byte[] providedHash;
+        try
+        {
+            providedHash = Convert.FromHexString(signature.AsSpan(Prefix.Length));
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
 
-        return string.Equals(expectedSignature, actualSignature, StringComparison.OrdinalIgnoreCase);
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var expectedHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(payload));
+
+        // Constant-time compare on the raw bytes — avoids the timing-side-channel
+        // that a string.Equals comparison would have leaked (Copilot review on #992).
+        return CryptographicOperations.FixedTimeEquals(expectedHash, providedHash);
     }
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

## Summary
Follow-up on Copilot's post-merge comment on #992. The webhook HMAC compare used `string.Equals` on hex digests, which short-circuits on first mismatch and leaks timing information. Replace with `CryptographicOperations.FixedTimeEquals` on the raw bytes.

## Changes
- Decode the provided `sha256=<hex>` with `Convert.FromHexString` (catches FormatException → fail closed)
- Compare raw HMAC bytes with `FixedTimeEquals` (constant-time)
- Explicit `StringComparison.Ordinal` on prefix check

## Test plan
- [x] `dotnet test GitHubWebhooksControllerTests` — 10/10 pass (no test changes required)
- [ ] CI green