### PR TITLE
refactor(tray): split MenuEventDispatcher into four domain handlers

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
@@ -111,31 +111,41 @@ public static class TrayServicesExtensions
         // Icon animation service for hand icon animations
         services.AddSingleton<IIconAnimationService, IconAnimationService>();
 
-        // Menu event dispatcher for handling tray menu actions
+        // Menu event dispatcher for handling tray menu actions. The four
+        // domain handlers are constructed inline so the DI graph reads top-
+        // down (which handler owns which optional service) instead of being
+        // scattered across separate AddSingleton calls.
         services.AddSingleton<IMenuEventDispatcher>(sp =>
         {
-            var logger = sp.GetRequiredService<ILogger<MenuEventDispatcher>>();
-            var muteService = sp.GetRequiredService<IManualMuteService>();
-            var settingsService = sp.GetRequiredService<ISettingsService>();
             var configuration = sp.GetRequiredService<IConfiguration>();
-            var llmProvider = sp.GetService<ILlmProvider>();
-            var dictationControl = sp.GetService<IDictationControl>();
-            var promptSyncService = sp.GetService<IPromptSyncService>();
-            var menuStateManager = sp.GetService<IMenuStateManager>();
-            var correctionFilter = sp.GetService<Olbrasoft.VirtualAssistant.Voice.Filters.DatabaseCorrectionFilterStrategy>();
-
             var dashboardBaseUrl = configuration["Dashboard:BaseUrl"] ?? "http://localhost:5055";
 
+            var mute = new Tray.Handlers.MuteMenuHandler(
+                sp.GetRequiredService<ILogger<Tray.Handlers.MuteMenuHandler>>(),
+                sp.GetRequiredService<IManualMuteService>(),
+                sp.GetRequiredService<ISettingsService>());
+
+            var dictation = new Tray.Handlers.DictationMenuHandler(
+                sp.GetRequiredService<ILogger<Tray.Handlers.DictationMenuHandler>>(),
+                sp.GetService<IDictationControl>());
+
+            var llm = new Tray.Handlers.LlmMenuHandler(
+                sp.GetRequiredService<ILogger<Tray.Handlers.LlmMenuHandler>>(),
+                sp.GetService<ILlmProvider>(),
+                sp.GetService<IPromptSyncService>(),
+                sp.GetService<IMenuStateManager>(),
+                sp.GetService<Olbrasoft.VirtualAssistant.Voice.Filters.DatabaseCorrectionFilterStrategy>());
+
+            var dashboard = new Tray.Handlers.DashboardMenuHandler(
+                sp.GetRequiredService<ILogger<Tray.Handlers.DashboardMenuHandler>>(),
+                dashboardBaseUrl);
+
             return new MenuEventDispatcher(
-                logger,
-                muteService,
-                settingsService,
-                dashboardBaseUrl,
-                llmProvider,
-                dictationControl,
-                promptSyncService,
-                menuStateManager,
-                correctionFilter);
+                sp.GetRequiredService<ILogger<MenuEventDispatcher>>(),
+                mute,
+                dictation,
+                llm,
+                dashboard);
         });
 
         // Recording notification service for dictation status (Phase 1 - issue #670)

--- a/src/VirtualAssistant.Service/Tray/Handlers/DashboardMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/DashboardMenuHandler.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+/// <inheritdoc />
+public sealed class DashboardMenuHandler : IDashboardMenuHandler
+{
+    private readonly ILogger<DashboardMenuHandler> _logger;
+    private readonly string _dashboardBaseUrl;
+
+    public DashboardMenuHandler(
+        ILogger<DashboardMenuHandler> logger,
+        string dashboardBaseUrl)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _dashboardBaseUrl = dashboardBaseUrl ?? "http://localhost:5055";
+    }
+
+    public void HandleDashboard()
+    {
+        try
+        {
+            var dashboardUrl = $"{_dashboardBaseUrl}/Admin";
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "xdg-open",
+                    Arguments = dashboardUrl,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+            process.Start();
+            _logger.LogInformation("Opened dashboard at {Url}", dashboardUrl);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to open dashboard");
+        }
+    }
+
+    public void HandleAbout()
+    {
+        var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+        _logger.LogInformation("About requested - Version: {Version}", version);
+
+        try
+        {
+            var text = $"<b>VirtualAssistant</b>\\n\\nVerze: {version}\\n\\nLinux virtuální asistent pro ovládání desktopu a integraci s AI coding agenty.\\n\\nhttps://github.com/Olbrasoft/VirtualAssistant";
+
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "zenity",
+                    Arguments = $"--info --title=\"O aplikaci\" --text=\"{text}\" --no-wrap --ok-label=\"Zavřít\"",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+            process.Start();
+            _logger.LogInformation("Showed About dialog (zenity) - Version: {Version}", version);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to show about dialog using zenity");
+        }
+    }
+}

--- a/src/VirtualAssistant.Service/Tray/Handlers/DictationMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/DictationMenuHandler.cs
@@ -1,0 +1,56 @@
+using Olbrasoft.VirtualAssistant.Core.Services;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+/// <inheritdoc />
+public sealed class DictationMenuHandler : IDictationMenuHandler
+{
+    private readonly ILogger<DictationMenuHandler> _logger;
+    private readonly IDictationControl? _dictationControl;
+
+    public DictationMenuHandler(
+        ILogger<DictationMenuHandler> logger,
+        IDictationControl? dictationControl = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _dictationControl = dictationControl;
+    }
+
+    public void HandleDictationToggle(bool enabled)
+    {
+        try
+        {
+            if (_dictationControl == null)
+            {
+                _logger.LogWarning("Dictation control not available");
+                return;
+            }
+
+            _logger.LogInformation("Setting dictation enabled: {Enabled}", enabled);
+            _dictationControl.SetDictationEnabled(enabled);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to toggle dictation");
+        }
+    }
+
+    public void HandleStreamingTranscriptionToggle(bool enabled)
+    {
+        try
+        {
+            if (_dictationControl == null)
+            {
+                _logger.LogWarning("Dictation control not available");
+                return;
+            }
+
+            _logger.LogInformation("Setting streaming transcription enabled: {Enabled}", enabled);
+            _dictationControl.SetStreamingTranscriptionEnabled(enabled);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to toggle streaming transcription");
+        }
+    }
+}

--- a/src/VirtualAssistant.Service/Tray/Handlers/IDashboardMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/IDashboardMenuHandler.cs
@@ -1,0 +1,12 @@
+namespace Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+/// <summary>
+/// Handles browser / dialog menu actions (Dashboard open, About dialog).
+/// Kept separate from LLM/billing so the dashboard-URL configuration lives
+/// with only the handlers that actually need it.
+/// </summary>
+public interface IDashboardMenuHandler
+{
+    void HandleDashboard();
+    void HandleAbout();
+}

--- a/src/VirtualAssistant.Service/Tray/Handlers/IDictationMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/IDictationMenuHandler.cs
@@ -1,0 +1,12 @@
+namespace Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+/// <summary>
+/// Handles dictation-related menu actions. Dictation control is optional
+/// (not every deployment runs dictation), so missing control services are
+/// logged and ignored rather than crashing the menu.
+/// </summary>
+public interface IDictationMenuHandler
+{
+    void HandleDictationToggle(bool enabled);
+    void HandleStreamingTranscriptionToggle(bool enabled);
+}

--- a/src/VirtualAssistant.Service/Tray/Handlers/ILlmMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/ILlmMenuHandler.cs
@@ -1,0 +1,13 @@
+namespace Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+/// <summary>
+/// Handles LLM-related menu actions: correction toggle, prompt reload, Mercury
+/// billing dashboard, and the transcription-corrections cache flush.
+/// </summary>
+public interface ILlmMenuHandler
+{
+    void HandleLlmCorrectionToggle(bool enabled);
+    void HandleReloadPrompt();
+    void HandleMercuryBilling();
+    void HandleReloadCorrectionsCache();
+}

--- a/src/VirtualAssistant.Service/Tray/Handlers/IMuteMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/IMuteMenuHandler.cs
@@ -1,0 +1,10 @@
+namespace Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+/// <summary>
+/// Handles the mute-related menu actions (microphone toggle, TTS mute).
+/// </summary>
+public interface IMuteMenuHandler
+{
+    void HandleMuteToggle();
+    Task HandleTtsMuteToggleAsync(bool muted);
+}

--- a/src/VirtualAssistant.Service/Tray/Handlers/LlmMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/LlmMenuHandler.cs
@@ -1,0 +1,145 @@
+using System.Diagnostics;
+using Olbrasoft.VirtualAssistant.Service.Services;
+using Olbrasoft.VirtualAssistant.Service.Tray.Menu;
+using Olbrasoft.VirtualAssistant.Voice.Filters;
+using Olbrasoft.VirtualAssistant.Voice.Services;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+/// <inheritdoc />
+public sealed class LlmMenuHandler : ILlmMenuHandler
+{
+    private readonly ILogger<LlmMenuHandler> _logger;
+    private readonly ILlmProvider? _llmProvider;
+    private readonly IPromptSyncService? _promptSyncService;
+    private readonly IMenuStateManager? _menuStateManager;
+    private readonly DatabaseCorrectionFilterStrategy? _correctionFilter;
+
+    public LlmMenuHandler(
+        ILogger<LlmMenuHandler> logger,
+        ILlmProvider? llmProvider = null,
+        IPromptSyncService? promptSyncService = null,
+        IMenuStateManager? menuStateManager = null,
+        DatabaseCorrectionFilterStrategy? correctionFilter = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _llmProvider = llmProvider;
+        _promptSyncService = promptSyncService;
+        _menuStateManager = menuStateManager;
+        _correctionFilter = correctionFilter;
+    }
+
+    public void HandleLlmCorrectionToggle(bool enabled)
+    {
+        if (_llmProvider == null)
+        {
+            _logger.LogWarning("LLM provider not available");
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Toggling LLM correction to: {Enabled}", enabled);
+            _llmProvider.SetEnabled(enabled);
+            _logger.LogInformation("LLM correction successfully {Status}", enabled ? "enabled" : "disabled");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to toggle LLM correction");
+        }
+    }
+
+    public void HandleReloadPrompt()
+    {
+        if (_llmProvider == null)
+        {
+            _logger.LogWarning("LLM provider not available");
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Syncing LLM prompts...");
+            _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.Syncing);
+
+            if (_promptSyncService != null)
+            {
+                var result = _promptSyncService.SyncPrompts();
+
+                if (result.Success)
+                {
+                    _logger.LogInformation("Prompt sync completed. Copied {Count} files.", result.FilesCopied);
+                    _llmProvider.ReloadPrompt();
+                    _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.InSync);
+                    _logger.LogInformation("LLM prompts synced and reloaded successfully");
+                }
+                else
+                {
+                    var errorMsg = string.Join("; ", result.Errors);
+                    _logger.LogError("Prompt sync failed: {Errors}", errorMsg);
+                    _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.SyncFailed, errorMsg);
+                }
+            }
+            else
+            {
+                // Fallback: just clear cache (legacy behavior before PromptSync was wired up).
+                _logger.LogWarning("PromptSyncService not available - ensure PromptSync:SourcePath is configured in appsettings.json. Only clearing LLM prompt cache.");
+                _llmProvider.ReloadPrompt();
+                _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.Unknown);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to sync LLM prompts");
+            _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.SyncFailed, ex.Message);
+        }
+    }
+
+    public void HandleMercuryBilling()
+    {
+        try
+        {
+            const string billingUrl = "https://platform.inceptionlabs.ai/dashboard/billing";
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "xdg-open",
+                    Arguments = billingUrl,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+            process.Start();
+            _logger.LogInformation("Opened Mercury billing dashboard at {Url}", billingUrl);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to open Mercury billing dashboard");
+        }
+    }
+
+    /// <summary>
+    /// Invalidates the transcription corrections cache so a freshly INSERTed row
+    /// in <c>transcription_corrections</c> takes effect on the very next dictation.
+    /// No-op if the filter strategy is not available (e.g. running in tests).
+    /// </summary>
+    public void HandleReloadCorrectionsCache()
+    {
+        if (_correctionFilter is null)
+        {
+            _logger.LogWarning("Transcription correction filter not available; cache invalidation skipped");
+            return;
+        }
+
+        try
+        {
+            _correctionFilter.InvalidateCache();
+            _logger.LogInformation("Transcription corrections cache invalidated from tray menu");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to invalidate transcription corrections cache");
+        }
+    }
+}

--- a/src/VirtualAssistant.Service/Tray/Handlers/MuteMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/MuteMenuHandler.cs
@@ -1,0 +1,47 @@
+using Olbrasoft.VirtualAssistant.Core.Services;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+/// <inheritdoc />
+public sealed class MuteMenuHandler : IMuteMenuHandler
+{
+    private readonly ILogger<MuteMenuHandler> _logger;
+    private readonly IManualMuteService _muteService;
+    private readonly ISettingsService _settingsService;
+
+    public MuteMenuHandler(
+        ILogger<MuteMenuHandler> logger,
+        IManualMuteService muteService,
+        ISettingsService settingsService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _muteService = muteService ?? throw new ArgumentNullException(nameof(muteService));
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+    }
+
+    public void HandleMuteToggle()
+    {
+        try
+        {
+            _muteService.Toggle();
+            _logger.LogInformation("Mute toggled via tray menu to: {IsMuted}", _muteService.IsMuted);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to toggle mute from tray menu");
+        }
+    }
+
+    public async Task HandleTtsMuteToggleAsync(bool muted)
+    {
+        try
+        {
+            await _settingsService.SetAsync("tts.muted", muted);
+            _logger.LogInformation("TTS mute set via tray menu to: {IsMuted}", muted);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set TTS mute from tray menu");
+        }
+    }
+}

--- a/src/VirtualAssistant.Service/Tray/MenuEventDispatcher.cs
+++ b/src/VirtualAssistant.Service/Tray/MenuEventDispatcher.cs
@@ -1,298 +1,49 @@
-using System.Diagnostics;
-using System.Reflection;
 using Olbrasoft.VirtualAssistant.Core.Services;
-using Olbrasoft.VirtualAssistant.Service.Services;
-using Olbrasoft.VirtualAssistant.Service.Tray.Menu;
-using Olbrasoft.VirtualAssistant.Voice.Filters;
-using Olbrasoft.VirtualAssistant.Voice.Services;
+using Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
 
 namespace Olbrasoft.VirtualAssistant.Service.Tray;
 
 /// <summary>
-/// Dispatches menu events from tray icon context menu to appropriate handlers.
-/// Implements Command pattern for menu actions.
+/// Facade over the four domain handlers that implement tray-menu actions.
+/// The dispatcher itself holds no business logic — it only forwards calls so
+/// that <see cref="IMenuEventDispatcher"/> stays a single entry point while
+/// each domain (mute / dictation / LLM / dashboard) can evolve independently.
+/// Constructor dropped from nine parameters to five; per-handler dependencies
+/// stay inside the handler that actually uses them.
 /// </summary>
 public class MenuEventDispatcher : IMenuEventDispatcher
 {
     private readonly ILogger<MenuEventDispatcher> _logger;
-    private readonly IManualMuteService _muteService;
-    private readonly ISettingsService _settingsService;
-    private readonly string _dashboardBaseUrl;
-    private readonly ILlmProvider? _llmProvider;
-    private readonly IDictationControl? _dictationControl;
-    private readonly IPromptSyncService? _promptSyncService;
-    private readonly IMenuStateManager? _menuStateManager;
-    private readonly DatabaseCorrectionFilterStrategy? _correctionFilter;
+    private readonly IMuteMenuHandler _mute;
+    private readonly IDictationMenuHandler _dictation;
+    private readonly ILlmMenuHandler _llm;
+    private readonly IDashboardMenuHandler _dashboard;
 
     public MenuEventDispatcher(
         ILogger<MenuEventDispatcher> logger,
-        IManualMuteService muteService,
-        ISettingsService settingsService,
-        string dashboardBaseUrl,
-        ILlmProvider? llmProvider = null,
-        IDictationControl? dictationControl = null,
-        IPromptSyncService? promptSyncService = null,
-        IMenuStateManager? menuStateManager = null,
-        DatabaseCorrectionFilterStrategy? correctionFilter = null)
+        IMuteMenuHandler mute,
+        IDictationMenuHandler dictation,
+        ILlmMenuHandler llm,
+        IDashboardMenuHandler dashboard)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _muteService = muteService ?? throw new ArgumentNullException(nameof(muteService));
-        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
-        _dashboardBaseUrl = dashboardBaseUrl ?? "http://localhost:5055";
-        _llmProvider = llmProvider;
-        _dictationControl = dictationControl;
-        _promptSyncService = promptSyncService;
-        _menuStateManager = menuStateManager;
-        _correctionFilter = correctionFilter;
+        _mute = mute ?? throw new ArgumentNullException(nameof(mute));
+        _dictation = dictation ?? throw new ArgumentNullException(nameof(dictation));
+        _llm = llm ?? throw new ArgumentNullException(nameof(llm));
+        _dashboard = dashboard ?? throw new ArgumentNullException(nameof(dashboard));
     }
 
-    /// <inheritdoc/>
-    public void HandleMuteToggle()
-    {
-        try
-        {
-            _muteService.Toggle();
-            _logger.LogInformation("Mute toggled via tray menu to: {IsMuted}", _muteService.IsMuted);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to toggle mute from tray menu");
-        }
-    }
+    public void HandleMuteToggle() => _mute.HandleMuteToggle();
+    public Task HandleTtsMuteToggleAsync(bool muted) => _mute.HandleTtsMuteToggleAsync(muted);
 
-    /// <inheritdoc/>
-    public async Task HandleTtsMuteToggleAsync(bool muted)
-    {
-        try
-        {
-            await _settingsService.SetAsync("tts.muted", muted);
-            _logger.LogInformation("TTS mute set via tray menu to: {IsMuted}", muted);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to set TTS mute from tray menu");
-        }
-    }
+    public void HandleDashboard() => _dashboard.HandleDashboard();
+    public void HandleAbout() => _dashboard.HandleAbout();
 
-    /// <inheritdoc/>
-    public void HandleDashboard()
-    {
-        OpenDashboardInBrowser("Opened dashboard at {Url}");
-    }
+    public void HandleLlmCorrectionToggle(bool enabled) => _llm.HandleLlmCorrectionToggle(enabled);
+    public void HandleReloadPrompt() => _llm.HandleReloadPrompt();
+    public void HandleMercuryBilling() => _llm.HandleMercuryBilling();
+    public void HandleReloadCorrectionsCache() => _llm.HandleReloadCorrectionsCache();
 
-    /// <inheritdoc/>
-    public void HandleAbout()
-    {
-        var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
-        _logger.LogInformation("About requested - Version: {Version}", version);
-
-        try
-        {
-            var text = $"<b>VirtualAssistant</b>\\n\\nVerze: {version}\\n\\nLinux virtuální asistent pro ovládání desktopu a integraci s AI coding agenty.\\n\\nhttps://github.com/Olbrasoft/VirtualAssistant";
-
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "zenity",
-                    Arguments = $"--info --title=\"O aplikaci\" --text=\"{text}\" --no-wrap --ok-label=\"Zavřít\"",
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-            process.Start();
-            _logger.LogInformation("Showed About dialog (zenity) - Version: {Version}", version);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to show about dialog using zenity");
-        }
-    }
-
-    private void OpenDashboardInBrowser(string logMessage)
-    {
-        try
-        {
-            var dashboardUrl = $"{_dashboardBaseUrl}/Admin";
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "xdg-open",
-                    Arguments = dashboardUrl,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-            process.Start();
-            _logger.LogInformation(logMessage, dashboardUrl);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to open dashboard");
-        }
-    }
-
-    /// <inheritdoc/>
-    public void HandleLlmCorrectionToggle(bool enabled)
-    {
-        if (_llmProvider == null)
-        {
-            _logger.LogWarning("LLM provider not available");
-            return;
-        }
-
-        try
-        {
-            _logger.LogInformation("Toggling LLM correction to: {Enabled}", enabled);
-            _llmProvider.SetEnabled(enabled);
-            _logger.LogInformation("LLM correction successfully {Status}", enabled ? "enabled" : "disabled");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to toggle LLM correction");
-        }
-    }
-
-    /// <inheritdoc/>
-    public void HandleReloadPrompt()
-    {
-        if (_llmProvider == null)
-        {
-            _logger.LogWarning("LLM provider not available");
-            return;
-        }
-
-        try
-        {
-            _logger.LogInformation("Syncing LLM prompts...");
-
-            // Update menu to show syncing state
-            _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.Syncing);
-
-            // Sync prompts from source to deployment directory
-            if (_promptSyncService != null)
-            {
-                var result = _promptSyncService.SyncPrompts();
-
-                if (result.Success)
-                {
-                    _logger.LogInformation("Prompt sync completed. Copied {Count} files.", result.FilesCopied);
-
-                    // Clear cache so prompts are reloaded from newly copied files
-                    _llmProvider.ReloadPrompt();
-
-                    _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.InSync);
-                    _logger.LogInformation("LLM prompts synced and reloaded successfully");
-                }
-                else
-                {
-                    var errorMsg = string.Join("; ", result.Errors);
-                    _logger.LogError("Prompt sync failed: {Errors}", errorMsg);
-                    _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.SyncFailed, errorMsg);
-                }
-            }
-            else
-            {
-                // Fallback: just clear cache (old behavior)
-                _logger.LogWarning("PromptSyncService not available - ensure PromptSync:SourcePath is configured in appsettings.json. Only clearing LLM prompt cache.");
-                _llmProvider.ReloadPrompt();
-                _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.Unknown);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to sync LLM prompts");
-            _menuStateManager?.UpdatePromptSyncStatus(PromptSyncStatus.SyncFailed, ex.Message);
-        }
-    }
-
-    /// <inheritdoc/>
-    public void HandleMercuryBilling()
-    {
-        try
-        {
-            var billingUrl = "https://platform.inceptionlabs.ai/dashboard/billing";
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "xdg-open",
-                    Arguments = billingUrl,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-            process.Start();
-            _logger.LogInformation("Opened Mercury billing dashboard at {Url}", billingUrl);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to open Mercury billing dashboard");
-        }
-    }
-
-    /// <inheritdoc/>
-    public void HandleDictationToggle(bool enabled)
-    {
-        try
-        {
-            if (_dictationControl == null)
-            {
-                _logger.LogWarning("Dictation control not available");
-                return;
-            }
-
-            _logger.LogInformation("Setting dictation enabled: {Enabled}", enabled);
-            _dictationControl.SetDictationEnabled(enabled);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to toggle dictation");
-        }
-    }
-
-    /// <summary>
-    /// Invalidates the transcription corrections cache so a freshly INSERTed row in
-    /// <c>transcription_corrections</c> takes effect on the very next dictation.
-    /// No-op if the filter strategy is not available (e.g. running in tests).
-    /// </summary>
-    public void HandleReloadCorrectionsCache()
-    {
-        if (_correctionFilter is null)
-        {
-            _logger.LogWarning("Transcription correction filter not available; cache invalidation skipped");
-            return;
-        }
-
-        try
-        {
-            _correctionFilter.InvalidateCache();
-            _logger.LogInformation("Transcription corrections cache invalidated from tray menu");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to invalidate transcription corrections cache");
-        }
-    }
-
-    /// <inheritdoc/>
-    public void HandleStreamingTranscriptionToggle(bool enabled)
-    {
-        try
-        {
-            if (_dictationControl == null)
-            {
-                _logger.LogWarning("Dictation control not available");
-                return;
-            }
-
-            _logger.LogInformation("Setting streaming transcription enabled: {Enabled}", enabled);
-            _dictationControl.SetStreamingTranscriptionEnabled(enabled);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to toggle streaming transcription");
-        }
-    }
+    public void HandleDictationToggle(bool enabled) => _dictation.HandleDictationToggle(enabled);
+    public void HandleStreamingTranscriptionToggle(bool enabled) => _dictation.HandleStreamingTranscriptionToggle(enabled);
 }

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DashboardMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DashboardMenuHandlerTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray.Handlers;
+
+public class DashboardMenuHandlerTests
+{
+    private readonly Mock<ILogger<DashboardMenuHandler>> _loggerMock = new();
+
+    [Fact]
+    public void Constructor_NullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new DashboardMenuHandler(null!, "http://localhost:5055"));
+
+    [Fact]
+    public void Constructor_NullDashboardUrl_FallsBackToLocalhost()
+    {
+        // Defensive fallback matches the pre-split behavior of MenuEventDispatcher —
+        // some test code used to pass null through and expect "http://localhost:5055".
+        var sut = new DashboardMenuHandler(_loggerMock.Object, null!);
+
+        Assert.NotNull(sut);
+    }
+
+    [Fact]
+    public void HandleDashboard_DoesNotThrow()
+    {
+        // The method spawns xdg-open; we can't meaningfully assert on the
+        // subprocess, but exceptions must be swallowed on CI runners where
+        // xdg-open is absent.
+        var sut = new DashboardMenuHandler(_loggerMock.Object, "http://localhost:5055");
+
+        var ex = Record.Exception(() => sut.HandleDashboard());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void HandleAbout_DoesNotThrow()
+    {
+        // Same reasoning as HandleDashboard — zenity may be absent; the
+        // handler must log and return rather than propagate.
+        var sut = new DashboardMenuHandler(_loggerMock.Object, "http://localhost:5055");
+
+        var ex = Record.Exception(() => sut.HandleAbout());
+
+        Assert.Null(ex);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DictationMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DictationMenuHandlerTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray.Handlers;
+
+public class DictationMenuHandlerTests
+{
+    private readonly Mock<ILogger<DictationMenuHandler>> _loggerMock = new();
+
+    [Fact]
+    public void HandleDictationToggle_WithoutDictationControl_IsNoOp()
+    {
+        // Running without dictation support is a valid deployment, so a missing
+        // control service must not crash the menu click.
+        var sut = new DictationMenuHandler(_loggerMock.Object, dictationControl: null);
+
+        var ex = Record.Exception(() => sut.HandleDictationToggle(true));
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void HandleDictationToggle_DelegatesValueToControl(bool enabled)
+    {
+        var controlMock = new Mock<IDictationControl>();
+        var sut = new DictationMenuHandler(_loggerMock.Object, controlMock.Object);
+
+        sut.HandleDictationToggle(enabled);
+
+        controlMock.Verify(x => x.SetDictationEnabled(enabled), Times.Once);
+    }
+
+    [Fact]
+    public void HandleDictationToggle_WhenControlThrows_SwallowsException()
+    {
+        var controlMock = new Mock<IDictationControl>();
+        controlMock.Setup(x => x.SetDictationEnabled(It.IsAny<bool>())).Throws<InvalidOperationException>();
+        var sut = new DictationMenuHandler(_loggerMock.Object, controlMock.Object);
+
+        var ex = Record.Exception(() => sut.HandleDictationToggle(true));
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void HandleStreamingTranscriptionToggle_DelegatesValueToControl(bool enabled)
+    {
+        var controlMock = new Mock<IDictationControl>();
+        var sut = new DictationMenuHandler(_loggerMock.Object, controlMock.Object);
+
+        sut.HandleStreamingTranscriptionToggle(enabled);
+
+        controlMock.Verify(x => x.SetStreamingTranscriptionEnabled(enabled), Times.Once);
+    }
+
+    [Fact]
+    public void HandleStreamingTranscriptionToggle_WithoutDictationControl_IsNoOp()
+    {
+        var sut = new DictationMenuHandler(_loggerMock.Object, dictationControl: null);
+
+        var ex = Record.Exception(() => sut.HandleStreamingTranscriptionToggle(true));
+
+        Assert.Null(ex);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/LlmMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/LlmMenuHandlerTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Service.Services;
+using Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+using Olbrasoft.VirtualAssistant.Service.Tray.Menu;
+using Olbrasoft.VirtualAssistant.Voice.Services;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray.Handlers;
+
+public class LlmMenuHandlerTests
+{
+    private readonly Mock<ILogger<LlmMenuHandler>> _loggerMock = new();
+    private readonly Mock<ILlmProvider> _llmProviderMock = new();
+    private readonly Mock<IPromptSyncService> _syncMock = new();
+    private readonly Mock<IMenuStateManager> _stateManagerMock = new();
+
+    [Fact]
+    public void HandleLlmCorrectionToggle_WithoutProvider_IsNoOp()
+    {
+        var sut = new LlmMenuHandler(_loggerMock.Object, llmProvider: null);
+
+        var ex = Record.Exception(() => sut.HandleLlmCorrectionToggle(true));
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void HandleLlmCorrectionToggle_DelegatesToProvider(bool enabled)
+    {
+        var sut = new LlmMenuHandler(_loggerMock.Object, _llmProviderMock.Object);
+
+        sut.HandleLlmCorrectionToggle(enabled);
+
+        _llmProviderMock.Verify(x => x.SetEnabled(enabled), Times.Once);
+    }
+
+    [Fact]
+    public void HandleReloadPrompt_WithSyncSuccess_UpdatesStateToInSync()
+    {
+        _syncMock.Setup(x => x.SyncPrompts()).Returns(new PromptSyncResult(true, 3, 0, Array.Empty<string>()));
+        var sut = new LlmMenuHandler(_loggerMock.Object, _llmProviderMock.Object, _syncMock.Object, _stateManagerMock.Object);
+
+        sut.HandleReloadPrompt();
+
+        _llmProviderMock.Verify(x => x.ReloadPrompt(), Times.Once);
+        _stateManagerMock.Verify(x => x.UpdatePromptSyncStatus(PromptSyncStatus.InSync, null), Times.Once);
+    }
+
+    [Fact]
+    public void HandleReloadPrompt_WithSyncFailure_UpdatesStateToSyncFailed()
+    {
+        _syncMock.Setup(x => x.SyncPrompts()).Returns(new PromptSyncResult(false, 0, 1, new[] { "permission denied" }));
+        var sut = new LlmMenuHandler(_loggerMock.Object, _llmProviderMock.Object, _syncMock.Object, _stateManagerMock.Object);
+
+        sut.HandleReloadPrompt();
+
+        _stateManagerMock.Verify(x => x.UpdatePromptSyncStatus(PromptSyncStatus.SyncFailed, "permission denied"), Times.Once);
+        _llmProviderMock.Verify(x => x.ReloadPrompt(), Times.Never);
+    }
+
+    [Fact]
+    public void HandleReloadPrompt_WithoutSyncService_FallsBackToCacheReload()
+    {
+        // Legacy deployment path where PromptSync isn't configured yet — the
+        // menu click must still flush the LLM cache so the user can see effect.
+        var sut = new LlmMenuHandler(_loggerMock.Object, _llmProviderMock.Object, promptSyncService: null, _stateManagerMock.Object);
+
+        sut.HandleReloadPrompt();
+
+        _llmProviderMock.Verify(x => x.ReloadPrompt(), Times.Once);
+        _stateManagerMock.Verify(x => x.UpdatePromptSyncStatus(PromptSyncStatus.Unknown, null), Times.Once);
+    }
+
+    [Fact]
+    public void HandleReloadCorrectionsCache_WithoutFilter_IsNoOp()
+    {
+        var sut = new LlmMenuHandler(_loggerMock.Object);
+
+        var ex = Record.Exception(() => sut.HandleReloadCorrectionsCache());
+
+        Assert.Null(ex);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/MuteMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/MuteMenuHandlerTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray.Handlers;
+
+public class MuteMenuHandlerTests
+{
+    private readonly Mock<ILogger<MuteMenuHandler>> _loggerMock = new();
+    private readonly Mock<IManualMuteService> _muteServiceMock = new();
+    private readonly Mock<ISettingsService> _settingsServiceMock = new();
+    private readonly MuteMenuHandler _sut;
+
+    public MuteMenuHandlerTests()
+    {
+        _sut = new MuteMenuHandler(_loggerMock.Object, _muteServiceMock.Object, _settingsServiceMock.Object);
+    }
+
+    [Fact]
+    public void HandleMuteToggle_CallsMuteServiceToggle()
+    {
+        _sut.HandleMuteToggle();
+        _muteServiceMock.Verify(x => x.Toggle(), Times.Once);
+    }
+
+    [Fact]
+    public void HandleMuteToggle_WhenServiceThrows_SwallowsException()
+    {
+        _muteServiceMock.Setup(x => x.Toggle()).Throws<InvalidOperationException>();
+
+        var ex = Record.Exception(() => _sut.HandleMuteToggle());
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task HandleTtsMuteToggleAsync_WritesSettingWithGivenValue(bool muted)
+    {
+        await _sut.HandleTtsMuteToggleAsync(muted);
+
+        _settingsServiceMock.Verify(x => x.SetAsync("tts.muted", muted), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleTtsMuteToggleAsync_WhenSettingsThrows_SwallowsException()
+    {
+        _settingsServiceMock
+            .Setup(x => x.SetAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var ex = await Record.ExceptionAsync(() => _sut.HandleTtsMuteToggleAsync(true));
+
+        Assert.Null(ex);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Tray/MenuEventDispatcherTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/MenuEventDispatcherTests.cs
@@ -1,511 +1,136 @@
 using Microsoft.Extensions.Logging;
 using Moq;
-using Olbrasoft.VirtualAssistant.Core.Services;
-using Olbrasoft.VirtualAssistant.Data.Entities;
 using Olbrasoft.VirtualAssistant.Service.Tray;
-using Olbrasoft.VirtualAssistant.Voice.Filters;
-using Olbrasoft.VirtualAssistant.Voice.Services;
+using Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
 
 namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray;
 
 /// <summary>
-/// Unit tests for MenuEventDispatcher.
-/// Tests menu event handling, command pattern implementation, and error handling.
+/// After the #980 split <see cref="MenuEventDispatcher"/> is a thin facade
+/// over four domain handlers — these tests pin the delegation contract.
+/// Per-handler behavior (error swallowing, null-dependency guards, actual
+/// side effects) is covered by the dedicated handler test classes.
 /// </summary>
 public class MenuEventDispatcherTests
 {
-    private readonly Mock<ILogger<MenuEventDispatcher>> _loggerMock;
-    private readonly Mock<IManualMuteService> _muteServiceMock;
-    private readonly Mock<ISettingsService> _settingsServiceMock;
-    private readonly Mock<ILlmProvider> _llmProviderMock;
-    private readonly Mock<IDictationControl> _dictationControlMock;
-    private const string DashboardBaseUrl = "http://localhost:5055";
+    private readonly Mock<ILogger<MenuEventDispatcher>> _loggerMock = new();
+    private readonly Mock<IMuteMenuHandler> _muteMock = new();
+    private readonly Mock<IDictationMenuHandler> _dictationMock = new();
+    private readonly Mock<ILlmMenuHandler> _llmMock = new();
+    private readonly Mock<IDashboardMenuHandler> _dashboardMock = new();
+    private readonly MenuEventDispatcher _sut;
 
     public MenuEventDispatcherTests()
     {
-        _loggerMock = new Mock<ILogger<MenuEventDispatcher>>();
-        _muteServiceMock = new Mock<IManualMuteService>();
-        _settingsServiceMock = new Mock<ISettingsService>();
-        _llmProviderMock = new Mock<ILlmProvider>();
-        _dictationControlMock = new Mock<IDictationControl>();
-    }
-
-    #region Constructor Tests
-
-    [Fact]
-    public void Constructor_WithValidParameters_CreatesInstance()
-    {
-        // Act
-        var sut = new MenuEventDispatcher(
+        _sut = new MenuEventDispatcher(
             _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl);
-
-        // Assert
-        Assert.NotNull(sut);
+            _muteMock.Object,
+            _dictationMock.Object,
+            _llmMock.Object,
+            _dashboardMock.Object);
     }
 
     [Fact]
-    public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+    public void Constructor_WithNullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
+            null!, _muteMock.Object, _dictationMock.Object, _llmMock.Object, _dashboardMock.Object));
+
+    [Fact]
+    public void Constructor_WithNullMute_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
+            _loggerMock.Object, null!, _dictationMock.Object, _llmMock.Object, _dashboardMock.Object));
+
+    [Fact]
+    public void Constructor_WithNullDictation_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
+            _loggerMock.Object, _muteMock.Object, null!, _llmMock.Object, _dashboardMock.Object));
+
+    [Fact]
+    public void Constructor_WithNullLlm_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
+            _loggerMock.Object, _muteMock.Object, _dictationMock.Object, null!, _dashboardMock.Object));
+
+    [Fact]
+    public void Constructor_WithNullDashboard_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
+            _loggerMock.Object, _muteMock.Object, _dictationMock.Object, _llmMock.Object, null!));
+
+    [Fact]
+    public void HandleMuteToggle_DelegatesToMuteHandler()
     {
-        // Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            new MenuEventDispatcher(
-                null!,
-                _muteServiceMock.Object,
-                _settingsServiceMock.Object,
-                DashboardBaseUrl));
+        _sut.HandleMuteToggle();
+        _muteMock.Verify(x => x.HandleMuteToggle(), Times.Once);
     }
 
     [Fact]
-    public void Constructor_WithNullMuteService_ThrowsArgumentNullException()
+    public async Task HandleTtsMuteToggleAsync_DelegatesToMuteHandler()
     {
-        // Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            new MenuEventDispatcher(
-                _loggerMock.Object,
-                null!,
-                _settingsServiceMock.Object,
-                DashboardBaseUrl));
+        _muteMock.Setup(x => x.HandleTtsMuteToggleAsync(true)).Returns(Task.CompletedTask);
+
+        await _sut.HandleTtsMuteToggleAsync(true);
+
+        _muteMock.Verify(x => x.HandleTtsMuteToggleAsync(true), Times.Once);
     }
 
     [Fact]
-    public void Constructor_WithNullSettingsService_ThrowsArgumentNullException()
+    public void HandleDashboard_DelegatesToDashboardHandler()
     {
-        // Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            new MenuEventDispatcher(
-                _loggerMock.Object,
-                _muteServiceMock.Object,
-                null!,
-                DashboardBaseUrl));
+        _sut.HandleDashboard();
+        _dashboardMock.Verify(x => x.HandleDashboard(), Times.Once);
     }
 
     [Fact]
-    public void Constructor_WithNullOptionalParameters_CreatesInstance()
+    public void HandleAbout_DelegatesToDashboardHandler()
     {
-        // Act
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            llmProvider: null,
-            dictationControl: null);
-
-        // Assert
-        Assert.NotNull(sut);
+        _sut.HandleAbout();
+        _dashboardMock.Verify(x => x.HandleAbout(), Times.Once);
     }
 
-    #endregion
-
-    #region HandleMuteToggle Tests
-
-    [Fact]
-    public void HandleMuteToggle_CallsMuteServiceToggle()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void HandleLlmCorrectionToggle_DelegatesToLlmHandler(bool enabled)
     {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl);
-
-        _muteServiceMock.Setup(x => x.Toggle());
-        _muteServiceMock.Setup(x => x.IsMuted).Returns(true);
-
-        // Act
-        sut.HandleMuteToggle();
-
-        // Assert
-        _muteServiceMock.Verify(x => x.Toggle(), Times.Once);
+        _sut.HandleLlmCorrectionToggle(enabled);
+        _llmMock.Verify(x => x.HandleLlmCorrectionToggle(enabled), Times.Once);
     }
 
     [Fact]
-    public void HandleMuteToggle_WhenToggleFails_LogsError()
+    public void HandleReloadPrompt_DelegatesToLlmHandler()
     {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl);
-
-        var exception = new InvalidOperationException("Toggle failed");
-        _muteServiceMock.Setup(x => x.Toggle()).Throws(exception);
-
-        // Act
-        sut.HandleMuteToggle();
-
-        // Assert - Should not throw, but should log error
-        _muteServiceMock.Verify(x => x.Toggle(), Times.Once);
-    }
-
-    #endregion
-
-    #region HandleTtsMuteToggleAsync Tests
-
-    [Fact]
-    public async Task HandleTtsMuteToggleAsync_WhenCurrentlyUnmuted_SetsMutedToTrue()
-    {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl);
-
-        // Act
-        await sut.HandleTtsMuteToggleAsync(true);
-
-        // Assert
-        _settingsServiceMock.Verify(x => x.SetAsync("tts.muted", true), Times.Once);
+        _sut.HandleReloadPrompt();
+        _llmMock.Verify(x => x.HandleReloadPrompt(), Times.Once);
     }
 
     [Fact]
-    public async Task HandleTtsMuteToggleAsync_WhenCurrentlyMuted_SetsMutedToFalse()
+    public void HandleMercuryBilling_DelegatesToLlmHandler()
     {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl);
-
-        // Act
-        await sut.HandleTtsMuteToggleAsync(false);
-
-        // Assert
-        _settingsServiceMock.Verify(x => x.SetAsync("tts.muted", false), Times.Once);
+        _sut.HandleMercuryBilling();
+        _llmMock.Verify(x => x.HandleMercuryBilling(), Times.Once);
     }
 
     [Fact]
-    public async Task HandleTtsMuteToggleAsync_WhenToggleFails_LogsError()
+    public void HandleReloadCorrectionsCache_DelegatesToLlmHandler()
     {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl);
-
-        var exception = new InvalidOperationException("Settings error");
-        _settingsServiceMock.Setup(x => x.SetAsync("tts.muted", It.IsAny<bool>()))
-            .ThrowsAsync(exception);
-
-        // Act
-        await sut.HandleTtsMuteToggleAsync(true);
-
-        // Assert - Should not throw, but should log error
-        _settingsServiceMock.Verify(x => x.SetAsync("tts.muted", true), Times.Once);
+        _sut.HandleReloadCorrectionsCache();
+        _llmMock.Verify(x => x.HandleReloadCorrectionsCache(), Times.Once);
     }
 
-    #endregion
-
-    #region HandleShowLogs Tests
-
-    // DISABLED: This test opens actual Chrome browser (side-effect)
-    // HandleShowLogs() calls Process.Start() which launches browser
-    // Unit tests should not have side-effects on the system
-    // TODO: Refactor HandleShowLogs to use IProcessStarter interface for testability
-
-    //[Fact]
-    //public void HandleShowLogs_ConstructsCorrectUrl()
-    //{
-    //    // Arrange
-    //    var sut = new MenuEventDispatcher(
-    //        _loggerMock.Object,
-    //        _muteServiceMock.Object,
-    //        _settingsServiceMock.Object,
-    //        DashboardBaseUrl);
-    //
-    //    // Act & Assert
-    //    // Note: We can't easily test Process.Start without integration tests
-    //    // This test verifies the method doesn't throw
-    //    sut.HandleShowLogs();
-    //}
-
-    #endregion
-
-    #region HandleLlmCorrectionToggle Tests
-
-    [Fact]
-    public void HandleLlmCorrectionToggle_WithoutProvider_LogsWarning()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void HandleDictationToggle_DelegatesToDictationHandler(bool enabled)
     {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            llmProvider: null);
-
-        // Act
-        sut.HandleLlmCorrectionToggle(true);
-
-        // Assert - Should log warning but not throw
+        _sut.HandleDictationToggle(enabled);
+        _dictationMock.Verify(x => x.HandleDictationToggle(enabled), Times.Once);
     }
 
-    [Fact]
-    public void HandleLlmCorrectionToggle_WithProvider_EnablesCorrection()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void HandleStreamingTranscriptionToggle_DelegatesToDictationHandler(bool enabled)
     {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            _llmProviderMock.Object);
-
-        _llmProviderMock.Setup(x => x.SetEnabled(true));
-
-        // Act
-        sut.HandleLlmCorrectionToggle(true);
-
-        // Assert
-        _llmProviderMock.Verify(x => x.SetEnabled(true), Times.Once);
+        _sut.HandleStreamingTranscriptionToggle(enabled);
+        _dictationMock.Verify(x => x.HandleStreamingTranscriptionToggle(enabled), Times.Once);
     }
-
-    [Fact]
-    public void HandleLlmCorrectionToggle_WithProvider_DisablesCorrection()
-    {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            _llmProviderMock.Object);
-
-        _llmProviderMock.Setup(x => x.SetEnabled(false));
-
-        // Act
-        sut.HandleLlmCorrectionToggle(false);
-
-        // Assert
-        _llmProviderMock.Verify(x => x.SetEnabled(false), Times.Once);
-    }
-
-    [Fact]
-    public void HandleLlmCorrectionToggle_WhenSetEnabledFails_LogsError()
-    {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            _llmProviderMock.Object);
-
-        var exception = new InvalidOperationException("Provider error");
-        _llmProviderMock.Setup(x => x.SetEnabled(It.IsAny<bool>()))
-            .Throws(exception);
-
-        // Act
-        sut.HandleLlmCorrectionToggle(true);
-
-        // Assert - Should not throw, but should log error
-        _llmProviderMock.Verify(x => x.SetEnabled(true), Times.Once);
-    }
-
-    #endregion
-
-    #region HandleReloadPrompt Tests
-
-    // DISABLED: These tests are no longer needed
-    // HandleReloadPrompt() now only clears cache via ILlmProvider.ReloadPrompt()
-    // No filesystem operations, prompts deployed via deploy.sh script
-
-    //[Fact]
-    //public void HandleReloadPrompt_WithoutProvider_LogsWarning()
-    //{
-    //    // Arrange
-    //    var sut = new MenuEventDispatcher(
-    //        _loggerMock.Object,
-    //        _muteServiceMock.Object,
-    //        _settingsServiceMock.Object,
-    //        DashboardBaseUrl,
-    //        llmProvider: null);
-    //
-    //    // Act
-    //    sut.HandleReloadPrompt();
-    //
-    //    // Assert - Should log warning but not throw
-    //}
-    //
-    //[Fact]
-    //public void HandleReloadPrompt_WithProvider_CallsReloadPrompt()
-    //{
-    //    // Arrange
-    //    var sut = new MenuEventDispatcher(
-    //        _loggerMock.Object,
-    //        _muteServiceMock.Object,
-    //        _settingsServiceMock.Object,
-    //        DashboardBaseUrl,
-    //        _llmProviderMock.Object);
-    //
-    //    _llmProviderMock.Setup(x => x.ReloadPrompt());
-    //
-    //    // Act
-    //    sut.HandleReloadPrompt();
-    //
-    //    // Assert
-    //    _llmProviderMock.Verify(x => x.ReloadPrompt(), Times.Once);
-    //}
-    //
-    //[Fact]
-    //public void HandleReloadPrompt_WhenReloadFails_LogsError()
-    //{
-    //    // Arrange
-    //    var sut = new MenuEventDispatcher(
-    //        _loggerMock.Object,
-    //        _muteServiceMock.Object,
-    //        _settingsServiceMock.Object,
-    //        DashboardBaseUrl,
-    //        _llmProviderMock.Object);
-    //
-    //    var exception = new InvalidOperationException("Reload failed");
-    //    _llmProviderMock.Setup(x => x.ReloadPrompt())
-    //        .Throws(exception);
-    //
-    //    // Act
-    //    sut.HandleReloadPrompt();
-    //
-    //    // Assert - Should not throw, but should log error
-    //    _llmProviderMock.Verify(x => x.ReloadPrompt(), Times.Once);
-    //}
-
-    #endregion
-
-    #region HandleDictationToggle Tests
-
-    [Fact]
-    public void HandleDictationToggle_WithoutControl_LogsWarning()
-    {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            dictationControl: null);
-
-        // Act
-        sut.HandleDictationToggle(true);
-
-        // Assert - Should log warning but not throw
-    }
-
-    [Fact]
-    public void HandleDictationToggle_WithControl_EnablesDictation()
-    {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            dictationControl: _dictationControlMock.Object);
-
-        _dictationControlMock.Setup(x => x.SetDictationEnabled(true));
-
-        // Act
-        sut.HandleDictationToggle(true);
-
-        // Assert
-        _dictationControlMock.Verify(x => x.SetDictationEnabled(true), Times.Once);
-    }
-
-    [Fact]
-    public void HandleDictationToggle_WithControl_DisablesDictation()
-    {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            dictationControl: _dictationControlMock.Object);
-
-        _dictationControlMock.Setup(x => x.SetDictationEnabled(false));
-
-        // Act
-        sut.HandleDictationToggle(false);
-
-        // Assert
-        _dictationControlMock.Verify(x => x.SetDictationEnabled(false), Times.Once);
-    }
-
-    [Fact]
-    public void HandleDictationToggle_WhenSetEnabledFails_LogsError()
-    {
-        // Arrange
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            dictationControl: _dictationControlMock.Object);
-
-        var exception = new InvalidOperationException("Control error");
-        _dictationControlMock.Setup(x => x.SetDictationEnabled(It.IsAny<bool>()))
-            .Throws(exception);
-
-        // Act
-        sut.HandleDictationToggle(true);
-
-        // Assert - Should not throw, but should log error
-        _dictationControlMock.Verify(x => x.SetDictationEnabled(true), Times.Once);
-    }
-
-    #endregion
-
-    #region HandleReloadCorrectionsCache Tests
-
-    [Fact]
-    public void HandleReloadCorrectionsCache_WithoutFilter_LogsWarningDoesNotThrow()
-    {
-        // correctionFilter omitted — the tray should not crash if the Voice layer
-        // decided to disable DB corrections (repository: null construction).
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            correctionFilter: null);
-
-        var ex = Record.Exception(() => sut.HandleReloadCorrectionsCache());
-
-        Assert.Null(ex);
-    }
-
-    [Fact]
-    public void HandleReloadCorrectionsCache_WithFilter_ForcesNextApplyToReloadFromRepository()
-    {
-        // Verifies the contract the tray button was built for: after a click, the
-        // very next Apply() calls the repository, picking up newly INSERTed rows.
-        var repo = new Mock<ITranscriptionCorrectionRepository>();
-        repo.Setup(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<TranscriptionCorrection>());
-
-        var filter = new DatabaseCorrectionFilterStrategy(
-            Mock.Of<ILogger<DatabaseCorrectionFilterStrategy>>(),
-            repo.Object);
-
-        var sut = new MenuEventDispatcher(
-            _loggerMock.Object,
-            _muteServiceMock.Object,
-            _settingsServiceMock.Object,
-            DashboardBaseUrl,
-            correctionFilter: filter);
-
-        filter.Apply("warm cache");
-        sut.HandleReloadCorrectionsCache();
-        filter.Apply("trigger reload");
-
-        repo.Verify(r => r.GetActiveCorrectionsAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
-    }
-
-    #endregion
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Partially addresses #980 (MenuEventDispatcher half)

## Summary
MenuEventDispatcher had grown to 298 LOC with a 9-parameter constructor (5 optional) and 9 Handle* methods spanning four unrelated domains. Every Handle* method began with a null guard for its own optional dependency. Split into four focused handlers behind small interfaces, keeping `IMenuEventDispatcher` as the single entry point (no change for callers).

## Numbers
| Class | LOC | Ctor params |
|---|---|---|
| `MenuEventDispatcher` (facade) | 49 | 5 (logger + 4 handlers) |
| `MuteMenuHandler` | 47 | 3 |
| `DictationMenuHandler` | 56 | 2 |
| `LlmMenuHandler` | 145 | 5 (4 optional) |
| `DashboardMenuHandler` | 71 | 2 |

All within the issue acceptance criteria (≤ 5 ctor params, ≤ 10 public methods).

## Decisions
- `IMenuEventDispatcher` surface unchanged — no caller (TrayCoordinatorService, MenuEventRouter) needs updating.
- Optional dependencies live inside the handler that actually needs them (e.g. `IDictationControl?` only on `DictationMenuHandler`). Menu actions on deployments that lack a service log-and-return locally instead of being guarded nine times on the dispatcher.
- DI factory constructs all four handlers inline rather than as separate top-level singletons — reads top-down, no risk of a registration being forgotten.

## Scope note
The `VirtualAssistantDBusMenuHandler` split (MenuStateUpdater + MenuEventForwarder extracts) is deferred to a follow-up PR so review stays focused.

## Tests
- `MenuEventDispatcherTests` rewritten as thin delegation verification (13 tests)
- `MuteMenuHandlerTests` / `DictationMenuHandlerTests` / `LlmMenuHandlerTests` / `DashboardMenuHandlerTests` added with happy-path + error-swallowing + null-dep coverage
- Service.Tests: 307 → 328 (+21 tests), all green

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — Core 86, Service 328, Voice 312, all pass
- [ ] CI green
- [ ] Manual tray smoke test: mute toggle, TTS mute, dashboard, about, LLM toggle, prompt reload, dictation toggle