### PR TITLE
fix(tests): remove three subprocess-spawning tray tests

### DIFF
--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DashboardMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DashboardMenuHandlerTests.cs
@@ -22,28 +22,10 @@ public class DashboardMenuHandlerTests
         Assert.NotNull(sut);
     }
 
-    [Fact]
-    public void HandleDashboard_DoesNotThrow()
-    {
-        // The method spawns xdg-open; we can't meaningfully assert on the
-        // subprocess, but exceptions must be swallowed on CI runners where
-        // xdg-open is absent.
-        var sut = new DashboardMenuHandler(_loggerMock.Object, "http://localhost:5055");
-
-        var ex = Record.Exception(() => sut.HandleDashboard());
-
-        Assert.Null(ex);
-    }
-
-    [Fact]
-    public void HandleAbout_DoesNotThrow()
-    {
-        // Same reasoning as HandleDashboard — zenity may be absent; the
-        // handler must log and return rather than propagate.
-        var sut = new DashboardMenuHandler(_loggerMock.Object, "http://localhost:5055");
-
-        var ex = Record.Exception(() => sut.HandleAbout());
-
-        Assert.Null(ex);
-    }
+    // Deliberately no tests for HandleDashboard / HandleAbout: their only
+    // side effect is spawning xdg-open / zenity, which on the developer
+    // machine actually opens a browser tab and a dialog window. A "does
+    // not throw" assertion is not worth polluting the developer's session.
+    // If the subprocess contract ever needs verification, wrap the process
+    // spawn behind an IProcessLauncher abstraction first.
 }

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/LlmMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/LlmMenuHandlerTests.cs
@@ -87,15 +87,10 @@ public class LlmMenuHandlerTests
         Assert.Null(ex);
     }
 
-    [Fact]
-    public void HandleMercuryBilling_DoesNotThrow()
-    {
-        // The handler shells out to xdg-open which may not exist on CI runners.
-        // The implementation must swallow the subprocess failure, not propagate it.
-        var sut = new LlmMenuHandler(_loggerMock.Object);
-
-        var ex = Record.Exception(() => sut.HandleMercuryBilling());
-
-        Assert.Null(ex);
-    }
+    // Deliberately no test for HandleMercuryBilling: its only side effect
+    // is spawning xdg-open on the billing URL, which on the developer
+    // machine actually opens a browser tab. A "does not throw" assertion
+    // is not worth polluting the developer's session. If the subprocess
+    // contract ever needs verification, wrap the process spawn behind an
+    // IProcessLauncher abstraction first.
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

## Problem
The "does not throw" tests I added for `HandleDashboard`, `HandleAbout`, and `HandleMercuryBilling` in #1005 / #1008 each call the real handler method — which spawns `xdg-open` or `zenity` as subprocesses. Result: every `dotnet test` run on a developer machine pops the About dialog on screen and opens two browser tabs (dashboard + Mercury billing). User reported this happening and asked for those tests to go.

## Fix
Remove the three tests. The implementations already swallow all exceptions as a contract, so the assertions weren't catching regressions of value. Left a comment where each sat, with the path forward (wrap process spawning in an IProcessLauncher abstraction if the contract ever needs to be pinned).

## Test plan
- [x] `dotnet test tests/VirtualAssistant.Service.Tests --filter "~Tray"` — 95 pass, no subprocess spawned
- [ ] CI green