### PR TITLE
fix(config): address Copilot findings on PR #1012

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -191,11 +191,21 @@ public static class VoiceServicesExtensions
         });
 
         // Read from "OpenCode:Url" (nested key matching appsettings.json). No
-        // fallback — a missing value surfaces as a clear failure in the
-        // OpenCodeClient constructor rather than silently connecting to
-        // a stale localhost port.
-        var openCodeUrl = configuration["OpenCode:Url"] ?? string.Empty;
-        services.AddSingleton(_ => new OpenCodeClient(openCodeUrl));
+        // hardcoded localhost fallback — a missing value fails fast at startup
+        // with a clear error message naming the config key, rather than
+        // waiting for the first OpenCode call to surface a less actionable
+        // exception from inside the HTTP client. (Copilot review on PR #1012.)
+        services.AddSingleton(sp =>
+        {
+            var openCodeUrl = configuration["OpenCode:Url"];
+            if (string.IsNullOrWhiteSpace(openCodeUrl))
+            {
+                throw new InvalidOperationException(
+                    "OpenCode:Url is not configured. Set it in appsettings.json to the " +
+                    "OpenCode server base URL (e.g. http://localhost:4096).");
+            }
+            return new OpenCodeClient(openCodeUrl);
+        });
         services.AddSingleton<ITextInputService, TextInputService>();
     }
 

--- a/src/VirtualAssistant.Voice/Services/SpeechToTextClient.cs
+++ b/src/VirtualAssistant.Voice/Services/SpeechToTextClient.cs
@@ -13,6 +13,7 @@ public class SpeechToTextClient : ISpeechToTextClient
     private readonly HttpClient _httpClient;
     private readonly ILogger<SpeechToTextClient> _logger;
     private readonly string _statusUrl;
+    private readonly bool _configured;
 
     public SpeechToTextClient(
         HttpClient httpClient,
@@ -21,14 +22,31 @@ public class SpeechToTextClient : ISpeechToTextClient
     {
         _httpClient = httpClient;
         _logger = logger;
-        _statusUrl = $"{settings.Value.BaseUrl.TrimEnd('/')}/api/status";
 
+        var baseUrl = settings.Value.BaseUrl;
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            // #984/#1012: BaseUrl defaults to empty when the config key is
+            // absent. Log the miss once at construction and turn GetStatusAsync
+            // into a clean no-op rather than letting every call throw
+            // InvalidOperationException from HttpClient on a relative URI.
+            _logger.LogWarning(
+                "SpeechToText:BaseUrl is not configured; GetStatusAsync will return null for every call");
+            _statusUrl = string.Empty;
+            _configured = false;
+            return;
+        }
+
+        _statusUrl = $"{baseUrl.TrimEnd('/')}/api/status";
+        _configured = true;
         _logger.LogDebug("SpeechToTextClient initialized with status URL: {Url}", _statusUrl);
     }
 
     /// <inheritdoc />
     public async Task<SpeechToTextStatus?> GetStatusAsync(CancellationToken cancellationToken = default)
     {
+        if (!_configured) return null;
+
         try
         {
             var response = await _httpClient.GetAsync(_statusUrl, cancellationToken);


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to #1012 addressing Copilot's review comments.

## Summary
- SpeechToTextClient: guards empty BaseUrl at construction — logs once and returns null from GetStatusAsync instead of letting HttpClient throw InvalidOperationException on every call
- VoiceServicesExtensions OpenCode registration: fails fast with a clear \"OpenCode:Url is not configured\" error from the DI factory instead of passing empty string to OpenCodeClient

## Test plan
- [x] `dotnet build` 0 errors
- [x] `dotnet test --filter '!~IntegrationTests'` all pass (929 ok, 6 pre-existing skipped)