### PR TITLE
fix(keyboard): kill dotool before throw in timeout branch

### DIFF
--- a/src/VirtualAssistant.Core/Keyboard/DotoolProcessRunner.cs
+++ b/src/VirtualAssistant.Core/Keyboard/DotoolProcessRunner.cs
@@ -27,10 +27,12 @@ public sealed class DotoolProcessRunner : IDotoolProcessRunner
             {
                 FileName = "dotool",
                 RedirectStandardInput = true,
-                // StandardOutput is intentionally NOT redirected. dotool produces
-                // no meaningful output on success and leaving the child's stdout
-                // attached to our stdout would let it deadlock if it ever wrote
-                // more than the pipe buffer. (Copilot review on PR #997.)
+                // StandardOutput is intentionally NOT redirected. The pipe-buffer
+                // deadlock risk comes from redirecting without reading — if we
+                // set RedirectStandardOutput = true and never drained the pipe,
+                // dotool would block once its stdout buffer filled. Leaving it
+                // attached to the parent is safe and matches the fact that dotool
+                // has no meaningful output on success. (Copilot review on PR #997.)
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
@@ -54,11 +56,17 @@ public sealed class DotoolProcessRunner : IDotoolProcessRunner
 
         if (done == timeoutTask)
         {
+            // Kill the child BEFORE anything that can throw. If caller cancellation
+            // raced with the timer, the process must still die so we don't leak
+            // a live dotool on the way out via the throw below. (Copilot review
+            // on PR #998.)
+            TryKill(process);
+
             // Caller cancellation takes precedence over timer expiry so the
             // exception surfaced upstream reflects the real cause.
             cancellationToken.ThrowIfCancellationRequested();
-            _logger.LogError("dotool timed out after {Timeout} — killing process", timeout);
-            TryKill(process);
+
+            _logger.LogError("dotool timed out after {Timeout}", timeout);
             return DotoolResult.Timeout();
         }
 


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to #998 — two more Copilot findings on `DotoolProcessRunner`:

## 1. Timeout branch could leak dotool on cancel race (real bug)
If the timer expired in the same tick the caller cancelled, `ThrowIfCancellationRequested()` threw BEFORE `TryKill(process)` could run, leaving the live dotool child behind. Swap the order so the process is always killed before any throw path.

## 2. Comment wording inaccuracy (cosmetic)
The "don't redirect stdout" comment implied redirecting caused the deadlock. The deadlock actually comes from redirecting without reading. Reworded to explain the reasoning correctly.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test tests/VirtualAssistant.Core.Tests` — 77 pass
- [ ] CI green
- [ ] Smoke test: dictation still works after deploy