### PR TITLE
fix(audio): address Copilot findings on PR #1001 (buffer overload, nullable cleanup, event sender)

### DIFF
--- a/src/VirtualAssistant.Voice/Audio/AudioBufferManager.cs
+++ b/src/VirtualAssistant.Voice/Audio/AudioBufferManager.cs
@@ -14,6 +14,28 @@ public sealed class AudioBufferManager : IAudioBufferManager
         }
     }
 
+    /// <summary>
+    /// Array overload — preferred on the capture hot path because it skips the
+    /// extra copy that the span overload has to do to feed
+    /// <see cref="List{T}.AddRange(IEnumerable{T})"/>.
+    /// </summary>
+    public bool TryAppend(byte[] chunk, int maxSizeBytes, out int newByteCount)
+    {
+        ArgumentNullException.ThrowIfNull(chunk);
+        lock (_lock)
+        {
+            if (_buffer.Count + chunk.Length > maxSizeBytes)
+            {
+                newByteCount = _buffer.Count;
+                return false;
+            }
+
+            _buffer.AddRange(chunk);
+            newByteCount = _buffer.Count;
+            return true;
+        }
+    }
+
     public bool TryAppend(ReadOnlySpan<byte> chunk, int maxSizeBytes, out int newByteCount)
     {
         lock (_lock)
@@ -24,9 +46,11 @@ public sealed class AudioBufferManager : IAudioBufferManager
                 return false;
             }
 
-            // List<byte>.AddRange does not accept a span, so copy via a stackalloc-free
-            // temp when the span is small or ToArray when large. The capture chunk sizes
-            // here are on the order of 4-16 kB so ToArray is fine.
+            // List<byte>.AddRange has no span overload, so the ReadOnlySpan path
+            // pays one extra copy via ToArray. Callers that already hold a byte[]
+            // (the capture loop, in practice) should prefer the array overload
+            // above to avoid this clone. Capture chunks are ~4-16 kB so the
+            // clone is acceptable, but not free.
             _buffer.AddRange(chunk.ToArray());
             newByteCount = _buffer.Count;
             return true;

--- a/src/VirtualAssistant.Voice/Audio/AudioRecordingCoordinator.cs
+++ b/src/VirtualAssistant.Voice/Audio/AudioRecordingCoordinator.cs
@@ -42,17 +42,22 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
         _options = options.Value;
         _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
         _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
+
+        // Re-raise the scheduler's event from this instance so the sender the
+        // subscribers see is the coordinator, matching the pre-split contract
+        // where AudioRecordingCoordinator was the emitter. (Copilot review on
+        // PR #1001.)
+        _scheduler.ChunkAvailable += OnSchedulerChunkAvailable;
     }
+
+    private void OnSchedulerChunkAvailable(object? sender, AudioChunkEventArgs e)
+        => ChunkAvailable?.Invoke(this, e);
 
     /// <inheritdoc />
     public bool IsRecording => _recordingTask != null;
 
     /// <inheritdoc />
-    public event EventHandler<AudioChunkEventArgs>? ChunkAvailable
-    {
-        add => _scheduler.ChunkAvailable += value;
-        remove => _scheduler.ChunkAvailable -= value;
-    }
+    public event EventHandler<AudioChunkEventArgs>? ChunkAvailable;
 
     /// <inheritdoc />
     public void EnableChunking(TimeSpan interval) => _scheduler.Enable(interval);
@@ -216,6 +221,8 @@ public class AudioRecordingCoordinator : IAudioRecordingCoordinator, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+
+        _scheduler.ChunkAvailable -= OnSchedulerChunkAvailable;
 
         if (IsRecording)
         {

--- a/src/VirtualAssistant.Voice/Audio/ChunkEmissionScheduler.cs
+++ b/src/VirtualAssistant.Voice/Audio/ChunkEmissionScheduler.cs
@@ -54,8 +54,8 @@ public sealed class ChunkEmissionScheduler : IChunkEmissionScheduler
     public void TryEmitIfDue(IAudioBufferManager buffer)
     {
         ArgumentNullException.ThrowIfNull(buffer);
-        byte[]? bytes = null;
-        int chunkIndex = 0;
+        byte[] bytes;
+        int chunkIndex;
 
         lock (_lock)
         {
@@ -77,8 +77,8 @@ public sealed class ChunkEmissionScheduler : IChunkEmissionScheduler
     public void EmitFinal(IAudioBufferManager buffer)
     {
         ArgumentNullException.ThrowIfNull(buffer);
-        byte[]? bytes = null;
-        int chunkIndex = 0;
+        byte[] bytes;
+        int chunkIndex;
 
         lock (_lock)
         {

--- a/src/VirtualAssistant.Voice/Audio/IAudioBufferManager.cs
+++ b/src/VirtualAssistant.Voice/Audio/IAudioBufferManager.cs
@@ -17,7 +17,15 @@ public interface IAudioBufferManager
     /// Appends <paramref name="chunk"/> iff doing so would not exceed
     /// <paramref name="maxSizeBytes"/>. Returns <c>false</c> (without mutation)
     /// when the limit would be breached so the caller can stop the capture
-    /// loop cleanly.
+    /// loop cleanly. Preferred over the span overload on the hot path — the
+    /// span overload has to clone into a temp array before feeding
+    /// <see cref="List{T}.AddRange(IEnumerable{T})"/>.
+    /// </summary>
+    bool TryAppend(byte[] chunk, int maxSizeBytes, out int newByteCount);
+
+    /// <summary>
+    /// Span-based overload. Pays one extra copy via <c>ToArray()</c> — only
+    /// use when the caller genuinely holds a span.
     /// </summary>
     bool TryAppend(ReadOnlySpan<byte> chunk, int maxSizeBytes, out int newByteCount);
 


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to #1001 — five Copilot findings:

## 1. Perf: `AudioBufferManager.TryAppend` cloned every chunk
The span overload calls `chunk.ToArray()` because `List<byte>.AddRange` has no span overload. On the capture hot path the caller already holds a `byte[]`, so the clone was wasted. Added a `byte[]` overload that feeds `AddRange(byte[])` directly; C# overload resolution picks it automatically.

## 2. Misleading comment in span `TryAppend`
The comment described a small/large hybrid path that didn't exist. Reworded to describe what the code actually does and to point callers at the new array overload.

## 3 & 4. Unnecessary nullable warnings in scheduler
`TryEmitIfDue` / `EmitFinal` declared `bytes` as `byte[]?` but passed it to `FireChunkAvailable` which requires non-null. All code paths that reach the call site assign `bytes`, so declare it as plain `byte[]` and drop the nullable.

## 5. Event sender now matches pre-split contract
`AudioRecordingCoordinator.ChunkAvailable` used to emit with `sender = coordinator`; after #1001 it forwarded to the scheduler so `sender` became the scheduler. Restored by re-raising from the coordinator in `OnSchedulerChunkAvailable`, and `Dispose` unsubscribes to avoid a dangling handler.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — Core 77, Voice 312, Service 307, all green
- [ ] CI green
- [ ] Smoke test: dictation still transcribes after deploy