### PR TITLE
refactor(keyboard): extract DotoolProcessRunner + ClipboardPasteOrchestrator

### DIFF
--- a/src/VirtualAssistant.Core/Keyboard/ClipboardPasteOrchestrator.cs
+++ b/src/VirtualAssistant.Core/Keyboard/ClipboardPasteOrchestrator.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging;
+using Olbrasoft.VirtualAssistant.Core.Clipboard;
+
+namespace Olbrasoft.VirtualAssistant.Core.Keyboard;
+
+/// <inheritdoc />
+public sealed class ClipboardPasteOrchestrator : IClipboardPasteOrchestrator
+{
+    private readonly IClipboardManager _clipboardManager;
+    private readonly ILogger<ClipboardPasteOrchestrator> _logger;
+
+    public ClipboardPasteOrchestrator(
+        IClipboardManager clipboardManager,
+        ILogger<ClipboardPasteOrchestrator> logger)
+    {
+        _clipboardManager = clipboardManager ?? throw new ArgumentNullException(nameof(clipboardManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<bool> StageAndRestoreAsync(
+        string stagedText,
+        bool usePrimary,
+        Func<Task<bool>> performPasteAsync,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stagedText);
+        ArgumentNullException.ThrowIfNull(performPasteAsync);
+
+        var original = usePrimary
+            ? await _clipboardManager.GetPrimarySelectionAsync(cancellationToken)
+            : await _clipboardManager.GetClipboardAsync(cancellationToken);
+
+        if (usePrimary)
+            await _clipboardManager.SetPrimarySelectionAsync(stagedText, cancellationToken);
+        else
+            await _clipboardManager.SetClipboardAsync(stagedText, cancellationToken);
+
+        try
+        {
+            return await performPasteAsync();
+        }
+        finally
+        {
+            await TryRestoreAsync(original, usePrimary, cancellationToken);
+        }
+    }
+
+    private async Task TryRestoreAsync(string? original, bool usePrimary, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(original)) return;
+
+        try
+        {
+            if (usePrimary)
+                await _clipboardManager.SetPrimarySelectionAsync(original, cancellationToken);
+            else
+                await _clipboardManager.SetClipboardAsync(original, cancellationToken);
+
+            _logger.LogDebug("Restored original {Selection}", usePrimary ? "PRIMARY" : "CLIPBOARD");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Could not restore {Selection}: {Message}",
+                usePrimary ? "PRIMARY" : "CLIPBOARD", ex.Message);
+        }
+    }
+}

--- a/src/VirtualAssistant.Core/Keyboard/DotoolProcessRunner.cs
+++ b/src/VirtualAssistant.Core/Keyboard/DotoolProcessRunner.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Core.Keyboard;
+
+/// <inheritdoc />
+public sealed class DotoolProcessRunner : IDotoolProcessRunner
+{
+    private readonly ILogger<DotoolProcessRunner> _logger;
+
+    public DotoolProcessRunner(ILogger<DotoolProcessRunner> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<DotoolResult> SendKeysAsync(
+        IReadOnlyList<string> keys,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        if (keys.Count == 0) return DotoolResult.Ok();
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotool",
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+
+        process.Start();
+        foreach (var key in keys)
+        {
+            await process.StandardInput.WriteLineAsync($"key {key}".AsMemory(), cancellationToken);
+        }
+        process.StandardInput.Close();
+
+        // Independent timeout CTS: binding the timer to cancellationToken would
+        // conflate "user cancelled" with "dotool hung" and produce misleading
+        // log messages.
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        var processTask = process.WaitForExitAsync(cancellationToken);
+        var timeoutTask = Task.Delay(Timeout.InfiniteTimeSpan, timeoutCts.Token);
+        var done = await Task.WhenAny(processTask, timeoutTask);
+
+        if (done == timeoutTask)
+        {
+            // Caller cancellation takes precedence over timer expiry so the
+            // exception surfaced upstream reflects the real cause.
+            cancellationToken.ThrowIfCancellationRequested();
+            _logger.LogError("dotool timed out after {Timeout} — killing process", timeout);
+            TryKill(process);
+            return DotoolResult.Timeout();
+        }
+
+        await processTask;
+
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync(cancellationToken);
+            return DotoolResult.Failed(error);
+        }
+
+        return DotoolResult.Ok();
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited) process.Kill();
+        }
+        catch { /* best effort — process may have exited between the check and Kill */ }
+    }
+}

--- a/src/VirtualAssistant.Core/Keyboard/IClipboardPasteOrchestrator.cs
+++ b/src/VirtualAssistant.Core/Keyboard/IClipboardPasteOrchestrator.cs
@@ -1,0 +1,27 @@
+namespace Olbrasoft.VirtualAssistant.Core.Keyboard;
+
+/// <summary>
+/// Encapsulates the "save current selection → stage new text → run paste → restore"
+/// choreography shared between <c>TypeIntoActiveWindow</c> and <c>PasteFromClipboard</c>.
+/// The orchestrator owns the save/restore contract; the caller supplies the actual
+/// paste action (a dotool key press, almost always).
+/// </summary>
+public interface IClipboardPasteOrchestrator
+{
+    /// <summary>
+    /// Saves the current content of the selection indicated by <paramref name="usePrimary"/>,
+    /// replaces it with <paramref name="stagedText"/>, runs <paramref name="performPasteAsync"/>,
+    /// and restores the original selection in a finally block.
+    /// </summary>
+    /// <remarks>
+    /// If the original selection is empty, the restore step is skipped (matching the
+    /// legacy behavior — no point overwriting a blank selection with blank).
+    /// Failures during the restore step are logged and swallowed; they must not
+    /// mask the caller's real result.
+    /// </remarks>
+    Task<bool> StageAndRestoreAsync(
+        string stagedText,
+        bool usePrimary,
+        Func<Task<bool>> performPasteAsync,
+        CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Core/Keyboard/IDotoolProcessRunner.cs
+++ b/src/VirtualAssistant.Core/Keyboard/IDotoolProcessRunner.cs
@@ -1,0 +1,31 @@
+namespace Olbrasoft.VirtualAssistant.Core.Keyboard;
+
+/// <summary>
+/// Spawns a dotool process, writes one or more <c>key {shortcut}</c> commands
+/// to its stdin, and waits for exit with an independent timeout. Centralises
+/// the process-juggling boilerplate that used to be duplicated across every
+/// paste/send-key path in <see cref="XDoToolKeyboardService"/>.
+/// </summary>
+public interface IDotoolProcessRunner
+{
+    /// <summary>
+    /// Sends one or more dotool <c>key</c> commands. Timeout is independent of
+    /// <paramref name="cancellationToken"/> — a caller cancellation surfaces as
+    /// <see cref="OperationCanceledException"/>, a timer expiry surfaces as
+    /// <see cref="DotoolResult.TimedOut"/>.
+    /// </summary>
+    Task<DotoolResult> SendKeysAsync(
+        IReadOnlyList<string> keys,
+        TimeSpan timeout,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Outcome of a <see cref="IDotoolProcessRunner.SendKeysAsync"/> call.
+/// </summary>
+public readonly record struct DotoolResult(bool Success, string? Error, bool TimedOut)
+{
+    public static DotoolResult Ok() => new(true, null, false);
+    public static DotoolResult Failed(string error) => new(false, error, false);
+    public static DotoolResult Timeout() => new(false, null, true);
+}

--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Olbrasoft.VirtualAssistant.Core.Clipboard;
 using Olbrasoft.VirtualAssistant.Core.WindowManagement;
@@ -12,22 +11,8 @@ namespace Olbrasoft.VirtualAssistant.Core.Keyboard;
 /// </summary>
 public class XDoToolKeyboardService : IKeyboardSimulationService
 {
-    private readonly IClipboardManager _clipboardManager;
-    private readonly ITerminalDetector _terminalDetector;
-    private readonly ICliAppDetector _cliAppDetector;
-    private readonly ILogger<XDoToolKeyboardService> _logger;
-
-    public XDoToolKeyboardService(
-        IClipboardManager clipboardManager,
-        ITerminalDetector terminalDetector,
-        ICliAppDetector cliAppDetector,
-        ILogger<XDoToolKeyboardService> logger)
-    {
-        _clipboardManager = clipboardManager ?? throw new ArgumentNullException(nameof(clipboardManager));
-        _terminalDetector = terminalDetector ?? throw new ArgumentNullException(nameof(terminalDetector));
-        _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }
+    private static readonly TimeSpan PasteTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan SequenceTimeout = TimeSpan.FromSeconds(10);
 
     // Defense-in-depth: paste shortcuts are never passed to a shell, but the
     // value is still used as dotool input. Keep the allowed set explicit so a
@@ -35,8 +20,40 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
     // something unexpected.
     private static readonly HashSet<string> AllowedPasteShortcuts = new(StringComparer.OrdinalIgnoreCase)
     {
-        "ctrl+v", "ctrl+shift+v", "shift+insert"
+        "ctrl+v", "ctrl+shift+v", "shift+insert",
     };
+
+    private static readonly HashSet<string> AllowedKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "enter", "ctrl+u", "ctrl+v", "ctrl+shift+v", "shift+insert",
+        "escape", "tab", "backspace", "delete", "alt+F4",
+        "super+kp1", "super+kp2", "super+kp3", "super+kp4",
+        "super+kp5", "super+kp6", "super+kp7", "super+kp8",
+        "end", "ctrl+a",
+    };
+
+    private readonly IClipboardManager _clipboardManager;
+    private readonly IClipboardPasteOrchestrator _pasteOrchestrator;
+    private readonly IDotoolProcessRunner _dotoolRunner;
+    private readonly ITerminalDetector _terminalDetector;
+    private readonly ICliAppDetector _cliAppDetector;
+    private readonly ILogger<XDoToolKeyboardService> _logger;
+
+    public XDoToolKeyboardService(
+        IClipboardManager clipboardManager,
+        IClipboardPasteOrchestrator pasteOrchestrator,
+        IDotoolProcessRunner dotoolRunner,
+        ITerminalDetector terminalDetector,
+        ICliAppDetector cliAppDetector,
+        ILogger<XDoToolKeyboardService> logger)
+    {
+        _clipboardManager = clipboardManager ?? throw new ArgumentNullException(nameof(clipboardManager));
+        _pasteOrchestrator = pasteOrchestrator ?? throw new ArgumentNullException(nameof(pasteOrchestrator));
+        _dotoolRunner = dotoolRunner ?? throw new ArgumentNullException(nameof(dotoolRunner));
+        _terminalDetector = terminalDetector ?? throw new ArgumentNullException(nameof(terminalDetector));
+        _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
 
     /// <summary>
     /// Types text into the active window using clipboard + dotool paste.
@@ -59,108 +76,39 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
                 text.Length > 50 ? text.Substring(0, 50) + "..." : text,
                 text.Length);
 
-            // Add space after text
             var textToType = text + " ";
-
             var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
             var usePrimary = pasteShortcut == "shift+insert";
-
-            // Step 1: Save current selection we are about to overwrite
-            string? originalClipboard = null;
-            string? originalPrimary = null;
-            if (usePrimary)
-            {
-                originalPrimary = await _clipboardManager.GetPrimarySelectionAsync(cancellationToken);
-                await _clipboardManager.SetPrimarySelectionAsync(textToType, cancellationToken);
-            }
-            else
-            {
-                originalClipboard = await _clipboardManager.GetClipboardAsync(cancellationToken);
-                await _clipboardManager.SetClipboardAsync(textToType, cancellationToken);
-            }
-
-            // Small delay to ensure selection is ready before we trigger the paste
-            await Task.Delay(50, cancellationToken);
 
             _logger.LogInformation("Simulating paste with shortcut: {Shortcut} (selection: {Selection})",
                 pasteShortcut, usePrimary ? "PRIMARY" : "CLIPBOARD");
 
-            // Invoke dotool directly and pipe the command over stdin. The previous
-            // implementation composed a `bash -c "echo 'key …' | dotool"` string with
-            // string interpolation — safe only because pasteShortcut came from a
-            // hardcoded set, but a shell-injection foot-gun if that ever changes.
-            using var dotoolProcess = new Process
-            {
-                StartInfo = new ProcessStartInfo
+            var pasted = await _pasteOrchestrator.StageAndRestoreAsync(
+                textToType,
+                usePrimary,
+                async () =>
                 {
-                    FileName = "dotool",
-                    RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
+                    // Small delay to ensure selection is ready before we trigger the paste.
+                    await Task.Delay(50, cancellationToken);
 
-            dotoolProcess.Start();
-            await dotoolProcess.StandardInput.WriteLineAsync($"key {pasteShortcut}");
-            dotoolProcess.StandardInput.Close();
+                    if (!await SendPasteShortcutAsync(pasteShortcut, cancellationToken))
+                        return false;
 
-            // Use an independent timeout CTS. Binding the timer to `cancellationToken`
-            // would conflate "user cancelled" with "dotool hung 5 s", and the timeout
-            // branch below would log a fake timeout when the real cause was cancellation.
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            var dotoolTask = dotoolProcess.WaitForExitAsync(cancellationToken);
-            var timeoutTask = Task.Delay(Timeout.InfiniteTimeSpan, timeoutCts.Token);
-            var completedTask = await Task.WhenAny(dotoolTask, timeoutTask);
+                    // Wait long enough for the terminal/tmux/TUI chain to read the
+                    // selection before we restore it. 100 ms was too short in tmux —
+                    // the terminal paste handler had not yet read the PRIMARY by the
+                    // time we wrote the original value back, so the user saw the old
+                    // content pasted.
+                    await Task.Delay(300, cancellationToken);
+                    return true;
+                },
+                cancellationToken);
 
-            if (completedTask == timeoutTask)
+            if (pasted)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                _logger.LogError("dotool paste timeout after 5 seconds, killing process");
-                TryKillProcess(dotoolProcess);
-                return false;
+                _logger.LogInformation("✅ Typed {Length} characters into active window", textToType.Length);
             }
-
-            // Surface cancellation as OperationCanceledException (caught below) rather
-            // than as a silent "timeout" false-positive.
-            await dotoolTask;
-
-            if (dotoolProcess.ExitCode != 0)
-            {
-                var error = await dotoolProcess.StandardError.ReadToEndAsync(cancellationToken);
-                _logger.LogError("dotool failed with exit code {ExitCode}: {Error}", dotoolProcess.ExitCode, error);
-                return false;
-            }
-
-            // Wait long enough for the terminal/tmux/TUI chain to read the
-            // selection before we restore it. 100 ms was too short in tmux —
-            // the terminal paste handler had not yet read the PRIMARY by the
-            // time we wrote the original value back, so the user saw the old
-            // content pasted.
-            await Task.Delay(300, cancellationToken);
-
-            // Step 4: Restore the original selection we overwrote
-            try
-            {
-                if (usePrimary && !string.IsNullOrEmpty(originalPrimary))
-                {
-                    await _clipboardManager.SetPrimarySelectionAsync(originalPrimary, cancellationToken);
-                    _logger.LogDebug("Restored original PRIMARY selection");
-                }
-                else if (!usePrimary && !string.IsNullOrEmpty(originalClipboard))
-                {
-                    await _clipboardManager.SetClipboardAsync(originalClipboard, cancellationToken);
-                    _logger.LogDebug("Restored original clipboard content");
-                }
-            }
-            catch (InvalidOperationException ex)
-            {
-                _logger.LogWarning("Could not restore selection: {Message}", ex.Message);
-            }
-
-            _logger.LogInformation("✅ Typed {Length} characters into active window", textToType.Length);
-            return true;
+            return pasted;
         }
         catch (OperationCanceledException)
         {
@@ -173,15 +121,6 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             return false;
         }
     }
-
-    private static readonly HashSet<string> AllowedKeys = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "enter", "ctrl+u", "ctrl+v", "ctrl+shift+v", "shift+insert",
-        "escape", "tab", "backspace", "delete", "alt+F4",
-        "super+kp1", "super+kp2", "super+kp3", "super+kp4",
-        "super+kp5", "super+kp6", "super+kp7", "super+kp8",
-        "end", "ctrl+a"
-    };
 
     /// <inheritdoc/>
     public async Task SendKeyAsync(string key, CancellationToken cancellationToken = default)
@@ -201,44 +140,14 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
         try
         {
             _logger.LogInformation("Sending key: {Key}", key);
+            var result = await _dotoolRunner.SendKeysAsync(new[] { key }, PasteTimeout, cancellationToken);
 
-            using var dotoolProcess = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "dotool",
-                    RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-
-            dotoolProcess.Start();
-            await dotoolProcess.StandardInput.WriteLineAsync($"key {key}");
-            dotoolProcess.StandardInput.Close();
-
-            var dotoolTask = dotoolProcess.WaitForExitAsync(cancellationToken);
-            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
-            var completedTask = await Task.WhenAny(dotoolTask, timeoutTask);
-
-            if (completedTask == timeoutTask)
-            {
-                _logger.LogError("dotool SendKey timeout after 5 seconds, killing process");
-                try { dotoolProcess.Kill(); } catch { /* best effort */ }
-                return;
-            }
-
-            if (dotoolProcess.ExitCode != 0)
-            {
-                var error = await dotoolProcess.StandardError.ReadToEndAsync(cancellationToken);
-                _logger.LogError("dotool SendKey failed with exit code {ExitCode}: {Error}", dotoolProcess.ExitCode, error);
-            }
+            if (result.TimedOut)
+                _logger.LogError("dotool SendKey timed out after {Timeout}", PasteTimeout);
+            else if (!result.Success)
+                _logger.LogError("dotool SendKey failed: {Error}", result.Error);
             else
-            {
                 _logger.LogDebug("Successfully sent key: {Key}", key);
-            }
         }
         catch (OperationCanceledException)
         {
@@ -268,47 +177,12 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
         try
         {
             _logger.LogInformation("Sending key sequence: {Count} keys", keys.Count);
+            var result = await _dotoolRunner.SendKeysAsync(keys, SequenceTimeout, cancellationToken);
 
-            using var dotoolProcess = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "dotool",
-                    RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-
-            dotoolProcess.Start();
-
-            foreach (var key in keys)
-                await dotoolProcess.StandardInput.WriteLineAsync($"key {key}");
-
-            dotoolProcess.StandardInput.Close();
-
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            var dotoolTask = dotoolProcess.WaitForExitAsync(cancellationToken);
-            var timeoutTask = Task.Delay(Timeout.InfiniteTimeSpan, timeoutCts.Token);
-
-            var completedTask = await Task.WhenAny(dotoolTask, timeoutTask);
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (completedTask != dotoolTask)
-            {
-                _logger.LogError("dotool key sequence timeout, killing process");
-                try { dotoolProcess.Kill(); } catch { /* best effort */ }
-                return;
-            }
-
-            if (dotoolProcess.ExitCode != 0)
-            {
-                var error = await dotoolProcess.StandardError.ReadToEndAsync(cancellationToken);
-                _logger.LogError("dotool sequence failed: {Error}", error);
-            }
+            if (result.TimedOut)
+                _logger.LogError("dotool key sequence timed out after {Timeout}", SequenceTimeout);
+            else if (!result.Success)
+                _logger.LogError("dotool sequence failed: {Error}", result.Error);
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
@@ -326,15 +200,11 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             return false;
         }
 
-        Process? dotoolProcess = null;
-
         try
         {
-            // 1. Detect paste shortcut first so we know which selection to write to
             var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
             var usePrimary = pasteShortcut == "shift+insert";
 
-            // 2. Stage the text in the right selection (Shift+Insert reads PRIMARY)
             if (usePrimary)
                 await _clipboardManager.SetPrimarySelectionAsync(text, cancellationToken);
             else
@@ -342,61 +212,21 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
 
             await Task.Delay(30, cancellationToken);
 
-            dotoolProcess = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "dotool",
-                    RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-
-            dotoolProcess.Start();
-            await dotoolProcess.StandardInput.WriteLineAsync($"key {pasteShortcut}");
-            dotoolProcess.StandardInput.Close();
-
-            var dotoolTask = dotoolProcess.WaitForExitAsync(cancellationToken);
-            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
-            var completedTask = await Task.WhenAny(dotoolTask, timeoutTask);
-
-            if (completedTask == timeoutTask)
-            {
-                _logger.LogError("FastPaste: dotool timeout");
-                TryKillProcess(dotoolProcess);
+            if (!await SendPasteShortcutAsync(pasteShortcut, cancellationToken))
                 return false;
-            }
-
-            await dotoolTask;
-
-            if (dotoolProcess.ExitCode != 0)
-            {
-                var error = await dotoolProcess.StandardError.ReadToEndAsync(cancellationToken);
-                _logger.LogError("FastPaste failed: {Error}", error);
-                return false;
-            }
 
             _logger.LogInformation("FastPaste: {Length} chars pasted", text.Length);
             return true;
         }
         catch (OperationCanceledException)
         {
-            TryKillProcess(dotoolProcess);
             _logger.LogInformation("FastPaste cancelled");
             return false;
         }
         catch (Exception ex)
         {
-            TryKillProcess(dotoolProcess);
             _logger.LogError(ex, "FastPaste failed");
             return false;
-        }
-        finally
-        {
-            dotoolProcess?.Dispose();
         }
     }
 
@@ -419,36 +249,40 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
                 return;
             }
 
-            var originalPrimary = await _clipboardManager.GetPrimarySelectionAsync(cancellationToken);
-            try
-            {
-                await _clipboardManager.SetPrimarySelectionAsync(clipboard, cancellationToken);
-                await Task.Delay(50, cancellationToken);
-                await SendKeyAsync(pasteShortcut, cancellationToken);
-                await Task.Delay(300, cancellationToken);
-            }
-            finally
-            {
-                if (!string.IsNullOrEmpty(originalPrimary))
+            await _pasteOrchestrator.StageAndRestoreAsync(
+                clipboard,
+                usePrimary: true,
+                async () =>
                 {
-                    try { await _clipboardManager.SetPrimarySelectionAsync(originalPrimary, cancellationToken); }
-                    catch (Exception ex) { _logger.LogWarning(ex, "Could not restore PRIMARY selection"); }
-                }
-            }
+                    await Task.Delay(50, cancellationToken);
+                    await SendKeyAsync(pasteShortcut, cancellationToken);
+                    await Task.Delay(300, cancellationToken);
+                    return true;
+                },
+                cancellationToken);
             return;
         }
 
         await SendKeyAsync(pasteShortcut, cancellationToken);
     }
 
-    private static void TryKillProcess(Process? process)
+    private async Task<bool> SendPasteShortcutAsync(string pasteShortcut, CancellationToken cancellationToken)
     {
-        if (process == null) return;
-        try
+        var result = await _dotoolRunner.SendKeysAsync(new[] { pasteShortcut }, PasteTimeout, cancellationToken);
+
+        if (result.TimedOut)
         {
-            if (!process.HasExited) process.Kill();
+            _logger.LogError("dotool paste timed out after {Timeout}", PasteTimeout);
+            return false;
         }
-        catch { /* best effort */ }
+
+        if (!result.Success)
+        {
+            _logger.LogError("dotool paste failed: {Error}", result.Error);
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -195,6 +195,8 @@ public static class VoiceServicesExtensions
         services.AddSingleton<IClipboardManager, WlClipboardManager>();
         services.AddSingleton<ITerminalDetector, WaylandTerminalDetector>();
         services.AddSingleton<ICliAppDetector, TerminalCliAppDetector>();
+        services.AddSingleton<IDotoolProcessRunner, DotoolProcessRunner>();
+        services.AddSingleton<IClipboardPasteOrchestrator, ClipboardPasteOrchestrator>();
         services.AddSingleton<IKeyboardSimulationService, XDoToolKeyboardService>();
 
         services.AddSingleton<IKeyboardLedReader, LinuxKeyboardLedReader>();

--- a/tests/VirtualAssistant.Core.Tests/Keyboard/ClipboardPasteOrchestratorTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Keyboard/ClipboardPasteOrchestratorTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Clipboard;
+using Olbrasoft.VirtualAssistant.Core.Keyboard;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.Keyboard;
+
+/// <summary>
+/// Unit tests for <see cref="ClipboardPasteOrchestrator"/>. The save/stage/restore
+/// choreography used to be inlined inside every paste path of XDoToolKeyboardService
+/// and was never unit-tested. Now that it's a separate class each branch is covered.
+/// </summary>
+public class ClipboardPasteOrchestratorTests
+{
+    private readonly Mock<IClipboardManager> _clipboardMock = new();
+    private readonly Mock<ILogger<ClipboardPasteOrchestrator>> _loggerMock = new();
+    private readonly ClipboardPasteOrchestrator _sut;
+
+    public ClipboardPasteOrchestratorTests()
+    {
+        _sut = new ClipboardPasteOrchestrator(_clipboardMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task StageAndRestoreAsync_ClipboardPath_SavesStagesAndRestoresClipboard()
+    {
+        _clipboardMock.Setup(x => x.GetClipboardAsync(It.IsAny<CancellationToken>())).ReturnsAsync("original clipboard");
+        var pasteRan = false;
+
+        var result = await _sut.StageAndRestoreAsync(
+            "new text",
+            usePrimary: false,
+            performPasteAsync: () => { pasteRan = true; return Task.FromResult(true); },
+            CancellationToken.None);
+
+        Assert.True(result);
+        Assert.True(pasteRan);
+        _clipboardMock.Verify(x => x.SetClipboardAsync("new text", It.IsAny<CancellationToken>()), Times.Once);
+        _clipboardMock.Verify(x => x.SetClipboardAsync("original clipboard", It.IsAny<CancellationToken>()), Times.Once);
+        _clipboardMock.Verify(x => x.GetPrimarySelectionAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StageAndRestoreAsync_PrimaryPath_SavesStagesAndRestoresPrimary()
+    {
+        _clipboardMock.Setup(x => x.GetPrimarySelectionAsync(It.IsAny<CancellationToken>())).ReturnsAsync("original primary");
+
+        var result = await _sut.StageAndRestoreAsync(
+            "new text",
+            usePrimary: true,
+            performPasteAsync: () => Task.FromResult(true),
+            CancellationToken.None);
+
+        Assert.True(result);
+        _clipboardMock.Verify(x => x.SetPrimarySelectionAsync("new text", It.IsAny<CancellationToken>()), Times.Once);
+        _clipboardMock.Verify(x => x.SetPrimarySelectionAsync("original primary", It.IsAny<CancellationToken>()), Times.Once);
+        _clipboardMock.Verify(x => x.GetClipboardAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StageAndRestoreAsync_EmptyOriginal_SkipsRestore()
+    {
+        // An empty original should not be "restored" — the legacy behavior was to
+        // skip the SetClipboardAsync call when original was empty, and the test
+        // guards against a future refactor that accidentally overwrites a blank
+        // selection with another blank.
+        _clipboardMock.Setup(x => x.GetClipboardAsync(It.IsAny<CancellationToken>())).ReturnsAsync(string.Empty);
+
+        var result = await _sut.StageAndRestoreAsync(
+            "new text",
+            usePrimary: false,
+            performPasteAsync: () => Task.FromResult(true),
+            CancellationToken.None);
+
+        Assert.True(result);
+        _clipboardMock.Verify(x => x.SetClipboardAsync("new text", It.IsAny<CancellationToken>()), Times.Once);
+        _clipboardMock.Verify(x => x.SetClipboardAsync(string.Empty, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StageAndRestoreAsync_PasteReturnsFalse_StillRestoresOriginal()
+    {
+        _clipboardMock.Setup(x => x.GetPrimarySelectionAsync(It.IsAny<CancellationToken>())).ReturnsAsync("original");
+
+        var result = await _sut.StageAndRestoreAsync(
+            "new text",
+            usePrimary: true,
+            performPasteAsync: () => Task.FromResult(false),
+            CancellationToken.None);
+
+        Assert.False(result);
+        // Even when the paste action fails, the saved selection must be restored —
+        // otherwise the user loses their previous clipboard/primary content.
+        _clipboardMock.Verify(x => x.SetPrimarySelectionAsync("original", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StageAndRestoreAsync_PasteThrows_RestoresOriginalAndBubblesException()
+    {
+        _clipboardMock.Setup(x => x.GetClipboardAsync(It.IsAny<CancellationToken>())).ReturnsAsync("original");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.StageAndRestoreAsync(
+            "new text",
+            usePrimary: false,
+            performPasteAsync: () => throw new InvalidOperationException("paste blew up"),
+            CancellationToken.None));
+
+        _clipboardMock.Verify(x => x.SetClipboardAsync("original", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StageAndRestoreAsync_RestoreFails_DoesNotMaskPasteResult()
+    {
+        // Restore failure must be swallowed and logged — it must not override
+        // the caller's real success/failure result.
+        _clipboardMock.Setup(x => x.GetPrimarySelectionAsync(It.IsAny<CancellationToken>())).ReturnsAsync("original");
+        _clipboardMock
+            .Setup(x => x.SetPrimarySelectionAsync("original", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("clipboard service down"));
+
+        var result = await _sut.StageAndRestoreAsync(
+            "new text",
+            usePrimary: true,
+            performPasteAsync: () => Task.FromResult(true),
+            CancellationToken.None);
+
+        Assert.True(result);
+    }
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Partially addresses #981 (keyboard half)

## Summary
XDoToolKeyboardService had two kinds of duplication:
1. 30-line "spawn dotool → pipe keys → wait with timeout → kill → check exit" copy-pasted across four paths
2. "Save selection → stage text → restore selection" choreography inlined twice with inconsistent cancellation and logging

Extract two small, single-responsibility helpers:
- `IDotoolProcessRunner` — owns process spawning + independent-timeout CTS + kill-on-timeout
- `IClipboardPasteOrchestrator` — owns save/stage/restore with finally-block restore that also handles paste-action throws

## Numbers
- `XDoToolKeyboardService.cs` — 493 → 327 LOC
- `DotoolProcessRunner.cs` — 81 LOC
- `ClipboardPasteOrchestrator.cs` — 67 LOC
- All new classes ≤ 100 LOC, single responsibility (issue #981 acceptance criteria)

## Scope note
The audio half of #981 (AudioBufferManager + ChunkEmissionScheduler extraction from AudioRecordingCoordinator) is deferred to a separate PR so review is focused.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — all projects pass (6 new ClipboardPasteOrchestrator tests; 2 pre-existing flaky AudioPlaybackServiceTests passed on re-run)
- [ ] CI green
- [ ] Smoke test: dictation + paste into GUI app and terminal after deploy