### PR TITLE
fix(tray): address Copilot findings on PR #1005 (logger, nullable url, test args)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
@@ -140,12 +140,7 @@ public static class TrayServicesExtensions
                 sp.GetRequiredService<ILogger<Tray.Handlers.DashboardMenuHandler>>(),
                 dashboardBaseUrl);
 
-            return new MenuEventDispatcher(
-                sp.GetRequiredService<ILogger<MenuEventDispatcher>>(),
-                mute,
-                dictation,
-                llm,
-                dashboard);
+            return new MenuEventDispatcher(mute, dictation, llm, dashboard);
         });
 
         // Recording notification service for dictation status (Phase 1 - issue #670)

--- a/src/VirtualAssistant.Service/Tray/Handlers/DashboardMenuHandler.cs
+++ b/src/VirtualAssistant.Service/Tray/Handlers/DashboardMenuHandler.cs
@@ -11,9 +11,13 @@ public sealed class DashboardMenuHandler : IDashboardMenuHandler
 
     public DashboardMenuHandler(
         ILogger<DashboardMenuHandler> logger,
-        string dashboardBaseUrl)
+        string? dashboardBaseUrl)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        // Nullable on purpose: config wiring in TrayServicesExtensions pulls
+        // the URL from IConfiguration and passes null when no override is
+        // present. Fall back to the in-process default rather than making
+        // every caller hand-roll the same "?? http://localhost:5055".
         _dashboardBaseUrl = dashboardBaseUrl ?? "http://localhost:5055";
     }
 

--- a/src/VirtualAssistant.Service/Tray/MenuEventDispatcher.cs
+++ b/src/VirtualAssistant.Service/Tray/MenuEventDispatcher.cs
@@ -8,25 +8,21 @@ namespace Olbrasoft.VirtualAssistant.Service.Tray;
 /// The dispatcher itself holds no business logic — it only forwards calls so
 /// that <see cref="IMenuEventDispatcher"/> stays a single entry point while
 /// each domain (mute / dictation / LLM / dashboard) can evolve independently.
-/// Constructor dropped from nine parameters to five; per-handler dependencies
-/// stay inside the handler that actually uses them.
+/// Per-handler dependencies stay inside the handler that actually uses them.
 /// </summary>
 public class MenuEventDispatcher : IMenuEventDispatcher
 {
-    private readonly ILogger<MenuEventDispatcher> _logger;
     private readonly IMuteMenuHandler _mute;
     private readonly IDictationMenuHandler _dictation;
     private readonly ILlmMenuHandler _llm;
     private readonly IDashboardMenuHandler _dashboard;
 
     public MenuEventDispatcher(
-        ILogger<MenuEventDispatcher> logger,
         IMuteMenuHandler mute,
         IDictationMenuHandler dictation,
         ILlmMenuHandler llm,
         IDashboardMenuHandler dashboard)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _mute = mute ?? throw new ArgumentNullException(nameof(mute));
         _dictation = dictation ?? throw new ArgumentNullException(nameof(dictation));
         _llm = llm ?? throw new ArgumentNullException(nameof(llm));

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DashboardMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DashboardMenuHandlerTests.cs
@@ -17,7 +17,7 @@ public class DashboardMenuHandlerTests
     {
         // Defensive fallback matches the pre-split behavior of MenuEventDispatcher —
         // some test code used to pass null through and expect "http://localhost:5055".
-        var sut = new DashboardMenuHandler(_loggerMock.Object, null!);
+        var sut = new DashboardMenuHandler(_loggerMock.Object, dashboardBaseUrl: null);
 
         Assert.NotNull(sut);
     }

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/LlmMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/LlmMenuHandlerTests.cs
@@ -65,7 +65,11 @@ public class LlmMenuHandlerTests
     {
         // Legacy deployment path where PromptSync isn't configured yet — the
         // menu click must still flush the LLM cache so the user can see effect.
-        var sut = new LlmMenuHandler(_loggerMock.Object, _llmProviderMock.Object, promptSyncService: null, _stateManagerMock.Object);
+        var sut = new LlmMenuHandler(
+            _loggerMock.Object,
+            _llmProviderMock.Object,
+            promptSyncService: null,
+            menuStateManager: _stateManagerMock.Object);
 
         sut.HandleReloadPrompt();
 
@@ -79,6 +83,18 @@ public class LlmMenuHandlerTests
         var sut = new LlmMenuHandler(_loggerMock.Object);
 
         var ex = Record.Exception(() => sut.HandleReloadCorrectionsCache());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void HandleMercuryBilling_DoesNotThrow()
+    {
+        // The handler shells out to xdg-open which may not exist on CI runners.
+        // The implementation must swallow the subprocess failure, not propagate it.
+        var sut = new LlmMenuHandler(_loggerMock.Object);
+
+        var ex = Record.Exception(() => sut.HandleMercuryBilling());
 
         Assert.Null(ex);
     }

--- a/tests/VirtualAssistant.Service.Tests/Tray/MenuEventDispatcherTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/MenuEventDispatcherTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Logging;
 using Moq;
 using Olbrasoft.VirtualAssistant.Service.Tray;
 using Olbrasoft.VirtualAssistant.Service.Tray.Handlers;
@@ -13,7 +12,6 @@ namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray;
 /// </summary>
 public class MenuEventDispatcherTests
 {
-    private readonly Mock<ILogger<MenuEventDispatcher>> _loggerMock = new();
     private readonly Mock<IMuteMenuHandler> _muteMock = new();
     private readonly Mock<IDictationMenuHandler> _dictationMock = new();
     private readonly Mock<ILlmMenuHandler> _llmMock = new();
@@ -23,7 +21,6 @@ public class MenuEventDispatcherTests
     public MenuEventDispatcherTests()
     {
         _sut = new MenuEventDispatcher(
-            _loggerMock.Object,
             _muteMock.Object,
             _dictationMock.Object,
             _llmMock.Object,
@@ -31,29 +28,24 @@ public class MenuEventDispatcherTests
     }
 
     [Fact]
-    public void Constructor_WithNullLogger_Throws() =>
-        Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
-            null!, _muteMock.Object, _dictationMock.Object, _llmMock.Object, _dashboardMock.Object));
-
-    [Fact]
     public void Constructor_WithNullMute_Throws() =>
         Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
-            _loggerMock.Object, null!, _dictationMock.Object, _llmMock.Object, _dashboardMock.Object));
+            null!, _dictationMock.Object, _llmMock.Object, _dashboardMock.Object));
 
     [Fact]
     public void Constructor_WithNullDictation_Throws() =>
         Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
-            _loggerMock.Object, _muteMock.Object, null!, _llmMock.Object, _dashboardMock.Object));
+            _muteMock.Object, null!, _llmMock.Object, _dashboardMock.Object));
 
     [Fact]
     public void Constructor_WithNullLlm_Throws() =>
         Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
-            _loggerMock.Object, _muteMock.Object, _dictationMock.Object, null!, _dashboardMock.Object));
+            _muteMock.Object, _dictationMock.Object, null!, _dashboardMock.Object));
 
     [Fact]
     public void Constructor_WithNullDashboard_Throws() =>
         Assert.Throws<ArgumentNullException>(() => new MenuEventDispatcher(
-            _loggerMock.Object, _muteMock.Object, _dictationMock.Object, _llmMock.Object, null!));
+            _muteMock.Object, _dictationMock.Object, _llmMock.Object, null!));
 
     [Fact]
     public void HandleMuteToggle_DelegatesToMuteHandler()


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to #1005. Four Copilot findings addressed:

1. **Unused logger on the dispatcher facade** — the facade is pure delegation, logging each forward would be noise. Dropped the logger field, constructor parameter, and the corresponding `Constructor_WithNullLogger_Throws` test.
2. **DashboardMenuHandler dashboardBaseUrl nullability** — implementation falls back to `http://localhost:5055` on null but parameter was typed non-nullable, forcing callers (TrayServicesExtensions, tests) to use `null!`. Changed to `string?` so the contract matches behavior.
3. **LlmMenuHandlerTests positional-after-named argument** — switched to fully named arguments so the call is unambiguous across C# versions.
4. **HandleMercuryBilling had no coverage** — added a `does not throw` test (same shape as HandleDashboard/HandleAbout). The richer reflection-heavy filter test Copilot suggested for HandleReloadCorrectionsCache was out of scope — DatabaseCorrectionFilterStrategy has its own tests.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — Core 86, Service 328, all pass (Voice had one pre-existing flaky AudioPlaybackService timing test unrelated to these changes)
- [ ] CI green