### PR TITLE
refactor(detection): split TerminalCliAppDetector into four focused classes

### DIFF
--- a/src/VirtualAssistant.Core/WindowManagement/CliAgentRegistry.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/CliAgentRegistry.cs
@@ -1,0 +1,68 @@
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <summary>
+/// A CLI agent we know how to detect, plus everything the three detection
+/// strategies need: the process name we'd find in the terminal's descendants,
+/// the substrings the TUI sets in the terminal title, and the prefix the
+/// user's tmux wrapper gives to sessions it spawns for this agent. Keeping
+/// these together means adding a new agent is a one-line change — there's
+/// no risk of the three detection paths drifting out of sync.
+/// </summary>
+public sealed record KnownAgent(
+    string AppName,
+    string PromptFileName,
+    string ProcessName,
+    string[] TitleMarkers,
+    string TmuxSessionPrefix);
+
+/// <summary>
+/// The single source of truth for every CLI agent the detector can recognise.
+/// Pure data + simple lookups; no I/O. Adding a new agent is one entry in
+/// <see cref="KnownAgents"/>.
+/// </summary>
+public static class CliAgentRegistry
+{
+    public static IReadOnlyList<KnownAgent> KnownAgents { get; } = new KnownAgent[]
+    {
+        new("Claude Code", "ClaudeCodeCorrection", "claude",
+            new[] { "Claude Code" }, "claude-"),
+        new("OpenCode", "OpenCodeCorrection", "opencode",
+            new[] { "OpenCode", "OC |" }, "opencode-"),
+        new("Gemini CLI", "GeminiCorrection", "gemini",
+            new[] { "Gemini" }, "gemini-"),
+    };
+
+    /// <summary>
+    /// Returns the agent whose tmux session prefix starts <paramref name="sessionName"/>,
+    /// or null if no agent claims the prefix. Case-insensitive so a user who
+    /// types "Claude-foo" still wins.
+    /// </summary>
+    public static KnownAgent? FindByTmuxSession(string sessionName)
+    {
+        if (string.IsNullOrEmpty(sessionName)) return null;
+        foreach (var agent in KnownAgents)
+        {
+            if (sessionName.StartsWith(agent.TmuxSessionPrefix, StringComparison.OrdinalIgnoreCase))
+                return agent;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first agent whose <see cref="KnownAgent.TitleMarkers"/>
+    /// appears anywhere in <paramref name="title"/>, or null on no match.
+    /// </summary>
+    public static KnownAgent? FindByTitle(string? title)
+    {
+        if (string.IsNullOrEmpty(title)) return null;
+        foreach (var agent in KnownAgents)
+        {
+            foreach (var marker in agent.TitleMarkers)
+            {
+                if (title.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                    return agent;
+            }
+        }
+        return null;
+    }
+}

--- a/src/VirtualAssistant.Core/WindowManagement/CliAppDetectionCache.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/CliAppDetectionCache.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <summary>
+/// Short-TTL cache for the most recent successful CLI-app detection.
+/// When a later probe fails transiently (gdbus slow, extension stalled),
+/// the orchestrator serves this value instead of falling through to the
+/// wrong paste shortcut. Claude Code intercepts Ctrl+V / Ctrl+Shift+V as
+/// "paste image", so a Ctrl+V fallback triggers the "No image found in
+/// clipboard" toast — the bug this cache exists to prevent. See issue #958.
+/// </summary>
+public sealed class CliAppDetectionCache
+{
+    /// <summary>
+    /// Long enough to ride out a gdbus hiccup between consecutive taps of
+    /// "Vložit rychle", short enough that a real app switch masked by a
+    /// persistent gdbus outage flips us back to "no cached app" quickly.
+    /// </summary>
+    internal static readonly TimeSpan CacheStaleness = TimeSpan.FromSeconds(10);
+
+    private readonly ILogger<CliAppDetectionCache>? _logger;
+    private readonly object _lock = new();
+    private CliAppDetectionResult? _result;
+    private DateTime _cachedAtUtc = DateTime.MinValue;
+
+    public CliAppDetectionCache(ILogger<CliAppDetectionCache>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public void Set(CliAppDetectionResult result)
+    {
+        lock (_lock)
+        {
+            _result = result;
+            _cachedAtUtc = DateTime.UtcNow;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _result = null;
+            _cachedAtUtc = DateTime.MinValue;
+        }
+    }
+
+    /// <summary>
+    /// Returns the cached value if it is still fresh, otherwise null.
+    /// <paramref name="failureReason"/> is logged for the fresh-hit case so the
+    /// caller's reason for asking ends up in the logs alongside the hit.
+    /// </summary>
+    public CliAppDetectionResult? TryGet(string failureReason)
+    {
+        CliAppDetectionResult? cached;
+        DateTime cachedAt;
+        lock (_lock)
+        {
+            cached = _result;
+            cachedAt = _cachedAtUtc;
+        }
+
+        var now = DateTime.UtcNow;
+        if (cached is not null && IsCacheFresh(cachedAt, now))
+        {
+            var age = now - cachedAt;
+            _logger?.LogInformation(
+                "Serving cached CLI app detection {AppName} (age {AgeSeconds:F1}s, reason: {Reason})",
+                cached.AppName, age.TotalSeconds, failureReason);
+            return cached;
+        }
+
+        _logger?.LogDebug("No usable cache (reason: {Reason})", failureReason);
+        return null;
+    }
+
+    public static bool IsCacheFresh(DateTime cachedAtUtc, DateTime nowUtc)
+        => cachedAtUtc != DateTime.MinValue && nowUtc - cachedAtUtc <= CacheStaleness;
+}

--- a/src/VirtualAssistant.Core/WindowManagement/GdbusWindowDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/GdbusWindowDetector.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <inheritdoc />
+public sealed class GdbusWindowDetector : IGdbusWindowDetector
+{
+    private readonly ILogger<GdbusWindowDetector> _logger;
+
+    public GdbusWindowDetector(ILogger<GdbusWindowDetector> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<FocusedWindowInfo?> GetFocusedWindowInfoAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "gdbus",
+                    Arguments = "call --session --dest org.gnome.Shell " +
+                               "--object-path /org/gnome/Shell/Extensions/Windows " +
+                               "--method org.gnome.Shell.Extensions.Windows.List",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+
+            process.Start();
+            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+
+            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+            {
+                _logger.LogDebug("D-Bus window-calls returned no data or failed");
+                return null;
+            }
+
+            var rawJsonArray = GdbusJsonHelper.TryExtractJsonArray(output);
+            if (rawJsonArray is null)
+            {
+                _logger.LogDebug("Could not parse D-Bus output");
+                return null;
+            }
+
+            var jsonArray = GdbusJsonHelper.UnescapeQuotes(rawJsonArray);
+            var windows = JsonSerializer.Deserialize<JsonElement>(jsonArray);
+
+            foreach (var window in windows.EnumerateArray())
+            {
+                if (window.TryGetProperty("focus", out var focusProp) && focusProp.GetBoolean())
+                {
+                    var wmClass = window.TryGetProperty("wm_class", out var wmClassProp)
+                        ? wmClassProp.GetString() ?? ""
+                        : "";
+                    var pid = window.TryGetProperty("pid", out var pidProp)
+                        ? pidProp.GetInt32()
+                        : 0;
+                    var title = window.TryGetProperty("title", out var titleProp)
+                        ? titleProp.GetString() ?? ""
+                        : "";
+
+                    if (pid > 0)
+                    {
+                        _logger.LogDebug("Focused window: {WmClass} \"{Title}\" (PID: {Pid})", wmClass, title, pid);
+                        return new FocusedWindowInfo(wmClass, pid, title);
+                    }
+                }
+            }
+
+            _logger.LogDebug("No focused window found");
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogDebug(ex, "Failed to parse D-Bus JSON response");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to get focused window info");
+            return null;
+        }
+    }
+}

--- a/src/VirtualAssistant.Core/WindowManagement/IGdbusWindowDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/IGdbusWindowDetector.cs
@@ -1,0 +1,24 @@
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <summary>
+/// Active-window info read from the GNOME <c>window-calls</c> extension
+/// via <c>gdbus</c>.
+/// </summary>
+public readonly record struct FocusedWindowInfo(string WmClass, int Pid, string Title);
+
+/// <summary>
+/// Resolves the currently focused window by calling the GNOME Shell
+/// <c>window-calls</c> extension over gdbus. Separated from the detector
+/// so the (brittle) JSON parsing can be swapped or stubbed without
+/// touching orchestration logic.
+/// </summary>
+public interface IGdbusWindowDetector
+{
+    /// <summary>
+    /// Returns info about the currently focused window, or null when the
+    /// gdbus call fails or no focused window is reported. Errors are
+    /// swallowed — this is called on the dictation hot path and a failure
+    /// must never propagate.
+    /// </summary>
+    Task<FocusedWindowInfo?> GetFocusedWindowInfoAsync(CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Core/WindowManagement/ITmuxCliAppMatcher.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/ITmuxCliAppMatcher.cs
@@ -1,0 +1,19 @@
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <summary>
+/// Detects CLI agents running under tmux. When the user's bashrc wrapper
+/// runs <c>tmux new-session -s claude-&lt;repo&gt;-&lt;tty&gt; -- claude "$@"</c>,
+/// the tmux server is systemd-scoped and the claude process is not in the
+/// focused terminal's descendant tree — so process-tree matching misses.
+/// This matcher asks tmux directly which session a descendant tmux client
+/// is attached to and matches the session name against the agent registry.
+/// </summary>
+public interface ITmuxCliAppMatcher
+{
+    /// <summary>
+    /// Runs <c>tmux list-clients</c> and returns the first descendant-PID's
+    /// session whose name prefix matches a known CLI-agent, or null if none
+    /// match or tmux is unavailable.
+    /// </summary>
+    Task<CliAppDetectionResult?> MatchAsync(IReadOnlySet<int> descendantPids, CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -1,57 +1,22 @@
 using System.Diagnostics;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
 
 /// <summary>
-/// Detects CLI applications running in terminal emulators by checking child processes
-/// of the active terminal window. This is useful when CLI apps (like Claude Code)
-/// change the terminal window title.
+/// Detects CLI applications (Claude Code, OpenCode, Gemini CLI) running inside
+/// the currently focused terminal. The class now delegates the three detection
+/// strategies to focused collaborators:
+/// <list type="bullet">
+/// <item><see cref="IGdbusWindowDetector"/> — resolves the focused window via GNOME Shell.</item>
+/// <item><see cref="CliAppDetectionCache"/> — serves the last successful result during transient gdbus failures.</item>
+/// <item><see cref="ITmuxCliAppMatcher"/> — matches tmux session names when the CLI app is outside the focused terminal's descendant tree.</item>
+/// </list>
+/// Process-tree + title-marker matching live inline — both are small and share
+/// the <see cref="CliAgentRegistry"/> shortlist used by the tmux matcher.
 /// </summary>
 public class TerminalCliAppDetector : ICliAppDetector
 {
-    private readonly ILogger<TerminalCliAppDetector> _logger;
-
-    // Last successful detection + its timestamp. When a later probe fails transiently
-    // (gdbus slow / returns empty), we serve this value instead of falling through to
-    // the wrong paste shortcut. Claude Code intercepts Ctrl+V and Ctrl+Shift+V as
-    // "paste image", so a Ctrl+V fallback triggers the "No image found in clipboard"
-    // toast — the very bug this cache is meant to prevent. See issue #958.
-    private readonly object _cacheLock = new();
-    private CliAppDetectionResult? _cachedResult;
-    private DateTime _cachedAtUtc = DateTime.MinValue;
-
-    // Staleness cap: long enough to ride out a gdbus hiccup between consecutive taps
-    // of "Vložit rychle", short enough that a real app switch masked by a persistent
-    // gdbus outage flips us back to "no cached app" quickly.
-    internal static readonly TimeSpan CacheStaleness = TimeSpan.FromSeconds(10);
-
-    /// <summary>
-    /// A CLI agent we know how to detect, plus everything the three detection
-    /// strategies need: the process name we'd find in the terminal's descendants,
-    /// the substrings the TUI sets in the terminal title, and the prefix the
-    /// user's tmux wrapper gives to sessions it spawns for this agent. Keeping
-    /// these together means adding a new agent is a one-line change — there's
-    /// no risk of the three detection paths drifting out of sync.
-    /// </summary>
-    private sealed record KnownAgent(
-        string AppName,
-        string PromptFileName,
-        string ProcessName,
-        string[] TitleMarkers,
-        string TmuxSessionPrefix);
-
-    private static readonly KnownAgent[] KnownAgents =
-    {
-        new("Claude Code", "ClaudeCodeCorrection", "claude",
-            new[] { "Claude Code" }, "claude-"),
-        new("OpenCode", "OpenCodeCorrection", "opencode",
-            new[] { "OpenCode", "OC |" }, "opencode-"),
-        new("Gemini CLI", "GeminiCorrection", "gemini",
-            new[] { "Gemini" }, "gemini-")
-    };
-
     /// <summary>
     /// Terminal window classes that we know how to detect CLI apps in.
     /// </summary>
@@ -59,232 +24,112 @@ public class TerminalCliAppDetector : ICliAppDetector
     {
         "kitty", "gnome-terminal", "gnome-terminal-server", "org.gnome.Terminal",
         "konsole", "xfce4-terminal", "mate-terminal", "tilix", "terminator",
-        "alacritty", "wezterm", "foot", "xterm", "urxvt", "st", "terminology"
+        "alacritty", "wezterm", "foot", "xterm", "urxvt", "st", "terminology",
     };
 
-    public TerminalCliAppDetector(ILogger<TerminalCliAppDetector> logger)
+    private readonly ILogger<TerminalCliAppDetector> _logger;
+    private readonly IGdbusWindowDetector _gdbus;
+    private readonly ITmuxCliAppMatcher _tmuxMatcher;
+    private readonly CliAppDetectionCache _cache;
+
+    public TerminalCliAppDetector(
+        ILogger<TerminalCliAppDetector> logger,
+        IGdbusWindowDetector gdbus,
+        ITmuxCliAppMatcher tmuxMatcher,
+        CliAppDetectionCache cache)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _gdbus = gdbus ?? throw new ArgumentNullException(nameof(gdbus));
+        _tmuxMatcher = tmuxMatcher ?? throw new ArgumentNullException(nameof(tmuxMatcher));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
     }
 
     public async Task<CliAppDetectionResult?> DetectCliAppAsync(CancellationToken cancellationToken = default)
     {
         try
         {
-            // Get focused window info including PID
-            var focusedWindow = await GetFocusedWindowInfoAsync(cancellationToken);
+            var focusedWindow = await _gdbus.GetFocusedWindowInfoAsync(cancellationToken);
             if (focusedWindow == null)
             {
-                // gdbus probe failed (or GNOME Shell slow / extension stalled). If the
-                // last successful detection is fresh enough, serve it — otherwise we'd
-                // fall back to Ctrl+V which Claude Code hijacks as "paste image".
-                return TryServeCachedResult("gdbus probe returned no focused window info");
+                return _cache.TryGet("gdbus probe returned no focused window info");
             }
 
-            // Check if focused window is a terminal
             if (!TerminalClasses.Contains(focusedWindow.Value.WmClass))
             {
                 _logger.LogDebug("Focused window is not a terminal: {WmClass}", focusedWindow.Value.WmClass);
                 // Confirmed non-terminal focus: invalidate cache so a later gdbus
-                // hiccup can't serve the stale CLI-app result (which would push
-                // Shift+Insert into a GUI app whose "real" paste shortcut is Ctrl+V).
-                ClearCache();
+                // hiccup can't serve the stale CLI-app result.
+                _cache.Clear();
                 return null;
             }
 
             _logger.LogDebug("Terminal detected: {WmClass} (PID: {Pid}), checking for CLI apps...",
                 focusedWindow.Value.WmClass, focusedWindow.Value.Pid);
 
-            // Get all descendant processes of the terminal
             var descendantPids = await GetDescendantProcessesAsync(focusedWindow.Value.Pid, cancellationToken);
             _logger.LogDebug("Found {Count} descendant processes for terminal PID {Pid}",
                 descendantPids.Count, focusedWindow.Value.Pid);
 
-            // Check if any known CLI app is among descendants
-            foreach (var agent in KnownAgents)
-            {
-                if (await IsProcessAmongPidsAsync(agent.ProcessName, descendantPids, cancellationToken))
-                {
-                    _logger.LogInformation("Detected CLI app in terminal: {AppName} (process: {ProcessName})",
-                        agent.AppName, agent.ProcessName);
-                    return CacheAndReturn(new CliAppDetectionResult(agent.AppName, agent.PromptFileName));
-                }
-            }
+            if (await MatchByProcessTreeAsync(descendantPids, cancellationToken) is { } processMatch)
+                return CacheAndReturn(processMatch);
 
-            // Fallback: when the CLI app runs under tmux, the tmux server is a
-            // systemd daemon and its panes (including claude) are NOT in the
-            // process tree of the focused terminal. In that case, trust the
-            // terminal window title — TUI agents set it themselves (e.g.
-            // "Claude Code", "OC | ...").
-            var title = focusedWindow.Value.Title ?? "";
-            foreach (var agent in KnownAgents)
-            {
-                foreach (var marker in agent.TitleMarkers)
-                {
-                    if (title.Contains(marker, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _logger.LogInformation(
-                            "Detected CLI app by terminal title: {AppName} (title: '{Title}')",
-                            agent.AppName, title);
-                        return CacheAndReturn(new CliAppDetectionResult(agent.AppName, agent.PromptFileName));
-                    }
-                }
-            }
+            if (MatchByTitle(focusedWindow.Value.Title) is { } titleMatch)
+                return CacheAndReturn(titleMatch);
 
-            // Last fallback: the user's bashrc wrapper runs `tmux new-session -s
-            // claude-<repo>-<tty> -- claude "$@"`, so the tmux *client* is in the
-            // terminal's descendants but the claude process lives under the tmux
-            // server (systemd-scoped, not in the process tree). Ask tmux which
-            // session that client is attached to and match the session name prefix.
-            var cliAppFromTmux = await DetectCliAppViaTmuxAsync(descendantPids, cancellationToken);
-            if (cliAppFromTmux != null)
-            {
-                return CacheAndReturn(cliAppFromTmux);
-            }
+            if (await _tmuxMatcher.MatchAsync(descendantPids, cancellationToken) is { } tmuxMatch)
+                return CacheAndReturn(tmuxMatch);
 
             _logger.LogDebug("No known CLI apps detected in terminal descendants, title or tmux sessions");
-            // Confirmed terminal without any known CLI app (e.g. plain bash): same
-            // invalidation reason as the non-terminal branch.
-            ClearCache();
+            // Confirmed terminal without any known CLI app (e.g. plain bash).
+            _cache.Clear();
             return null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error during CLI app detection");
-            // Same fall-through as a null gdbus result: a recent cached value is
-            // vastly better than a Ctrl+V fallback that hits the paste-image hijack.
-            return TryServeCachedResult("unhandled exception during detection");
+            return _cache.TryGet("unhandled exception during detection");
         }
     }
 
     private CliAppDetectionResult CacheAndReturn(CliAppDetectionResult result)
     {
-        lock (_cacheLock)
-        {
-            _cachedResult = result;
-            _cachedAtUtc = DateTime.UtcNow;
-        }
+        _cache.Set(result);
         return result;
     }
 
-    private void ClearCache()
+    private async Task<CliAppDetectionResult?> MatchByProcessTreeAsync(HashSet<int> descendantPids, CancellationToken cancellationToken)
     {
-        lock (_cacheLock)
+        foreach (var agent in CliAgentRegistry.KnownAgents)
         {
-            _cachedResult = null;
-            _cachedAtUtc = DateTime.MinValue;
+            if (await IsProcessAmongPidsAsync(agent.ProcessName, descendantPids, cancellationToken))
+            {
+                _logger.LogInformation("Detected CLI app in terminal: {AppName} (process: {ProcessName})",
+                    agent.AppName, agent.ProcessName);
+                return new CliAppDetectionResult(agent.AppName, agent.PromptFileName);
+            }
         }
-    }
-
-    private CliAppDetectionResult? TryServeCachedResult(string failureReason)
-    {
-        CliAppDetectionResult? cached;
-        DateTime cachedAt;
-        lock (_cacheLock)
-        {
-            cached = _cachedResult;
-            cachedAt = _cachedAtUtc;
-        }
-
-        if (cached is not null && IsCacheFresh(cachedAt, DateTime.UtcNow))
-        {
-            var age = DateTime.UtcNow - cachedAt;
-            _logger.LogInformation(
-                "Serving cached CLI app detection {AppName} (age {AgeSeconds:F1}s, reason: {Reason})",
-                cached.AppName, age.TotalSeconds, failureReason);
-            return cached;
-        }
-
-        _logger.LogDebug("No usable cache (reason: {Reason})", failureReason);
         return null;
     }
 
-    internal static bool IsCacheFresh(DateTime cachedAtUtc, DateTime nowUtc)
-        => cachedAtUtc != DateTime.MinValue && nowUtc - cachedAtUtc <= CacheStaleness;
-
-    /// <summary>
-    /// Gets information about the currently focused window using GNOME window-calls extension.
-    /// </summary>
-    private async Task<(string WmClass, int Pid, string Title)?> GetFocusedWindowInfoAsync(CancellationToken cancellationToken)
+    private CliAppDetectionResult? MatchByTitle(string? title)
     {
-        try
-        {
-            var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "gdbus",
-                    Arguments = "call --session --dest org.gnome.Shell " +
-                               "--object-path /org/gnome/Shell/Extensions/Windows " +
-                               "--method org.gnome.Shell.Extensions.Windows.List",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
+        var agent = CliAgentRegistry.FindByTitle(title);
+        if (agent is null) return null;
 
-            process.Start();
-            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
-
-            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
-            {
-                _logger.LogDebug("D-Bus window-calls returned no data or failed");
-                return null;
-            }
-
-            // Extract JSON array from gdbus output: ('[{...}]',)
-            var rawJsonArray = GdbusJsonHelper.TryExtractJsonArray(output);
-            if (rawJsonArray is null)
-            {
-                _logger.LogDebug("Could not parse D-Bus output");
-                return null;
-            }
-
-            var jsonArray = GdbusJsonHelper.UnescapeQuotes(rawJsonArray);
-
-            var windows = JsonSerializer.Deserialize<JsonElement>(jsonArray);
-
-            foreach (var window in windows.EnumerateArray())
-            {
-                if (window.TryGetProperty("focus", out var focusProp) && focusProp.GetBoolean())
-                {
-                    var wmClass = window.TryGetProperty("wm_class", out var wmClassProp)
-                        ? wmClassProp.GetString() ?? ""
-                        : "";
-                    var pid = window.TryGetProperty("pid", out var pidProp)
-                        ? pidProp.GetInt32()
-                        : 0;
-                    var title = window.TryGetProperty("title", out var titleProp)
-                        ? titleProp.GetString() ?? ""
-                        : "";
-
-                    if (pid > 0)
-                    {
-                        _logger.LogDebug("Focused window: {WmClass} \"{Title}\" (PID: {Pid})", wmClass, title, pid);
-                        return (wmClass, pid, title);
-                    }
-                }
-            }
-
-            _logger.LogDebug("No focused window found");
-            return null;
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogDebug(ex, "Failed to parse D-Bus JSON response");
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to get focused window info");
-            return null;
-        }
+        _logger.LogInformation(
+            "Detected CLI app by terminal title: {AppName} (title: '{Title}')",
+            agent.AppName, title);
+        return new CliAppDetectionResult(agent.AppName, agent.PromptFileName);
     }
 
     /// <summary>
-    /// Gets all descendant process IDs (children, grandchildren, etc.) of a given PID.
+    /// Walks the process tree rooted at <paramref name="parentPid"/> and returns
+    /// the full descendant PID set. BFS — each iteration spawns one pgrep, so
+    /// depth scales with tree depth, not breadth.
     /// </summary>
     private async Task<HashSet<int>> GetDescendantProcessesAsync(int parentPid, CancellationToken cancellationToken)
     {
@@ -300,25 +145,20 @@ public class TerminalCliAppDetector : ICliAppDetector
             foreach (var childPid in children)
             {
                 if (descendants.Add(childPid))
-                {
                     toProcess.Enqueue(childPid);
-                }
             }
         }
 
         return descendants;
     }
 
-    /// <summary>
-    /// Gets immediate child PIDs of a process.
-    /// </summary>
     private async Task<List<int>> GetChildPidsAsync(int parentPid, CancellationToken cancellationToken)
     {
         var children = new List<int>();
 
         try
         {
-            var process = new Process
+            using var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
@@ -327,8 +167,8 @@ public class TerminalCliAppDetector : ICliAppDetector
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                    CreateNoWindow = true,
+                },
             };
 
             process.Start();
@@ -340,12 +180,11 @@ public class TerminalCliAppDetector : ICliAppDetector
                 foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
                 {
                     if (int.TryParse(line.Trim(), out var pid))
-                    {
                         children.Add(pid);
-                    }
                 }
             }
         }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to get child PIDs for {ParentPid}", parentPid);
@@ -354,152 +193,13 @@ public class TerminalCliAppDetector : ICliAppDetector
         return children;
     }
 
-    /// <summary>
-    /// Parses the output of <c>tmux list-clients -F "#{client_pid}:#{session_name}"</c>
-    /// into a map of client PID → session name. Blank and malformed lines are
-    /// skipped. Session names may contain colons so we split on the first ':' only.
-    /// </summary>
-    internal static Dictionary<int, string> ParseTmuxClients(string? output)
+    private async Task<bool> IsProcessAmongPidsAsync(string processName, HashSet<int> pids, CancellationToken cancellationToken)
     {
-        var map = new Dictionary<int, string>();
-        if (string.IsNullOrWhiteSpace(output))
-        {
-            return map;
-        }
-
-        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-        {
-            var trimmed = line.Trim();
-            var separator = trimmed.IndexOf(':');
-            if (separator <= 0 || separator == trimmed.Length - 1)
-            {
-                continue;
-            }
-
-            if (!int.TryParse(trimmed[..separator], out var pid))
-            {
-                continue;
-            }
-
-            var session = trimmed[(separator + 1)..];
-            if (!string.IsNullOrEmpty(session))
-            {
-                map[pid] = session;
-            }
-        }
-
-        return map;
-    }
-
-    /// <summary>
-    /// Matches a tmux session name against the known-agent prefixes and returns
-    /// the CLI-app detection result if the prefix is known, otherwise null.
-    /// </summary>
-    internal static CliAppDetectionResult? MatchTmuxSessionName(string sessionName)
-    {
-        foreach (var agent in KnownAgents)
-        {
-            if (sessionName.StartsWith(agent.TmuxSessionPrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                return new CliAppDetectionResult(agent.AppName, agent.PromptFileName);
-            }
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// Runs <c>tmux list-clients</c> and returns the first descendant PID's
-    /// session whose name matches a known CLI-agent prefix.
-    /// </summary>
-    private async Task<CliAppDetectionResult?> DetectCliAppViaTmuxAsync(HashSet<int> descendantPids, CancellationToken cancellationToken)
-    {
-        if (descendantPids.Count == 0)
-        {
-            return null;
-        }
+        if (pids.Count == 0) return false;
 
         try
         {
             using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "tmux",
-                    Arguments = "list-clients -F \"#{client_pid}:#{session_name}\"",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-
-            process.Start();
-            try
-            {
-                var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-                await process.WaitForExitAsync(cancellationToken);
-
-                if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
-                {
-                    _logger.LogDebug("tmux list-clients returned no data (exit {ExitCode})", process.ExitCode);
-                    return null;
-                }
-
-                // Iterate the (small) client list and probe the descendant set
-                // instead of the other way round — a long-running terminal can
-                // accumulate hundreds of descendants while `tmux list-clients`
-                // is at most one row per attached terminal.
-                var clients = ParseTmuxClients(output);
-                foreach (var (clientPid, sessionName) in clients)
-                {
-                    if (!descendantPids.Contains(clientPid))
-                    {
-                        continue;
-                    }
-
-                    var match = MatchTmuxSessionName(sessionName);
-                    if (match != null)
-                    {
-                        _logger.LogInformation(
-                            "Detected CLI app via tmux session '{Session}' (client PID {Pid}): {AppName}",
-                            sessionName, clientPid, match.AppName);
-                        return match;
-                    }
-                }
-
-                return null;
-            }
-            catch (OperationCanceledException)
-            {
-                // Caller cancelled mid-probe. Kill the tmux child so it can't
-                // outlive the detection call and leak into ps output. Swallow
-                // kill errors — the process may already have exited.
-                try { process.Kill(entireProcessTree: true); } catch { }
-                throw;
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to query tmux clients for CLI app detection");
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Checks if a process with the given name is running with any of the specified PIDs.
-    /// </summary>
-    private async Task<bool> IsProcessAmongPidsAsync(string processName, HashSet<int> pids, CancellationToken cancellationToken)
-    {
-        if (pids.Count == 0)
-            return false;
-
-        try
-        {
-            var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
@@ -508,8 +208,8 @@ public class TerminalCliAppDetector : ICliAppDetector
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                    CreateNoWindow = true,
+                },
             };
 
             process.Start();
@@ -530,6 +230,7 @@ public class TerminalCliAppDetector : ICliAppDetector
 
             return false;
         }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to check if process '{ProcessName}' is among PIDs", processName);

--- a/src/VirtualAssistant.Core/WindowManagement/TmuxCliAppMatcher.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TmuxCliAppMatcher.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <inheritdoc />
+public sealed class TmuxCliAppMatcher : ITmuxCliAppMatcher
+{
+    private readonly ILogger<TmuxCliAppMatcher> _logger;
+
+    public TmuxCliAppMatcher(ILogger<TmuxCliAppMatcher> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<CliAppDetectionResult?> MatchAsync(IReadOnlySet<int> descendantPids, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(descendantPids);
+        if (descendantPids.Count == 0) return null;
+
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "tmux",
+                    Arguments = "list-clients -F \"#{client_pid}:#{session_name}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+
+            process.Start();
+            try
+            {
+                var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+                await process.WaitForExitAsync(cancellationToken);
+
+                if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+                {
+                    _logger.LogDebug("tmux list-clients returned no data (exit {ExitCode})", process.ExitCode);
+                    return null;
+                }
+
+                // Iterate the (small) client list and probe the descendant set
+                // instead of the other way round — a long-running terminal can
+                // accumulate hundreds of descendants while `tmux list-clients`
+                // is at most one row per attached terminal.
+                var clients = ParseTmuxClients(output);
+                foreach (var (clientPid, sessionName) in clients)
+                {
+                    if (!descendantPids.Contains(clientPid)) continue;
+
+                    var match = MatchTmuxSessionName(sessionName);
+                    if (match != null)
+                    {
+                        _logger.LogInformation(
+                            "Detected CLI app via tmux session '{Session}' (client PID {Pid}): {AppName}",
+                            sessionName, clientPid, match.AppName);
+                        return match;
+                    }
+                }
+
+                return null;
+            }
+            catch (OperationCanceledException)
+            {
+                // Caller cancelled mid-probe. Kill the tmux child so it can't
+                // outlive the detection call and leak into ps output.
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to query tmux clients for CLI app detection");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses the output of <c>tmux list-clients -F "#{client_pid}:#{session_name}"</c>
+    /// into a map of client PID → session name. Blank and malformed lines are
+    /// skipped. Session names may contain colons so we split on the first ':' only.
+    /// </summary>
+    public static Dictionary<int, string> ParseTmuxClients(string? output)
+    {
+        var map = new Dictionary<int, string>();
+        if (string.IsNullOrWhiteSpace(output)) return map;
+
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = line.Trim();
+            var separator = trimmed.IndexOf(':');
+            if (separator <= 0 || separator == trimmed.Length - 1) continue;
+
+            if (!int.TryParse(trimmed[..separator], out var pid)) continue;
+
+            var session = trimmed[(separator + 1)..];
+            if (!string.IsNullOrEmpty(session)) map[pid] = session;
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Matches a tmux session name against the known-agent prefixes and returns
+    /// the CLI-app detection result if the prefix is known, otherwise null.
+    /// </summary>
+    public static CliAppDetectionResult? MatchTmuxSessionName(string sessionName)
+    {
+        var agent = CliAgentRegistry.FindByTmuxSession(sessionName);
+        return agent is null ? null : new CliAppDetectionResult(agent.AppName, agent.PromptFileName);
+    }
+}

--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -194,6 +194,9 @@ public static class VoiceServicesExtensions
     {
         services.AddSingleton<IClipboardManager, WlClipboardManager>();
         services.AddSingleton<ITerminalDetector, WaylandTerminalDetector>();
+        services.AddSingleton<IGdbusWindowDetector, GdbusWindowDetector>();
+        services.AddSingleton<ITmuxCliAppMatcher, TmuxCliAppMatcher>();
+        services.AddSingleton<CliAppDetectionCache>();
         services.AddSingleton<ICliAppDetector, TerminalCliAppDetector>();
         services.AddSingleton<IDotoolProcessRunner, DotoolProcessRunner>();
         services.AddSingleton<IClipboardPasteOrchestrator, ClipboardPasteOrchestrator>();

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/CliAgentRegistryTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/CliAgentRegistryTests.cs
@@ -1,0 +1,56 @@
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
+
+/// <summary>
+/// Coverage for the cross-strategy lookup helpers on <see cref="CliAgentRegistry"/>.
+/// The tmux-prefix lookup is exercised indirectly via <c>TmuxCliAppMatcher</c>
+/// tests; here we pin the title-marker path that the detector's orchestrator
+/// uses for the non-tmux title fallback.
+/// </summary>
+public class CliAgentRegistryTests
+{
+    [Fact]
+    public void FindByTitle_ClaudeCodeMarkerAnywhereInTitle_ReturnsAgent()
+    {
+        var agent = CliAgentRegistry.FindByTitle("my-repo — Claude Code");
+
+        Assert.NotNull(agent);
+        Assert.Equal("Claude Code", agent!.AppName);
+    }
+
+    [Fact]
+    public void FindByTitle_OpenCodeShorthand_Matches()
+    {
+        // OpenCode sets "OC | ..." in some terminals — the shorthand is one of
+        // the declared markers and must not fall through to "no match".
+        var agent = CliAgentRegistry.FindByTitle("OC | main");
+
+        Assert.NotNull(agent);
+        Assert.Equal("OpenCode", agent!.AppName);
+    }
+
+    [Fact]
+    public void FindByTitle_CaseInsensitive()
+    {
+        var agent = CliAgentRegistry.FindByTitle("CLAUDE CODE");
+
+        Assert.NotNull(agent);
+        Assert.Equal("Claude Code", agent!.AppName);
+    }
+
+    [Fact]
+    public void FindByTitle_NoKnownMarker_ReturnsNull()
+    {
+        Assert.Null(CliAgentRegistry.FindByTitle("bash - 80x24"));
+        Assert.Null(CliAgentRegistry.FindByTitle(""));
+        Assert.Null(CliAgentRegistry.FindByTitle(null));
+    }
+
+    [Fact]
+    public void FindByTmuxSession_PrefixMustBeAtStart()
+    {
+        Assert.Null(CliAgentRegistry.FindByTmuxSession("work-claude-"));
+        Assert.NotNull(CliAgentRegistry.FindByTmuxSession("claude-work"));
+    }
+}

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/CliAppDetectionCacheTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/CliAppDetectionCacheTests.cs
@@ -1,0 +1,57 @@
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
+
+/// <summary>
+/// Behavioural coverage for <see cref="CliAppDetectionCache"/>. The freshness
+/// predicate is tested separately (see <c>TerminalCliAppDetectorCacheTests</c>);
+/// here we pin the Set/TryGet/Clear contract.
+/// </summary>
+public class CliAppDetectionCacheTests
+{
+    [Fact]
+    public void TryGet_BeforeAnySet_ReturnsNull()
+    {
+        var cache = new CliAppDetectionCache();
+
+        Assert.Null(cache.TryGet("no cache yet"));
+    }
+
+    [Fact]
+    public void TryGet_AfterSet_ReturnsStoredResult()
+    {
+        var cache = new CliAppDetectionCache();
+        var stored = new CliAppDetectionResult("Claude Code", "ClaudeCodeCorrection");
+        cache.Set(stored);
+
+        var got = cache.TryGet("gdbus failed");
+
+        Assert.NotNull(got);
+        Assert.Equal("Claude Code", got!.AppName);
+        Assert.Equal("ClaudeCodeCorrection", got.PromptFileName);
+    }
+
+    [Fact]
+    public void TryGet_AfterClear_ReturnsNull()
+    {
+        var cache = new CliAppDetectionCache();
+        cache.Set(new CliAppDetectionResult("Claude Code", "ClaudeCodeCorrection"));
+        cache.Clear();
+
+        Assert.Null(cache.TryGet("gdbus failed"));
+    }
+
+    [Fact]
+    public void Set_Overwrites_PreviousValue()
+    {
+        // Detector transitions (Claude Code → OpenCode as user switches terminals)
+        // must overwrite, not accumulate, so the stale app name never leaks back.
+        var cache = new CliAppDetectionCache();
+        cache.Set(new CliAppDetectionResult("Claude Code", "ClaudeCodeCorrection"));
+        cache.Set(new CliAppDetectionResult("OpenCode", "OpenCodeCorrection"));
+
+        var got = cache.TryGet("gdbus failed");
+
+        Assert.Equal("OpenCode", got!.AppName);
+    }
+}

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalCliAppDetectorCacheTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalCliAppDetectorCacheTests.cs
@@ -3,11 +3,13 @@ using Olbrasoft.VirtualAssistant.Core.WindowManagement;
 namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
 
 /// <summary>
-/// Cache-freshness contract for <see cref="TerminalCliAppDetector"/>. The full
-/// <c>DetectCliAppAsync</c> flow shells out to gdbus/pgrep and is tested manually;
-/// here we pin down just the pure time-based freshness predicate that decides
-/// whether a transient gdbus failure may be papered over with a cached value
-/// instead of falling back to Ctrl+V (which Claude Code hijacks as "paste image").
+/// Cache-freshness contract for the detector. The predicate moved from
+/// <c>TerminalCliAppDetector</c> to <see cref="CliAppDetectionCache"/> during
+/// the #973 split; the tests followed it. The full <c>DetectCliAppAsync</c>
+/// flow shells out to gdbus/pgrep and is tested manually; here we pin down
+/// just the pure time-based predicate that decides whether a transient gdbus
+/// failure may be papered over with a cached value instead of falling back
+/// to Ctrl+V (which Claude Code hijacks as "paste image").
 /// </summary>
 public class TerminalCliAppDetectorCacheTests
 {
@@ -16,7 +18,7 @@ public class TerminalCliAppDetectorCacheTests
     {
         // Detector has never completed a successful probe yet, so the cache must
         // not be served — the "DateTime.MinValue" sentinel means "no cache".
-        var result = TerminalCliAppDetector.IsCacheFresh(DateTime.MinValue, DateTime.UtcNow);
+        var result = CliAppDetectionCache.IsCacheFresh(DateTime.MinValue, DateTime.UtcNow);
 
         Assert.False(result);
     }
@@ -27,7 +29,7 @@ public class TerminalCliAppDetectorCacheTests
         var now = DateTime.UtcNow;
         var cachedAt = now.AddSeconds(-1);
 
-        var result = TerminalCliAppDetector.IsCacheFresh(cachedAt, now);
+        var result = CliAppDetectionCache.IsCacheFresh(cachedAt, now);
 
         Assert.True(result);
     }
@@ -38,9 +40,9 @@ public class TerminalCliAppDetectorCacheTests
         // Boundary is inclusive (<=), so a cache entry right at the limit still
         // serves. This prevents a tiny clock drift from flipping us to "stale".
         var now = DateTime.UtcNow;
-        var cachedAt = now - TerminalCliAppDetector.CacheStaleness;
+        var cachedAt = now - CliAppDetectionCache.CacheStaleness;
 
-        var result = TerminalCliAppDetector.IsCacheFresh(cachedAt, now);
+        var result = CliAppDetectionCache.IsCacheFresh(cachedAt, now);
 
         Assert.True(result);
     }
@@ -49,9 +51,9 @@ public class TerminalCliAppDetectorCacheTests
     public void IsCacheFresh_OneSecondPastStaleness_ReturnsFalse()
     {
         var now = DateTime.UtcNow;
-        var cachedAt = now - TerminalCliAppDetector.CacheStaleness - TimeSpan.FromSeconds(1);
+        var cachedAt = now - CliAppDetectionCache.CacheStaleness - TimeSpan.FromSeconds(1);
 
-        var result = TerminalCliAppDetector.IsCacheFresh(cachedAt, now);
+        var result = CliAppDetectionCache.IsCacheFresh(cachedAt, now);
 
         Assert.False(result);
     }

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalCliAppDetectorTmuxTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalCliAppDetectorTmuxTests.cs
@@ -3,20 +3,19 @@ using Olbrasoft.VirtualAssistant.Core.WindowManagement;
 namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
 
 /// <summary>
-/// Covers the pure helpers that back the tmux-session fallback for
-/// <see cref="TerminalCliAppDetector"/>. The full process-invoking path is
-/// tested manually; the parser and prefix matcher are the interesting bits
-/// because the bashrc wrapper's session naming (<c>claude-&lt;repo&gt;-&lt;tty&gt;</c>)
-/// is what lets us detect claude inside tmux at all.
+/// Covers the pure helpers that back the tmux-session fallback for the
+/// detector. The helpers migrated to <see cref="TmuxCliAppMatcher"/> and
+/// <see cref="CliAgentRegistry"/> during the #973 split; the tests followed
+/// them. The full process-invoking path is tested manually.
 /// </summary>
 public class TerminalCliAppDetectorTmuxTests
 {
     [Fact]
     public void ParseTmuxClients_EmptyOrNull_ReturnsEmptyMap()
     {
-        Assert.Empty(TerminalCliAppDetector.ParseTmuxClients(null));
-        Assert.Empty(TerminalCliAppDetector.ParseTmuxClients(""));
-        Assert.Empty(TerminalCliAppDetector.ParseTmuxClients("   \n  "));
+        Assert.Empty(TmuxCliAppMatcher.ParseTmuxClients(null));
+        Assert.Empty(TmuxCliAppMatcher.ParseTmuxClients(""));
+        Assert.Empty(TmuxCliAppMatcher.ParseTmuxClients("   \n  "));
     }
 
     [Fact]
@@ -24,7 +23,7 @@ public class TerminalCliAppDetectorTmuxTests
     {
         var output = "78600:claude-VirtualAssistant\n98159:claude-vercel-pts-2\n106024:claude-streamtape-pts-3\n";
 
-        var map = TerminalCliAppDetector.ParseTmuxClients(output);
+        var map = TmuxCliAppMatcher.ParseTmuxClients(output);
 
         Assert.Equal(3, map.Count);
         Assert.Equal("claude-VirtualAssistant", map[78600]);
@@ -37,7 +36,7 @@ public class TerminalCliAppDetectorTmuxTests
     {
         var output = "12345:valid-session\nnot-a-pid:whatever\n:missing-pid\nnocolon-line\n67890:\n";
 
-        var map = TerminalCliAppDetector.ParseTmuxClients(output);
+        var map = TmuxCliAppMatcher.ParseTmuxClients(output);
 
         Assert.Single(map);
         Assert.Equal("valid-session", map[12345]);
@@ -49,7 +48,7 @@ public class TerminalCliAppDetectorTmuxTests
         // Split on first ':' only so session names containing colons still parse.
         var output = "1001:weird:session:name\n";
 
-        var map = TerminalCliAppDetector.ParseTmuxClients(output);
+        var map = TmuxCliAppMatcher.ParseTmuxClients(output);
 
         Assert.Equal("weird:session:name", map[1001]);
     }
@@ -57,7 +56,7 @@ public class TerminalCliAppDetectorTmuxTests
     [Fact]
     public void MatchTmuxSessionName_ClaudePrefix_ReturnsClaudeCode()
     {
-        var result = TerminalCliAppDetector.MatchTmuxSessionName("claude-VirtualAssistant-pts-0");
+        var result = TmuxCliAppMatcher.MatchTmuxSessionName("claude-VirtualAssistant-pts-0");
 
         Assert.NotNull(result);
         Assert.Equal("Claude Code", result!.AppName);
@@ -67,7 +66,7 @@ public class TerminalCliAppDetectorTmuxTests
     [Fact]
     public void MatchTmuxSessionName_OpenCodePrefix_ReturnsOpenCode()
     {
-        var result = TerminalCliAppDetector.MatchTmuxSessionName("opencode-repo");
+        var result = TmuxCliAppMatcher.MatchTmuxSessionName("opencode-repo");
 
         Assert.NotNull(result);
         Assert.Equal("OpenCode", result!.AppName);
@@ -76,7 +75,7 @@ public class TerminalCliAppDetectorTmuxTests
     [Fact]
     public void MatchTmuxSessionName_GeminiPrefix_ReturnsGeminiCli()
     {
-        var result = TerminalCliAppDetector.MatchTmuxSessionName("gemini-foo");
+        var result = TmuxCliAppMatcher.MatchTmuxSessionName("gemini-foo");
 
         Assert.NotNull(result);
         Assert.Equal("Gemini CLI", result!.AppName);
@@ -87,7 +86,7 @@ public class TerminalCliAppDetectorTmuxTests
     {
         // Session names come from tmux verbatim, but treat the match as case-
         // insensitive so a user who names a session "Claude-foo" still wins.
-        var result = TerminalCliAppDetector.MatchTmuxSessionName("Claude-Foo");
+        var result = TmuxCliAppMatcher.MatchTmuxSessionName("Claude-Foo");
 
         Assert.NotNull(result);
         Assert.Equal("Claude Code", result!.AppName);
@@ -96,9 +95,9 @@ public class TerminalCliAppDetectorTmuxTests
     [Fact]
     public void MatchTmuxSessionName_UnknownPrefix_ReturnsNull()
     {
-        Assert.Null(TerminalCliAppDetector.MatchTmuxSessionName("work"));
-        Assert.Null(TerminalCliAppDetector.MatchTmuxSessionName("main"));
-        Assert.Null(TerminalCliAppDetector.MatchTmuxSessionName(""));
+        Assert.Null(TmuxCliAppMatcher.MatchTmuxSessionName("work"));
+        Assert.Null(TmuxCliAppMatcher.MatchTmuxSessionName("main"));
+        Assert.Null(TmuxCliAppMatcher.MatchTmuxSessionName(""));
     }
 
     [Fact]
@@ -107,6 +106,6 @@ public class TerminalCliAppDetectorTmuxTests
         // "my-claude-session" contains "claude-" but not at the start — we
         // require the prefix so that the bashrc wrapper's naming stays the
         // single source of truth.
-        Assert.Null(TerminalCliAppDetector.MatchTmuxSessionName("my-claude-session"));
+        Assert.Null(TmuxCliAppMatcher.MatchTmuxSessionName("my-claude-session"));
     }
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #973

## Summary
The detector had grown to 539 LOC owning four responsibilities in one place. Split three out, leaving a thin orchestrator:

| Concern | Extract | LOC |
|---|---|---|
| Agent catalog + cross-strategy lookups | `CliAgentRegistry` | 68 |
| Short-TTL cache state + predicate | `CliAppDetectionCache` | 81 |
| gdbus call + JSON parsing | `GdbusWindowDetector` / `IGdbusWindowDetector` | 96 |
| tmux client/session matching | `TmuxCliAppMatcher` / `ITmuxCliAppMatcher` | 122 |
| Orchestrator (remaining: TerminalClasses + process-tree + pipeline) | `TerminalCliAppDetector` | 240 |

`DetectCliAppAsync` drops from 90 LOC of nested try/catch to ~50 LOC of linear strategy chaining.

## Decisions
- Process-tree walking (`GetDescendantProcessesAsync`, `GetChildPidsAsync`, `IsProcessAmongPidsAsync`) stays in the orchestrator because splitting it out would add a fourth DI dependency without meaningful locality gain — it's driven entirely by the capture flow.
- `CliAgentRegistry` is a static class (pure data + lookups). No injection, no lifecycle — it's the single source of truth that's referenced by both the orchestrator (process + title) and `TmuxCliAppMatcher` (tmux).
- `TmuxCliAppMatcher.ParseTmuxClients` and `MatchTmuxSessionName` stay as public statics so the existing parse-/prefix-match test suites keep their shape (just the class name changed).

## Tests
- Moved `TerminalCliAppDetectorTmuxTests` → calls `TmuxCliAppMatcher.*`
- Moved `TerminalCliAppDetectorCacheTests` → calls `CliAppDetectionCache.*`
- Added `CliAppDetectionCacheTests` (Set/TryGet/Clear/Overwrite)
- Added `CliAgentRegistryTests` (title casing, OpenCode shorthand, tmux prefix-must-be-at-start)
- Core.Tests: 77 → 86

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — Core 86, Voice 312, Service 307, all green
- [ ] CI green
- [ ] Manual smoke test: paste into Claude Code (gdbus + tmux paths) still resolves