### PR TITLE
docs(tray): align comments with Copilot review on #1008 + #1009

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/TrayServicesExtensions.cs
@@ -190,9 +190,13 @@ public static class TrayServicesExtensions
             var logger = sp.GetRequiredService<ILogger<StateNotificationHandler>>();
             var muteService = sp.GetRequiredService<IManualMuteService>();
             var settingsService = sp.GetRequiredService<ISettingsService>();
-            // Force-resolve the D-Bus handler so it's registered with D-Bus before
-            // StateNotificationHandler starts publishing updates; the previous
-            // `menuHandler as IServiceStatusUpdater` cast went away with #1007.
+            // Force-resolve the D-Bus handler so the singleton is constructed
+            // before StateNotificationHandler starts publishing updates — the
+            // actual D-Bus registration happens later in
+            // VirtualAssistantDBusMenuHandler.RegisterWithDbus(Connection).
+            // The previous `menuHandler as IServiceStatusUpdater` cast went
+            // away with #1007; this discard keeps the construction-order
+            // dependency explicit.
             _ = sp.GetRequiredService<SystemTrayMenuHandler>();
             var iconCoordinator = sp.GetRequiredService<ITrayIconCoordinator>();
             var iconAnimationService = sp.GetRequiredService<IIconAnimationService>();

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DashboardMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/DashboardMenuHandlerTests.cs
@@ -26,6 +26,7 @@ public class DashboardMenuHandlerTests
     // side effect is spawning xdg-open / zenity, which on the developer
     // machine actually opens a browser tab and a dialog window. A "does
     // not throw" assertion is not worth polluting the developer's session.
-    // If the subprocess contract ever needs verification, wrap the process
-    // spawn behind an IProcessLauncher abstraction first.
+    // If the subprocess contract ever needs verification, inject
+    // Olbrasoft.VirtualAssistant.Core.Processes.IProcessExecutor — the
+    // codebase already has that abstraction for exactly this case.
 }

--- a/tests/VirtualAssistant.Service.Tests/Tray/Handlers/LlmMenuHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Tray/Handlers/LlmMenuHandlerTests.cs
@@ -91,6 +91,7 @@ public class LlmMenuHandlerTests
     // is spawning xdg-open on the billing URL, which on the developer
     // machine actually opens a browser tab. A "does not throw" assertion
     // is not worth polluting the developer's session. If the subprocess
-    // contract ever needs verification, wrap the process spawn behind an
-    // IProcessLauncher abstraction first.
+    // contract ever needs verification, inject
+    // Olbrasoft.VirtualAssistant.Core.Processes.IProcessExecutor — the
+    // codebase already has that abstraction for exactly this case.
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Two comment-only nits from Copilot:

1. **Reference existing `IProcessExecutor` abstraction** instead of a hypothetical `IProcessLauncher`. The repo already has `Olbrasoft.VirtualAssistant.Core.Processes.IProcessExecutor` for DI/testing of subprocess handlers.
2. **Fix "registers it with D-Bus" comment on force-resolve line**. Construction and D-Bus registration are separate steps; actual registration happens in `VirtualAssistantDBusMenuHandler.RegisterWithDbus(Connection)`. Reworded to make the difference clear.

No behavioral changes.

## Test plan
- [x] `dotnet build` — 0 errors
- [ ] CI green