### PR TITLE
refactor(audio): extract AudioBufferManager + ChunkEmissionScheduler from AudioRecordingCoordinator

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -95,11 +95,19 @@ public static class WorkerServicesExtensions
         // Register under the interface so callers don't need to know the concrete
         // implementation. Keeps DictationWorker and any future consumer decoupled
         // from Voice.Audio.AudioRecordingCoordinator specifically.
+        //
+        // The buffer manager and scheduler are constructed inline rather than as
+        // separate top-level registrations because their state is per-coordinator —
+        // registering them as global singletons would share buffer/cursor state
+        // across any future second coordinator (e.g. the continuous-listening
+        // pipeline, if it ever grows a streaming component).
         services.AddKeyedSingleton<IAudioRecordingCoordinator>(DictationKey, (sp, _) =>
             new Voice.Audio.AudioRecordingCoordinator(
                 sp.GetRequiredService<ILogger<Voice.Audio.AudioRecordingCoordinator>>(),
                 sp.GetRequiredKeyedService<IAudioCaptureService>(DictationKey),
-                sp.GetRequiredService<IOptions<Voice.Configuration.AudioRecordingOptions>>()));
+                sp.GetRequiredService<IOptions<Voice.Configuration.AudioRecordingOptions>>(),
+                new Voice.Audio.AudioBufferManager(),
+                new Voice.Audio.ChunkEmissionScheduler(sp.GetRequiredService<ILogger<Voice.Audio.ChunkEmissionScheduler>>())));
     }
 
     /// <summary>

--- a/src/VirtualAssistant.Voice/Audio/AudioBufferManager.cs
+++ b/src/VirtualAssistant.Voice/Audio/AudioBufferManager.cs
@@ -1,0 +1,69 @@
+namespace Olbrasoft.VirtualAssistant.Voice.Audio;
+
+/// <inheritdoc />
+public sealed class AudioBufferManager : IAudioBufferManager
+{
+    private readonly List<byte> _buffer = new();
+    private readonly object _lock = new();
+
+    public int ByteCount
+    {
+        get
+        {
+            lock (_lock) return _buffer.Count;
+        }
+    }
+
+    public bool TryAppend(ReadOnlySpan<byte> chunk, int maxSizeBytes, out int newByteCount)
+    {
+        lock (_lock)
+        {
+            if (_buffer.Count + chunk.Length > maxSizeBytes)
+            {
+                newByteCount = _buffer.Count;
+                return false;
+            }
+
+            // List<byte>.AddRange does not accept a span, so copy via a stackalloc-free
+            // temp when the span is small or ToArray when large. The capture chunk sizes
+            // here are on the order of 4-16 kB so ToArray is fine.
+            _buffer.AddRange(chunk.ToArray());
+            newByteCount = _buffer.Count;
+            return true;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock) _buffer.Clear();
+    }
+
+    public byte[] CopyTail(int fromCursor, out int newEndCursor)
+    {
+        lock (_lock)
+        {
+            var end = _buffer.Count;
+            if (fromCursor >= end)
+            {
+                newEndCursor = end;
+                return Array.Empty<byte>();
+            }
+
+            var length = end - fromCursor;
+            var result = new byte[length];
+            _buffer.CopyTo(fromCursor, result, 0, length);
+            newEndCursor = end;
+            return result;
+        }
+    }
+
+    public byte[] DrainToArray()
+    {
+        lock (_lock)
+        {
+            var result = _buffer.ToArray();
+            _buffer.Clear();
+            return result;
+        }
+    }
+}

--- a/src/VirtualAssistant.Voice/Audio/AudioRecordingCoordinator.cs
+++ b/src/VirtualAssistant.Voice/Audio/AudioRecordingCoordinator.cs
@@ -8,10 +8,12 @@ namespace Olbrasoft.VirtualAssistant.Voice.Audio;
 
 /// <summary>
 /// Coordinates audio recording workflow including buffer management and capture task lifecycle.
-/// Implements Single Responsibility Principle - only handles audio recording coordination.
+/// Buffer state and chunk-emission timing are delegated to <see cref="IAudioBufferManager"/>
+/// and <see cref="IChunkEmissionScheduler"/>; this class owns only the recording-session
+/// lifecycle (start/stop/emergency-stop, capture task, cancellation).
 /// </summary>
 /// <remarks>
-/// Maximum buffer size is configurable via AudioRecordingOptions.MaxBufferSizeBytes.
+/// Maximum buffer size is configurable via <see cref="AudioRecordingOptions.MaxBufferSizeBytes"/>.
 /// This prevents excessive memory usage during long recording sessions.
 /// </remarks>
 public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
@@ -19,64 +21,48 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
     private readonly ILogger<AudioRecordingCoordinator> _logger;
     private readonly IAudioCaptureService _audioCapture;
     private readonly AudioRecordingOptions _options;
+    private readonly IAudioBufferManager _buffer;
+    private readonly IChunkEmissionScheduler _scheduler;
 
     private CancellationTokenSource? _recordingCts;
     private Task? _recordingTask;
-    private readonly List<byte> _audioBuffer = new();
-    private readonly object _bufferLock = new();
     private readonly object _startLock = new();
     private bool _disposed;
-
-    // Streaming chunk emission state
-    private volatile bool _chunkingEnabled;
-    private TimeSpan _chunkInterval = TimeSpan.FromSeconds(8);
-    private int _lastChunkCursor;      // byte index in _audioBuffer where last chunk ended
-    private int _nextChunkIndex;       // ordinal for next emitted chunk
-    private DateTime _lastChunkEmit;   // last emit timestamp
 
     public AudioRecordingCoordinator(
         ILogger<AudioRecordingCoordinator> logger,
         IAudioCaptureService audioCapture,
-        IOptions<AudioRecordingOptions> options)
+        IOptions<AudioRecordingOptions> options,
+        IAudioBufferManager buffer,
+        IChunkEmissionScheduler scheduler)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _audioCapture = audioCapture ?? throw new ArgumentNullException(nameof(audioCapture));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
+        _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
     }
 
     /// <inheritdoc />
     public bool IsRecording => _recordingTask != null;
 
     /// <inheritdoc />
-    public event EventHandler<AudioChunkEventArgs>? ChunkAvailable;
-
-    /// <inheritdoc />
-    public void EnableChunking(TimeSpan interval)
+    public event EventHandler<AudioChunkEventArgs>? ChunkAvailable
     {
-        var normalizedInterval = interval < TimeSpan.FromSeconds(1) ? TimeSpan.FromSeconds(1) : interval;
-        lock (_bufferLock)
-        {
-            _chunkInterval = normalizedInterval;
-            _chunkingEnabled = true;
-        }
-        _logger.LogInformation("Chunk emission enabled with interval {Interval}s", normalizedInterval.TotalSeconds);
+        add => _scheduler.ChunkAvailable += value;
+        remove => _scheduler.ChunkAvailable -= value;
     }
 
     /// <inheritdoc />
-    public void DisableChunking()
-    {
-        lock (_bufferLock)
-        {
-            _chunkingEnabled = false;
-        }
-        _logger.LogInformation("Chunk emission disabled");
-    }
+    public void EnableChunking(TimeSpan interval) => _scheduler.Enable(interval);
+
+    /// <inheritdoc />
+    public void DisableChunking() => _scheduler.Disable();
 
     /// <inheritdoc />
     public async Task StartRecordingAsync(CancellationToken cancellationToken = default)
     {
-        // Use lock to prevent concurrent start operations (fixes race condition)
         lock (_startLock)
         {
             if (IsRecording)
@@ -87,22 +73,11 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
 
             try
             {
-                // Clear audio buffer and reset chunking cursor
-                lock (_bufferLock)
-                {
-                    _audioBuffer.Clear();
-                    _lastChunkCursor = 0;
-                    _nextChunkIndex = 0;
-                    _lastChunkEmit = DateTime.UtcNow;
-                }
+                _buffer.Clear();
+                _scheduler.Reset();
 
-                // Create cancellation token for recording
                 _recordingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-                // Start audio capture
                 _audioCapture.Start();
-
-                // Start recording task to capture audio chunks
                 _recordingTask = Task.Run(async () => await CaptureAudioAsync(_recordingCts.Token), _recordingCts.Token);
 
                 _logger.LogInformation("Recording started");
@@ -110,23 +85,14 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to start recording");
-
-                // Ensure audio capture is stopped if it was started
-                try
-                {
-                    _audioCapture.Stop();
-                }
-                catch (Exception stopEx)
-                {
-                    _logger.LogWarning(stopEx, "Error stopping audio capture during cleanup");
-                }
-
+                try { _audioCapture.Stop(); }
+                catch (Exception stopEx) { _logger.LogWarning(stopEx, "Error stopping audio capture during cleanup"); }
                 CleanupRecording();
                 throw;
             }
         }
 
-        await Task.CompletedTask; // Prevent async warning since we're using lock
+        await Task.CompletedTask;
     }
 
     /// <inheritdoc />
@@ -140,39 +106,22 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
 
         try
         {
-            // Cancel recording task
             _recordingCts?.Cancel();
 
-            // Wait for recording task to complete (use caller's cancellation token for timeout control)
             if (_recordingTask != null)
             {
-                try
-                {
-                    await _recordingTask.WaitAsync(cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Expected when canceling recording or when caller cancels
-                }
+                try { await _recordingTask.WaitAsync(cancellationToken); }
+                catch (OperationCanceledException) { /* expected */ }
             }
 
-            // Stop audio capture
             _audioCapture.Stop();
 
-            // Emit final chunk (tail since last emit) before clearing buffer.
-            // No-op when chunking disabled or no pending bytes.
-            TryEmitFinalChunk();
+            // Drain the tail as a final chunk (no-op when chunking disabled or empty)
+            // before we empty the buffer for the caller.
+            _scheduler.EmitFinal(_buffer);
 
-            // Get recorded audio
-            byte[] audioData;
-            lock (_bufferLock)
-            {
-                audioData = _audioBuffer.ToArray();
-                _audioBuffer.Clear();
-            }
-
+            var audioData = _buffer.DrainToArray();
             _logger.LogInformation("Recording stopped - {Bytes} bytes captured", audioData.Length);
-
             return audioData;
         }
         catch (Exception ex)
@@ -198,31 +147,16 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
         try
         {
             _logger.LogWarning("Emergency stop triggered");
-
-            // Cancel recording task
             _recordingCts?.Cancel();
 
-            // Wait for recording task to complete (use caller's cancellation token for timeout control)
             if (_recordingTask != null)
             {
-                try
-                {
-                    await _recordingTask.WaitAsync(cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Expected when canceling recording or when caller cancels
-                }
+                try { await _recordingTask.WaitAsync(cancellationToken); }
+                catch (OperationCanceledException) { /* expected */ }
             }
 
-            // Stop audio capture
             _audioCapture.Stop();
-
-            // Clear buffer
-            lock (_bufferLock)
-            {
-                _audioBuffer.Clear();
-            }
+            _buffer.Clear();
 
             _logger.LogInformation("Emergency stop completed");
         }
@@ -247,28 +181,18 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
             while (!cancellationToken.IsCancellationRequested)
             {
                 var chunk = await _audioCapture.ReadChunkAsync(cancellationToken);
-                if (chunk != null)
+                if (chunk == null) continue;
+
+                if (!_buffer.TryAppend(chunk, _options.MaxBufferSizeBytes, out var totalBytes))
                 {
-                    int totalBytes;
-                    lock (_bufferLock)
-                    {
-                        // Check buffer size limit before adding chunk
-                        if (_audioBuffer.Count + chunk.Length > _options.MaxBufferSizeBytes)
-                        {
-                            _logger.LogWarning(
-                                "Audio buffer size limit reached ({MaxSize} bytes). Stopping capture to prevent excessive memory usage.",
-                                _options.MaxBufferSizeBytes);
-                            break;
-                        }
-
-                        _audioBuffer.AddRange(chunk);
-                        totalBytes = _audioBuffer.Count;
-                    }
-
-                    _logger.LogDebug("Audio chunk captured: {Bytes} bytes (total: {Total})", chunk.Length, totalBytes);
-
-                    TryEmitChunk();
+                    _logger.LogWarning(
+                        "Audio buffer size limit reached ({MaxSize} bytes). Stopping capture to prevent excessive memory usage.",
+                        _options.MaxBufferSizeBytes);
+                    break;
                 }
+
+                _logger.LogDebug("Audio chunk captured: {Bytes} bytes (total: {Total})", chunk.Length, totalBytes);
+                _scheduler.TryEmitIfDue(_buffer);
             }
         }
         catch (OperationCanceledException)
@@ -281,76 +205,6 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
         }
     }
 
-    /// <summary>
-    /// Emits a chunk if chunking is enabled, the interval has elapsed, and there is
-    /// audio data past the last emit cursor.
-    /// </summary>
-    private void TryEmitChunk()
-    {
-        byte[]? chunkBytes = null;
-        int chunkIndex = 0;
-
-        lock (_bufferLock)
-        {
-            if (!_chunkingEnabled) return;
-            if (DateTime.UtcNow - _lastChunkEmit < _chunkInterval) return;
-            var pendingBytes = _audioBuffer.Count - _lastChunkCursor;
-            if (pendingBytes <= 0) return;
-
-            chunkBytes = new byte[pendingBytes];
-            _audioBuffer.CopyTo(_lastChunkCursor, chunkBytes, 0, pendingBytes);
-            _lastChunkCursor = _audioBuffer.Count;
-            chunkIndex = _nextChunkIndex++;
-            _lastChunkEmit = DateTime.UtcNow;
-        }
-
-        try
-        {
-            ChunkAvailable?.Invoke(this, new AudioChunkEventArgs(chunkIndex, chunkBytes));
-            _logger.LogDebug("Emitted audio chunk {Index}: {Bytes} bytes", chunkIndex, chunkBytes.Length);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error invoking ChunkAvailable handler for chunk {Index}", chunkIndex);
-        }
-    }
-
-    /// <summary>
-    /// Called from stop paths to drain the last pending bytes as a final chunk before
-    /// returning the full buffer to the caller. Only emits if chunking is enabled and
-    /// there's remaining audio past the last chunk cursor.
-    /// </summary>
-    private void TryEmitFinalChunk()
-    {
-        byte[]? tailBytes = null;
-        int chunkIndex = 0;
-
-        lock (_bufferLock)
-        {
-            if (!_chunkingEnabled) return;
-            var pendingBytes = _audioBuffer.Count - _lastChunkCursor;
-            if (pendingBytes <= 0) return;
-
-            tailBytes = new byte[pendingBytes];
-            _audioBuffer.CopyTo(_lastChunkCursor, tailBytes, 0, pendingBytes);
-            _lastChunkCursor = _audioBuffer.Count;
-            chunkIndex = _nextChunkIndex++;
-        }
-
-        try
-        {
-            ChunkAvailable?.Invoke(this, new AudioChunkEventArgs(chunkIndex, tailBytes));
-            _logger.LogDebug("Emitted final audio chunk {Index}: {Bytes} bytes", chunkIndex, tailBytes.Length);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error invoking ChunkAvailable handler for final chunk {Index}", chunkIndex);
-        }
-    }
-
-    /// <summary>
-    /// Cleans up recording resources (CTS and task references).
-    /// </summary>
     private void CleanupRecording()
     {
         _recordingCts?.Dispose();
@@ -358,23 +212,17 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
         _recordingTask = null;
     }
 
-    /// <summary>
-    /// Disposes resources and stops any active recording.
-    /// </summary>
     public void Dispose()
     {
-        if (_disposed)
-            return;
-
+        if (_disposed) return;
         _disposed = true;
 
-        // If recording is in progress, perform emergency stop
         if (IsRecording)
         {
             _logger.LogWarning("AudioRecordingCoordinator disposed while recording - performing emergency stop");
             try
             {
-                // Synchronous emergency stop (can't await in Dispose)
+                // Synchronous emergency stop (can't await in Dispose).
                 EmergencyStopAsync(CancellationToken.None).GetAwaiter().GetResult();
             }
             catch (Exception ex)
@@ -383,7 +231,6 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
             }
         }
 
-        // Cleanup any remaining CTS
         CleanupRecording();
     }
 }

--- a/src/VirtualAssistant.Voice/Audio/ChunkEmissionScheduler.cs
+++ b/src/VirtualAssistant.Voice/Audio/ChunkEmissionScheduler.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging;
+using Olbrasoft.VirtualAssistant.Core.Audio;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Audio;
+
+/// <inheritdoc />
+public sealed class ChunkEmissionScheduler : IChunkEmissionScheduler
+{
+    private static readonly TimeSpan MinInterval = TimeSpan.FromSeconds(1);
+
+    private readonly ILogger<ChunkEmissionScheduler> _logger;
+    private readonly object _lock = new();
+
+    private bool _enabled;
+    private TimeSpan _interval = TimeSpan.FromSeconds(8);
+    private int _cursor;
+    private int _nextIndex;
+    private DateTime _lastEmit;
+
+    public ChunkEmissionScheduler(ILogger<ChunkEmissionScheduler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public event EventHandler<AudioChunkEventArgs>? ChunkAvailable;
+
+    public void Enable(TimeSpan interval)
+    {
+        var normalized = interval < MinInterval ? MinInterval : interval;
+        lock (_lock)
+        {
+            _interval = normalized;
+            _enabled = true;
+        }
+        _logger.LogInformation("Chunk emission enabled with interval {Interval}s", normalized.TotalSeconds);
+    }
+
+    public void Disable()
+    {
+        lock (_lock) _enabled = false;
+        _logger.LogInformation("Chunk emission disabled");
+    }
+
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _cursor = 0;
+            _nextIndex = 0;
+            _lastEmit = DateTime.UtcNow;
+        }
+    }
+
+    public void TryEmitIfDue(IAudioBufferManager buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        byte[]? bytes = null;
+        int chunkIndex = 0;
+
+        lock (_lock)
+        {
+            if (!_enabled) return;
+            if (DateTime.UtcNow - _lastEmit < _interval) return;
+
+            var snapshot = buffer.CopyTail(_cursor, out var newCursor);
+            if (snapshot.Length == 0) return;
+
+            bytes = snapshot;
+            _cursor = newCursor;
+            chunkIndex = _nextIndex++;
+            _lastEmit = DateTime.UtcNow;
+        }
+
+        FireChunkAvailable(chunkIndex, bytes, final: false);
+    }
+
+    public void EmitFinal(IAudioBufferManager buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        byte[]? bytes = null;
+        int chunkIndex = 0;
+
+        lock (_lock)
+        {
+            if (!_enabled) return;
+
+            var snapshot = buffer.CopyTail(_cursor, out var newCursor);
+            if (snapshot.Length == 0) return;
+
+            bytes = snapshot;
+            _cursor = newCursor;
+            chunkIndex = _nextIndex++;
+        }
+
+        FireChunkAvailable(chunkIndex, bytes, final: true);
+    }
+
+    private void FireChunkAvailable(int chunkIndex, byte[] bytes, bool final)
+    {
+        try
+        {
+            ChunkAvailable?.Invoke(this, new AudioChunkEventArgs(chunkIndex, bytes));
+            _logger.LogDebug("Emitted {Kind}audio chunk {Index}: {Bytes} bytes",
+                final ? "final " : string.Empty, chunkIndex, bytes.Length);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error invoking ChunkAvailable handler for chunk {Index}", chunkIndex);
+        }
+    }
+}

--- a/src/VirtualAssistant.Voice/Audio/IAudioBufferManager.cs
+++ b/src/VirtualAssistant.Voice/Audio/IAudioBufferManager.cs
@@ -1,0 +1,42 @@
+namespace Olbrasoft.VirtualAssistant.Voice.Audio;
+
+/// <summary>
+/// Thread-safe buffer for PCM bytes captured during a recording session.
+/// Owns the write-lock previously held by <see cref="AudioRecordingCoordinator"/>
+/// so that buffer state is encapsulated behind one class instead of spread
+/// across lock-protected sections on the coordinator.
+/// </summary>
+public interface IAudioBufferManager
+{
+    /// <summary>
+    /// Current number of buffered bytes. Safe to read concurrently.
+    /// </summary>
+    int ByteCount { get; }
+
+    /// <summary>
+    /// Appends <paramref name="chunk"/> iff doing so would not exceed
+    /// <paramref name="maxSizeBytes"/>. Returns <c>false</c> (without mutation)
+    /// when the limit would be breached so the caller can stop the capture
+    /// loop cleanly.
+    /// </summary>
+    bool TryAppend(ReadOnlySpan<byte> chunk, int maxSizeBytes, out int newByteCount);
+
+    /// <summary>
+    /// Resets the buffer to empty. Used at the start of a new recording session.
+    /// </summary>
+    void Clear();
+
+    /// <summary>
+    /// Returns a copy of the buffer from <paramref name="fromCursor"/> to the
+    /// current end. <paramref name="newEndCursor"/> is set to the end index so
+    /// the caller can advance its own cursor. The snapshot is taken atomically
+    /// under the internal lock.
+    /// </summary>
+    byte[] CopyTail(int fromCursor, out int newEndCursor);
+
+    /// <summary>
+    /// Atomically copies the whole buffer into a new array and clears it.
+    /// Used at the end of a recording session to drain the result.
+    /// </summary>
+    byte[] DrainToArray();
+}

--- a/src/VirtualAssistant.Voice/Audio/IChunkEmissionScheduler.cs
+++ b/src/VirtualAssistant.Voice/Audio/IChunkEmissionScheduler.cs
@@ -1,0 +1,49 @@
+using Olbrasoft.VirtualAssistant.Core.Audio;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Audio;
+
+/// <summary>
+/// Owns the chunk-emission timing state that used to live inline in
+/// <see cref="AudioRecordingCoordinator"/> (enabled flag, interval, cursor,
+/// ordinal, last-emit timestamp) and fires <see cref="ChunkAvailable"/>
+/// when a new slice of the audio buffer is ready to be handed off.
+/// </summary>
+public interface IChunkEmissionScheduler
+{
+    /// <summary>
+    /// Raised outside the scheduler's lock so subscribers can re-enter without
+    /// deadlocking. A subscriber exception is caught and logged; it never
+    /// propagates into the capture loop.
+    /// </summary>
+    event EventHandler<AudioChunkEventArgs>? ChunkAvailable;
+
+    /// <summary>
+    /// Enables emission with the given minimum interval between chunks.
+    /// Intervals under 1 s are clamped to 1 s (matches legacy behavior).
+    /// </summary>
+    void Enable(TimeSpan interval);
+
+    /// <summary>
+    /// Disables emission. Previously emitted chunks remain with their subscribers.
+    /// </summary>
+    void Disable();
+
+    /// <summary>
+    /// Resets cursor, ordinal, and last-emit timestamp. Called at the start of
+    /// a new recording session.
+    /// </summary>
+    void Reset();
+
+    /// <summary>
+    /// Emits a chunk if emission is enabled, the interval has elapsed, and there
+    /// is data past the cursor. Called after every capture-chunk append.
+    /// </summary>
+    void TryEmitIfDue(IAudioBufferManager buffer);
+
+    /// <summary>
+    /// Emits the tail as a final chunk regardless of the interval, provided
+    /// emission is enabled and there is pending data. Called once from the
+    /// stop path before the coordinator drains the buffer.
+    /// </summary>
+    void EmitFinal(IAudioBufferManager buffer);
+}

--- a/tests/VirtualAssistant.Voice.Tests/Audio/AudioBufferManagerTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Audio/AudioBufferManagerTests.cs
@@ -1,0 +1,92 @@
+using Olbrasoft.VirtualAssistant.Voice.Audio;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Tests.Audio;
+
+/// <summary>
+/// Unit tests for <see cref="AudioBufferManager"/>. This state used to be two
+/// private fields inside AudioRecordingCoordinator and was only covered by the
+/// coordinator's end-to-end tests — now that it is its own class, the append,
+/// copy-tail, drain, and size-limit branches each have focused coverage.
+/// </summary>
+public class AudioBufferManagerTests
+{
+    [Fact]
+    public void TryAppend_WithinLimit_AppendsAndReportsNewCount()
+    {
+        var sut = new AudioBufferManager();
+
+        var appended = sut.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 100, out var newCount);
+
+        Assert.True(appended);
+        Assert.Equal(3, newCount);
+        Assert.Equal(3, sut.ByteCount);
+    }
+
+    [Fact]
+    public void TryAppend_ExceedingLimit_ReturnsFalseWithoutMutating()
+    {
+        var sut = new AudioBufferManager();
+        sut.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 10, out _);
+
+        var appended = sut.TryAppend(new byte[] { 4, 5, 6, 7, 8, 9, 10, 11 }, maxSizeBytes: 10, out var newCount);
+
+        // Legacy behavior: rejected append does not partially write — byte count
+        // stays at 3 so the capture loop can log and break without leaving a
+        // half-appended chunk in the buffer.
+        Assert.False(appended);
+        Assert.Equal(3, newCount);
+        Assert.Equal(3, sut.ByteCount);
+    }
+
+    [Fact]
+    public void CopyTail_SnapshotsFromCursorToEnd_AndReportsNewCursor()
+    {
+        var sut = new AudioBufferManager();
+        sut.TryAppend(new byte[] { 1, 2, 3, 4, 5 }, maxSizeBytes: 100, out _);
+
+        var tail = sut.CopyTail(fromCursor: 2, out var newCursor);
+
+        Assert.Equal(new byte[] { 3, 4, 5 }, tail);
+        Assert.Equal(5, newCursor);
+        Assert.Equal(5, sut.ByteCount);
+    }
+
+    [Fact]
+    public void CopyTail_CursorAtEnd_ReturnsEmptyArray()
+    {
+        var sut = new AudioBufferManager();
+        sut.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 100, out _);
+
+        var tail = sut.CopyTail(fromCursor: 3, out var newCursor);
+
+        Assert.Empty(tail);
+        Assert.Equal(3, newCursor);
+    }
+
+    [Fact]
+    public void DrainToArray_ReturnsCopyAndClears()
+    {
+        var sut = new AudioBufferManager();
+        sut.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 100, out _);
+
+        var drained = sut.DrainToArray();
+
+        Assert.Equal(new byte[] { 1, 2, 3 }, drained);
+        Assert.Equal(0, sut.ByteCount);
+
+        // Mutating the drained array must not affect the buffer's next session.
+        drained[0] = 99;
+        Assert.Equal(0, sut.ByteCount);
+    }
+
+    [Fact]
+    public void Clear_ResetsByteCount()
+    {
+        var sut = new AudioBufferManager();
+        sut.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 100, out _);
+
+        sut.Clear();
+
+        Assert.Equal(0, sut.ByteCount);
+    }
+}

--- a/tests/VirtualAssistant.Voice.Tests/Audio/ChunkEmissionSchedulerTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Audio/ChunkEmissionSchedulerTests.cs
@@ -1,0 +1,189 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Audio;
+using Olbrasoft.VirtualAssistant.Voice.Audio;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Tests.Audio;
+
+/// <summary>
+/// Unit tests for <see cref="ChunkEmissionScheduler"/>. Verifies the
+/// enable/interval/cursor state machine that used to live inline in
+/// AudioRecordingCoordinator.
+/// </summary>
+public class ChunkEmissionSchedulerTests
+{
+    private readonly ChunkEmissionScheduler _sut = new(Mock.Of<ILogger<ChunkEmissionScheduler>>());
+
+    [Fact]
+    public void TryEmitIfDue_WhenDisabled_DoesNothing()
+    {
+        var buffer = new AudioBufferManager();
+        buffer.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 100, out _);
+        var raised = 0;
+        _sut.ChunkAvailable += (_, _) => raised++;
+
+        _sut.TryEmitIfDue(buffer);
+
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public void TryEmitIfDue_EnabledButIntervalNotElapsed_DoesNothing()
+    {
+        // Reset sets lastEmit = UtcNow; a 10s interval means the very next call
+        // is definitely inside the dead zone, so nothing should fire.
+        _sut.Enable(TimeSpan.FromSeconds(10));
+        _sut.Reset();
+        var buffer = new AudioBufferManager();
+        buffer.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 100, out _);
+        var raised = 0;
+        _sut.ChunkAvailable += (_, _) => raised++;
+
+        _sut.TryEmitIfDue(buffer);
+
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public async Task TryEmitIfDue_EnabledAndIntervalElapsed_EmitsChunkWithAdvancingIndex()
+    {
+        // 1-s floor is enforced by Enable; use the floor to keep the test fast.
+        _sut.Enable(TimeSpan.FromMilliseconds(1));
+        _sut.Reset();
+        var buffer = new AudioBufferManager();
+        buffer.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 100, out _);
+        var received = new List<AudioChunkEventArgs>();
+        _sut.ChunkAvailable += (_, e) => received.Add(e);
+
+        await Task.Delay(1100); // step past the 1-s floor
+        _sut.TryEmitIfDue(buffer);
+
+        buffer.TryAppend(new byte[] { 4, 5 }, maxSizeBytes: 100, out _);
+        await Task.Delay(1100);
+        _sut.TryEmitIfDue(buffer);
+
+        Assert.Equal(2, received.Count);
+        Assert.Equal(0, received[0].Index);
+        Assert.Equal(new byte[] { 1, 2, 3 }, received[0].PcmBytes);
+        Assert.Equal(1, received[1].Index);
+        Assert.Equal(new byte[] { 4, 5 }, received[1].PcmBytes);
+    }
+
+    [Fact]
+    public async Task TryEmitIfDue_NoNewBytesSinceLastEmit_DoesNotEmit()
+    {
+        _sut.Enable(TimeSpan.FromMilliseconds(1));
+        _sut.Reset();
+        var buffer = new AudioBufferManager();
+        buffer.TryAppend(new byte[] { 1, 2, 3 }, maxSizeBytes: 100, out _);
+        var raised = 0;
+        _sut.ChunkAvailable += (_, _) => raised++;
+
+        await Task.Delay(1100);
+        _sut.TryEmitIfDue(buffer); // first emit consumes all 3 bytes
+
+        await Task.Delay(1100);
+        _sut.TryEmitIfDue(buffer); // no new bytes → skip
+
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void EmitFinal_EnabledWithPendingBytes_EmitsRegardlessOfInterval()
+    {
+        // EmitFinal is the "flush tail" call on stop. It must bypass the
+        // interval check so the final transcription chunk isn't lost.
+        _sut.Enable(TimeSpan.FromMinutes(30));
+        _sut.Reset();
+        var buffer = new AudioBufferManager();
+        buffer.TryAppend(new byte[] { 7, 8, 9 }, maxSizeBytes: 100, out _);
+        AudioChunkEventArgs? received = null;
+        _sut.ChunkAvailable += (_, e) => received = e;
+
+        _sut.EmitFinal(buffer);
+
+        Assert.NotNull(received);
+        Assert.Equal(new byte[] { 7, 8, 9 }, received.PcmBytes);
+    }
+
+    [Fact]
+    public void EmitFinal_NoPendingBytes_DoesNotEmit()
+    {
+        _sut.Enable(TimeSpan.FromSeconds(1));
+        _sut.Reset();
+        var buffer = new AudioBufferManager();
+        var raised = 0;
+        _sut.ChunkAvailable += (_, _) => raised++;
+
+        _sut.EmitFinal(buffer);
+
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public void Enable_IntervalBelowOneSecond_ClampsToOneSecond()
+    {
+        // Implementation detail worth pinning with a test: sub-second intervals
+        // would thrash the capture loop, so Enable floors to 1 s. The
+        // legacy code did this and callers rely on it.
+        _sut.Enable(TimeSpan.FromMilliseconds(50));
+        _sut.Reset();
+        var buffer = new AudioBufferManager();
+        buffer.TryAppend(new byte[] { 1 }, maxSizeBytes: 100, out _);
+        var raised = 0;
+        _sut.ChunkAvailable += (_, _) => raised++;
+
+        // Without the 1-s floor this would fire immediately; with the floor it
+        // is still inside the interval dead zone.
+        _sut.TryEmitIfDue(buffer);
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public async Task Disable_DuringSession_StopsFurtherEmissions()
+    {
+        _sut.Enable(TimeSpan.FromMilliseconds(1));
+        _sut.Reset();
+        var buffer = new AudioBufferManager();
+        buffer.TryAppend(new byte[] { 1, 2 }, maxSizeBytes: 100, out _);
+        var raised = 0;
+        _sut.ChunkAvailable += (_, _) => raised++;
+
+        await Task.Delay(1100);
+        _sut.TryEmitIfDue(buffer); // 1 emit
+
+        _sut.Disable();
+        buffer.TryAppend(new byte[] { 3 }, maxSizeBytes: 100, out _);
+        await Task.Delay(1100);
+        _sut.TryEmitIfDue(buffer); // skipped
+
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public async Task SubscriberException_IsSwallowed_AndDoesNotBreakFutureEmits()
+    {
+        _sut.Enable(TimeSpan.FromMilliseconds(1));
+        _sut.Reset();
+        var buffer = new AudioBufferManager();
+        buffer.TryAppend(new byte[] { 1 }, maxSizeBytes: 100, out _);
+
+        var throwingHandler = new EventHandler<AudioChunkEventArgs>((_, _) => throw new InvalidOperationException("boom"));
+        var receivedAfterThrow = 0;
+        _sut.ChunkAvailable += throwingHandler;
+        _sut.ChunkAvailable += (_, _) => receivedAfterThrow++;
+
+        await Task.Delay(1100);
+        _sut.TryEmitIfDue(buffer);
+
+        // A subscriber exception must not propagate into the capture loop —
+        // an earlier refactor that removed the try/catch around Invoke caused
+        // the capture task to die silently. This test pins the contract.
+        _sut.ChunkAvailable -= throwingHandler;
+        buffer.TryAppend(new byte[] { 2 }, maxSizeBytes: 100, out _);
+        await Task.Delay(1100);
+        _sut.TryEmitIfDue(buffer);
+
+        Assert.Equal(1, receivedAfterThrow);
+    }
+}

--- a/tests/VirtualAssistant.Voice.Tests/Services/AudioRecordingCoordinatorTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/AudioRecordingCoordinatorTests.cs
@@ -30,10 +30,15 @@ public class AudioRecordingCoordinatorTests
             MaxRecordingDurationMinutes = 16
         });
 
+        // Use real buffer and scheduler so these tests continue to assert
+        // end-to-end behavior (byte accumulation + drain). Their individual
+        // units are covered by dedicated test classes.
         _sut = new AudioRecordingCoordinator(
             _loggerMock.Object,
             _audioCaptureMock.Object,
-            _defaultOptions);
+            _defaultOptions,
+            new AudioBufferManager(),
+            new ChunkEmissionScheduler(Mock.Of<ILogger<ChunkEmissionScheduler>>()));
     }
 
     #region StartRecordingAsync Tests


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #981

## Summary
Finishes the audio half of #981 (PR #997 was the keyboard half).

`AudioRecordingCoordinator` owned three concerns in one class: buffer state, chunk-emission timing, and session lifecycle. Split 1 and 2 into their own small classes so the coordinator keeps only what the name promises — recording-session orchestration.

## Numbers
- `AudioRecordingCoordinator.cs` — 389 → 236 LOC
- `AudioBufferManager.cs` — 69 LOC
- `ChunkEmissionScheduler.cs` — 111 LOC
- All new classes ≤ 200 LOC (issue #981 acceptance criteria)

## Public surface preserved
`IAudioRecordingCoordinator` unchanged. `ChunkAvailable` event is now an add/remove forwarder to the scheduler; `EnableChunking` / `DisableChunking` forward to the scheduler's `Enable` / `Disable`.

## DI
Buffer + scheduler are `new`ed inline in the keyed-singleton factory rather than registered as top-level singletons. Their state is per-coordinator; sharing them across hypothetical future second coordinators (continuous-listening pipeline) would cross-contaminate cursor/buffer state.

## Tests
- `AudioBufferManagerTests` — 6 tests (append happy path, overflow, copy-tail, drain-and-clear, clear)
- `ChunkEmissionSchedulerTests` — 9 tests (disabled short-circuit, interval gate, advancing index, no-new-bytes skip, final bypass of interval, 1 s floor, disable-during-session, subscriber-exception isolation)
- `AudioRecordingCoordinatorTests` — updated ctor to inject real helper instances so the existing end-to-end byte assertions continue to exercise the whole pipeline

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — Core 77 pass, Voice 312 pass (includes 15 new), Service 307 pass, all projects green
- [ ] CI green
- [ ] Smoke test: dictation start/stop still produces transcribable audio after deploy