### PR TITLE
fix(detection): address Copilot findings on PR #1003 (cancel leaks, docs, test rename)

### DIFF
--- a/src/VirtualAssistant.Core/WindowManagement/CliAgentRegistry.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/CliAgentRegistry.cs
@@ -33,9 +33,9 @@ public static class CliAgentRegistry
     };
 
     /// <summary>
-    /// Returns the agent whose tmux session prefix starts <paramref name="sessionName"/>,
-    /// or null if no agent claims the prefix. Case-insensitive so a user who
-    /// types "Claude-foo" still wins.
+    /// Returns the agent whose tmux session prefix matches the start of
+    /// <paramref name="sessionName"/>, or null if no agent claims the prefix.
+    /// Case-insensitive so a user who types "Claude-foo" still wins.
     /// </summary>
     public static KnownAgent? FindByTmuxSession(string sessionName)
     {

--- a/src/VirtualAssistant.Core/WindowManagement/GdbusWindowDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/GdbusWindowDetector.cs
@@ -16,26 +16,38 @@ public sealed class GdbusWindowDetector : IGdbusWindowDetector
 
     public async Task<FocusedWindowInfo?> GetFocusedWindowInfoAsync(CancellationToken cancellationToken)
     {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "gdbus",
+                Arguments = "call --session --dest org.gnome.Shell " +
+                           "--object-path /org/gnome/Shell/Extensions/Windows " +
+                           "--method org.gnome.Shell.Extensions.Windows.List",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+
         try
         {
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "gdbus",
-                    Arguments = "call --session --dest org.gnome.Shell " +
-                               "--object-path /org/gnome/Shell/Extensions/Windows " +
-                               "--method org.gnome.Shell.Extensions.Windows.List",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                },
-            };
-
             process.Start();
-            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
+            string output;
+            try
+            {
+                output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Caller cancelled mid-probe. Kill the gdbus child so it can't
+                // outlive the detection call — under hotkey spam this would
+                // otherwise accumulate short-lived gdbus children.
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
 
             if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
             {

--- a/src/VirtualAssistant.Core/WindowManagement/IGdbusWindowDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/IGdbusWindowDetector.cs
@@ -16,9 +16,11 @@ public interface IGdbusWindowDetector
 {
     /// <summary>
     /// Returns info about the currently focused window, or null when the
-    /// gdbus call fails or no focused window is reported. Errors are
-    /// swallowed — this is called on the dictation hot path and a failure
-    /// must never propagate.
+    /// gdbus call fails or no focused window is reported. Detection and
+    /// parsing errors are swallowed — this is called on the dictation hot
+    /// path and such failures must never propagate. Caller-requested
+    /// cancellation is still honored and may propagate as an
+    /// <see cref="OperationCanceledException"/>.
     /// </summary>
     Task<FocusedWindowInfo?> GetFocusedWindowInfoAsync(CancellationToken cancellationToken);
 }

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -158,30 +158,13 @@ public class TerminalCliAppDetector : ICliAppDetector
 
         try
         {
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "pgrep",
-                    Arguments = $"-P {parentPid}",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                },
-            };
+            var output = await RunPgrepAsync($"-P {parentPid}", cancellationToken);
+            if (output is null) return children;
 
-            process.Start();
-            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
-
-            if (process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
+            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
             {
-                foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-                {
-                    if (int.TryParse(line.Trim(), out var pid))
-                        children.Add(pid);
-                }
+                if (int.TryParse(line.Trim(), out var pid))
+                    children.Add(pid);
             }
         }
         catch (OperationCanceledException) { throw; }
@@ -199,32 +182,15 @@ public class TerminalCliAppDetector : ICliAppDetector
 
         try
         {
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "pgrep",
-                    Arguments = $"-x {processName}",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                },
-            };
+            var output = await RunPgrepAsync($"-x {processName}", cancellationToken);
+            if (output is null) return false;
 
-            process.Start();
-            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
-
-            if (process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
+            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
             {
-                foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                if (int.TryParse(line.Trim(), out var pid) && pids.Contains(pid))
                 {
-                    if (int.TryParse(line.Trim(), out var pid) && pids.Contains(pid))
-                    {
-                        _logger.LogDebug("Found {ProcessName} (PID: {Pid}) among terminal descendants", processName, pid);
-                        return true;
-                    }
+                    _logger.LogDebug("Found {ProcessName} (PID: {Pid}) among terminal descendants", processName, pid);
+                    return true;
                 }
             }
 
@@ -236,5 +202,42 @@ public class TerminalCliAppDetector : ICliAppDetector
             _logger.LogDebug(ex, "Failed to check if process '{ProcessName}' is among PIDs", processName);
             return false;
         }
+    }
+
+    /// <summary>
+    /// Spawns pgrep with the given arguments, returns stdout on success or
+    /// null if pgrep exited non-zero (no match is exit 1). Kills the child
+    /// on caller cancellation before re-throwing so hotkey spam cannot
+    /// accumulate short-lived pgrep processes. (Copilot review on PR #1003.)
+    /// </summary>
+    private static async Task<string?> RunPgrepAsync(string arguments, CancellationToken cancellationToken)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "pgrep",
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+
+        process.Start();
+        string output;
+        try
+        {
+            output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { }
+            throw;
+        }
+
+        return process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output) ? output : null;
     }
 }

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TmuxCliAppMatcherTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TmuxCliAppMatcherTests.cs
@@ -8,7 +8,7 @@ namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
 /// <see cref="CliAgentRegistry"/> during the #973 split; the tests followed
 /// them. The full process-invoking path is tested manually.
 /// </summary>
-public class TerminalCliAppDetectorTmuxTests
+public class TmuxCliAppMatcherTests
 {
     [Fact]
     public void ParseTmuxClients_EmptyOrNull_ReturnsEmptyMap()


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to #1003 — five Copilot findings:

## 1. IGdbusWindowDetector doc contract mismatch
Doc said "failures must never propagate" but implementation rethrows OperationCanceledException. Clarified that detection/parse failures are swallowed while caller cancellation is still honored.

## 2. GdbusWindowDetector leaked gdbus child on cancel
Under hotkey spam, cancelled probes left live gdbus processes behind. Mirrored the tmux-matcher pattern: inner `try/catch (OperationCanceledException)` that kills the child and rethrows.

## 3. TerminalCliAppDetector leaked pgrep children on cancel
Same issue as #2 for both `GetChildPidsAsync` and `IsProcessAmongPidsAsync`. Extracted a private `RunPgrepAsync` helper so both paths share one kill-on-cancel implementation.

## 4. CliAgentRegistry.FindByTmuxSession docstring was backwards
"tmux session prefix starts sessionName" → "tmux session prefix matches the start of sessionName".

## 5. Test class rename
`TerminalCliAppDetectorTmuxTests` now exercises `TmuxCliAppMatcher` + `CliAgentRegistry`, not the detector. Renamed file and class to `TmuxCliAppMatcherTests` for clearer test discovery.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test tests/VirtualAssistant.Core.Tests` — 86/86 pass
- [ ] CI green
- [ ] Smoke test: dictation paste still works under hotkey spam (no accumulating gdbus/pgrep in `ps`)