### PR TITLE
fix(keyboard): address Copilot review findings on DotoolProcessRunner

### DIFF
--- a/src/VirtualAssistant.Core/Keyboard/DotoolProcessRunner.cs
+++ b/src/VirtualAssistant.Core/Keyboard/DotoolProcessRunner.cs
@@ -27,7 +27,10 @@ public sealed class DotoolProcessRunner : IDotoolProcessRunner
             {
                 FileName = "dotool",
                 RedirectStandardInput = true,
-                RedirectStandardOutput = true,
+                // StandardOutput is intentionally NOT redirected. dotool produces
+                // no meaningful output on success and leaving the child's stdout
+                // attached to our stdout would let it deadlock if it ever wrote
+                // more than the pipe buffer. (Copilot review on PR #997.)
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
@@ -59,12 +62,26 @@ public sealed class DotoolProcessRunner : IDotoolProcessRunner
             return DotoolResult.Timeout();
         }
 
-        await processTask;
+        try
+        {
+            await processTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // Without this, a caller cancellation during wait would leave a
+            // live dotool child behind — the regression Copilot flagged on
+            // PR #997 relative to the prior FastPaste path.
+            TryKill(process);
+            throw;
+        }
 
         if (process.ExitCode != 0)
         {
             var error = await process.StandardError.ReadToEndAsync(cancellationToken);
-            return DotoolResult.Failed(error);
+            var message = string.IsNullOrWhiteSpace(error)
+                ? $"dotool exited with code {process.ExitCode}."
+                : $"dotool exited with code {process.ExitCode}: {error.TrimEnd()}";
+            return DotoolResult.Failed(message);
         }
 
         return DotoolResult.Ok();


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to #997 — three post-merge Copilot findings on `DotoolProcessRunner`:

1. **Stdout redirect without a reader.** `RedirectStandardOutput = true` was set but never read. dotool is silent on success, so the redirect is pure liability: if anything ever wrote to stdout it could deadlock on the pipe buffer. Fix: drop the redirect.
2. **Cancellation during wait leaks the process.** If `cancellationToken` fires while `WaitForExitAsync` is in flight, the method re-throws without killing dotool. That's a regression vs the original `FastPaste` path which did kill-on-cancel. Fix: wrap `await processTask` in a `try/catch (OperationCanceledException)` that kills the child and re-throws.
3. **Exit code lost in error message.** Previous inline code logged the numeric exit code; the extracted runner only preserved stderr. Fix: include the code in the error string so `dotool exited with code 1: unknown key 'foo'` replaces plain `unknown key 'foo'`.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test tests/VirtualAssistant.Core.Tests` — 77 pass
- [ ] CI green
- [ ] Smoke test: dictation + paste works after deploy