### PR TITLE
fix(tray): address Copilot findings on PR #1007 (unused deps, unused local, missing tests, misleading test name)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
@@ -190,7 +190,10 @@ public static class TrayServicesExtensions
             var logger = sp.GetRequiredService<ILogger<StateNotificationHandler>>();
             var muteService = sp.GetRequiredService<IManualMuteService>();
             var settingsService = sp.GetRequiredService<ISettingsService>();
-            var menuHandler = sp.GetRequiredService<SystemTrayMenuHandler>();
+            // Force-resolve the D-Bus handler so it's registered with D-Bus before
+            // StateNotificationHandler starts publishing updates; the previous
+            // `menuHandler as IServiceStatusUpdater` cast went away with #1007.
+            _ = sp.GetRequiredService<SystemTrayMenuHandler>();
             var iconCoordinator = sp.GetRequiredService<ITrayIconCoordinator>();
             var iconAnimationService = sp.GetRequiredService<IIconAnimationService>();
             var lifecycleManager = sp.GetService<IServiceLifecycleManager>();
@@ -229,9 +232,7 @@ public static class TrayServicesExtensions
                 sp.GetRequiredService<ITrayIconCoordinator>(),
                 sp.GetRequiredService<IMenuEventDispatcher>(),
                 sp.GetRequiredService<IMenuEventForwarder>(),
-                sp.GetRequiredService<IServiceLifecycleManager>(),
-                sp.GetRequiredService<IStateNotificationHandler>(),
-                sp.GetRequiredService<IIconAnimationService>());
+                sp.GetRequiredService<IStateNotificationHandler>());
         });
 
         return services;

--- a/src/VirtualAssistant.Service/Tray/TrayCoordinatorService.cs
+++ b/src/VirtualAssistant.Service/Tray/TrayCoordinatorService.cs
@@ -14,9 +14,7 @@ public class TrayCoordinatorService : IDisposable
     private readonly ITrayIconCoordinator _iconCoordinator;
     private readonly IMenuEventDispatcher _menuDispatcher;
     private readonly IMenuEventForwarder _menuEventForwarder;
-    private readonly IServiceLifecycleManager _lifecycleManager;
     private readonly IStateNotificationHandler _stateHandler;
-    private readonly IIconAnimationService _iconAnimationService;
 
     // Stored handlers for clean unsubscription in Dispose. Inline lambdas
     // would give each += a fresh delegate instance and -= would not remove it.
@@ -44,17 +42,13 @@ public class TrayCoordinatorService : IDisposable
         ITrayIconCoordinator iconCoordinator,
         IMenuEventDispatcher menuDispatcher,
         IMenuEventForwarder menuEventForwarder,
-        IServiceLifecycleManager lifecycleManager,
-        IStateNotificationHandler stateHandler,
-        IIconAnimationService iconAnimationService)
+        IStateNotificationHandler stateHandler)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _iconCoordinator = iconCoordinator ?? throw new ArgumentNullException(nameof(iconCoordinator));
         _menuDispatcher = menuDispatcher ?? throw new ArgumentNullException(nameof(menuDispatcher));
         _menuEventForwarder = menuEventForwarder ?? throw new ArgumentNullException(nameof(menuEventForwarder));
-        _lifecycleManager = lifecycleManager ?? throw new ArgumentNullException(nameof(lifecycleManager));
         _stateHandler = stateHandler ?? throw new ArgumentNullException(nameof(stateHandler));
-        _iconAnimationService = iconAnimationService ?? throw new ArgumentNullException(nameof(iconAnimationService));
 
         _quitHandler = () => OnQuitRequested?.Invoke();
         _muteToggleHandler = () => _menuDispatcher.HandleMuteToggle();

--- a/tests/VirtualAssistant.Service.Tests/Tray/Menu/MenuEventForwarderTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Menu/MenuEventForwarderTests.cs
@@ -1,0 +1,96 @@
+using Moq;
+using Olbrasoft.VirtualAssistant.Service.Tray.Menu;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray.Menu;
+
+/// <summary>
+/// Unit tests for <see cref="MenuEventForwarder"/>. This class is pure event
+/// wiring — it subscribes to <see cref="IMenuEventRouter"/> and re-raises
+/// each event — so the tests pin that subscription happens in the ctor and
+/// events re-emit to the forwarder's own subscribers, and that Dispose
+/// unsubscribes from the router. A regression here would drop menu clicks
+/// silently at runtime.
+/// </summary>
+public class MenuEventForwarderTests
+{
+    private readonly Mock<IMenuEventRouter> _routerMock = new();
+
+    [Fact]
+    public void Constructor_NullRouter_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new MenuEventForwarder(null!));
+
+    [Fact]
+    public void Constructor_SubscribesToAllRouterEvents()
+    {
+        var sut = new MenuEventForwarder(_routerMock.Object);
+
+        _routerMock.VerifyAdd(x => x.OnQuitRequested += It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnMuteToggleRequested += It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnDashboardRequested += It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnAboutRequested += It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnLlmCorrectionToggled += It.IsAny<Action<bool>>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnReloadPromptRequested += It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnDictationToggleRequested += It.IsAny<Action<bool>>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnTtsMuteToggleRequested += It.IsAny<Action<bool>>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnMercuryBillingRequested += It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnStreamingTranscriptionToggled += It.IsAny<Action<bool>>(), Times.Once);
+        _routerMock.VerifyAdd(x => x.OnReloadCorrectionsCacheRequested += It.IsAny<Action>(), Times.Once);
+        GC.KeepAlive(sut);
+    }
+
+    [Fact]
+    public void RouterQuitEvent_ReRaisedOnForwarder()
+    {
+        var sut = new MenuEventForwarder(_routerMock.Object);
+        var raised = 0;
+        sut.OnQuitRequested += () => raised++;
+
+        _routerMock.Raise(x => x.OnQuitRequested += null);
+
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void RouterLlmCorrectionToggled_ReRaisedWithArgument()
+    {
+        var sut = new MenuEventForwarder(_routerMock.Object);
+        bool? received = null;
+        sut.OnLlmCorrectionToggled += enabled => received = enabled;
+
+        _routerMock.Raise(x => x.OnLlmCorrectionToggled += null, true);
+
+        Assert.Equal(true, received);
+    }
+
+    [Fact]
+    public void RouterDictationToggled_ReRaisedWithArgument()
+    {
+        var sut = new MenuEventForwarder(_routerMock.Object);
+        bool? received = null;
+        sut.OnDictationToggleRequested += enabled => received = enabled;
+
+        _routerMock.Raise(x => x.OnDictationToggleRequested += null, false);
+
+        Assert.Equal(false, received);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromAllRouterEvents()
+    {
+        var sut = new MenuEventForwarder(_routerMock.Object);
+
+        sut.Dispose();
+
+        _routerMock.VerifyRemove(x => x.OnQuitRequested -= It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnMuteToggleRequested -= It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnDashboardRequested -= It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnAboutRequested -= It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnLlmCorrectionToggled -= It.IsAny<Action<bool>>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnReloadPromptRequested -= It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnDictationToggleRequested -= It.IsAny<Action<bool>>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnTtsMuteToggleRequested -= It.IsAny<Action<bool>>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnMercuryBillingRequested -= It.IsAny<Action>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnStreamingTranscriptionToggled -= It.IsAny<Action<bool>>(), Times.Once);
+        _routerMock.VerifyRemove(x => x.OnReloadCorrectionsCacheRequested -= It.IsAny<Action>(), Times.Once);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Tray/TrayCoordinatorServiceTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/TrayCoordinatorServiceTests.cs
@@ -7,10 +7,10 @@ using Olbrasoft.VirtualAssistant.Service.Tray.Menu;
 namespace Olbrasoft.VirtualAssistant.Service.Tests.Tray;
 
 /// <summary>
-/// Unit tests for <see cref="TrayCoordinatorService"/>. After the #980
-/// DBusMenuHandler split, the coordinator subscribes to menu-click events
-/// via <see cref="IMenuEventForwarder"/> instead of casting the D-Bus
-/// handler, so the tests reflect that dependency shape.
+/// Unit tests for <see cref="TrayCoordinatorService"/>. After the #1007
+/// cleanup the coordinator only keeps the dependencies it actually uses
+/// (icon coordinator, menu dispatcher, menu event forwarder, state
+/// notification handler).
 /// </summary>
 public class TrayCoordinatorServiceTests
 {
@@ -18,58 +18,37 @@ public class TrayCoordinatorServiceTests
     private readonly Mock<ITrayIconCoordinator> _iconCoordinatorMock = new();
     private readonly Mock<IMenuEventDispatcher> _menuDispatcherMock = new();
     private readonly Mock<IMenuEventForwarder> _menuEventForwarderMock = new();
-    private readonly Mock<IServiceLifecycleManager> _lifecycleManagerMock = new();
     private readonly Mock<IStateNotificationHandler> _stateHandlerMock = new();
-    private readonly Mock<IIconAnimationService> _iconAnimationServiceMock = new();
 
     [Fact]
     public void Constructor_WithNullLogger_Throws() =>
         Assert.Equal("logger", Assert.Throws<ArgumentNullException>(() =>
             new TrayCoordinatorService(null!, _iconCoordinatorMock.Object, _menuDispatcherMock.Object,
-                _menuEventForwarderMock.Object, _lifecycleManagerMock.Object,
-                _stateHandlerMock.Object, _iconAnimationServiceMock.Object)).ParamName);
+                _menuEventForwarderMock.Object, _stateHandlerMock.Object)).ParamName);
 
     [Fact]
     public void Constructor_WithNullIconCoordinator_Throws() =>
         Assert.Equal("iconCoordinator", Assert.Throws<ArgumentNullException>(() =>
             new TrayCoordinatorService(_loggerMock.Object, null!, _menuDispatcherMock.Object,
-                _menuEventForwarderMock.Object, _lifecycleManagerMock.Object,
-                _stateHandlerMock.Object, _iconAnimationServiceMock.Object)).ParamName);
+                _menuEventForwarderMock.Object, _stateHandlerMock.Object)).ParamName);
 
     [Fact]
     public void Constructor_WithNullMenuDispatcher_Throws() =>
         Assert.Equal("menuDispatcher", Assert.Throws<ArgumentNullException>(() =>
             new TrayCoordinatorService(_loggerMock.Object, _iconCoordinatorMock.Object, null!,
-                _menuEventForwarderMock.Object, _lifecycleManagerMock.Object,
-                _stateHandlerMock.Object, _iconAnimationServiceMock.Object)).ParamName);
+                _menuEventForwarderMock.Object, _stateHandlerMock.Object)).ParamName);
 
     [Fact]
     public void Constructor_WithNullMenuEventForwarder_Throws() =>
         Assert.Equal("menuEventForwarder", Assert.Throws<ArgumentNullException>(() =>
             new TrayCoordinatorService(_loggerMock.Object, _iconCoordinatorMock.Object, _menuDispatcherMock.Object,
-                null!, _lifecycleManagerMock.Object,
-                _stateHandlerMock.Object, _iconAnimationServiceMock.Object)).ParamName);
-
-    [Fact]
-    public void Constructor_WithNullLifecycleManager_Throws() =>
-        Assert.Equal("lifecycleManager", Assert.Throws<ArgumentNullException>(() =>
-            new TrayCoordinatorService(_loggerMock.Object, _iconCoordinatorMock.Object, _menuDispatcherMock.Object,
-                _menuEventForwarderMock.Object, null!,
-                _stateHandlerMock.Object, _iconAnimationServiceMock.Object)).ParamName);
+                null!, _stateHandlerMock.Object)).ParamName);
 
     [Fact]
     public void Constructor_WithNullStateHandler_Throws() =>
         Assert.Equal("stateHandler", Assert.Throws<ArgumentNullException>(() =>
             new TrayCoordinatorService(_loggerMock.Object, _iconCoordinatorMock.Object, _menuDispatcherMock.Object,
-                _menuEventForwarderMock.Object, _lifecycleManagerMock.Object,
-                null!, _iconAnimationServiceMock.Object)).ParamName);
-
-    [Fact]
-    public void Constructor_WithNullIconAnimationService_Throws() =>
-        Assert.Equal("iconAnimationService", Assert.Throws<ArgumentNullException>(() =>
-            new TrayCoordinatorService(_loggerMock.Object, _iconCoordinatorMock.Object, _menuDispatcherMock.Object,
-                _menuEventForwarderMock.Object, _lifecycleManagerMock.Object,
-                _stateHandlerMock.Object, null!)).ParamName);
+                _menuEventForwarderMock.Object, null!)).ParamName);
 
     [Fact]
     public async Task InitializeAsync_CallsIconCoordinatorInitialize()
@@ -108,15 +87,11 @@ public class TrayCoordinatorServiceTests
     }
 
     [Fact]
-    public void MuteToggleEvent_ForwardsToDispatcher()
+    public void Dispose_UnsubscribesFromMuteToggleEvent()
     {
-        // Raise the forwarder's event with raw Mock.Raise is fiddly on Action-
-        // typed events; the simplest coverage is to subscribe a handler to the
-        // forwarder mock and verify the coordinator-installed handler runs.
-        // Since Moq doesn't expose event invocation on non-EventHandler types
-        // without a little help, we instead pin the behavior by verifying
-        // wiring happens in the ctor (the private stored handler is attached),
-        // which the Dispose test below confirms with -= verification.
+        // Named for what it asserts — Dispose detaches the coordinator's
+        // MuteToggle handler from the forwarder. (Copilot on #1007 flagged
+        // the previous name as misleading.)
         var coordinator = CreateCoordinator();
         coordinator.Dispose();
 
@@ -138,8 +113,6 @@ public class TrayCoordinatorServiceTests
         var coordinator = CreateCoordinator();
         coordinator.Dispose();
 
-        // Key menu-click events must be detached so the forwarder (and the
-        // router behind it) don't keep the coordinator alive and routed.
         _menuEventForwarderMock.VerifyRemove(x => x.OnQuitRequested -= It.IsAny<Action>(), Times.Once);
         _menuEventForwarderMock.VerifyRemove(x => x.OnReloadPromptRequested -= It.IsAny<Action>(), Times.Once);
         _menuEventForwarderMock.VerifyRemove(x => x.OnReloadCorrectionsCacheRequested -= It.IsAny<Action>(), Times.Once);
@@ -159,7 +132,5 @@ public class TrayCoordinatorServiceTests
         _iconCoordinatorMock.Object,
         _menuDispatcherMock.Object,
         _menuEventForwarderMock.Object,
-        _lifecycleManagerMock.Object,
-        _stateHandlerMock.Object,
-        _iconAnimationServiceMock.Object);
+        _stateHandlerMock.Object);
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to #1007 — four Copilot findings:

1. **Unused `IServiceLifecycleManager` + `IIconAnimationService` on TrayCoordinatorService**. Both were injected and stored but never used. Dropped from constructor, field list, and DI factory.
2. **Unused `menuHandler` local in StateNotificationHandler factory**. The `as IServiceStatusUpdater` cast had gone away but the local stayed. Replaced with `_ = sp.GetRequiredService<SystemTrayMenuHandler>()` so the "force-resolve D-Bus handler before publishing state" side effect stays explicit.
3. **MenuEventForwarder had no direct tests**. Added `MenuEventForwarderTests` with 6 tests: ctor null guard, ctor-subscribes-all-events, router-event re-raise (quit/LLM/dictation), Dispose-unsubscribes-all.
4. **Misleading test name `MuteToggleEvent_ForwardsToDispatcher`** — test actually asserted unsubscription on Dispose. Renamed to `Dispose_UnsubscribesFromMuteToggleEvent`.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 334 Service.Tests (up from 330), all projects green
- [ ] CI green