### PR TITLE
fix(voice): address Copilot findings on PRs #1013 and #1014

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -194,8 +194,9 @@ public static class VoiceServicesExtensions
         // hardcoded localhost fallback — a missing value fails fast at startup
         // with a clear error message naming the config key, rather than
         // waiting for the first OpenCode call to surface a less actionable
-        // exception from inside the HTTP client. (Copilot review on PR #1012.)
-        services.AddSingleton(sp =>
+        // exception from inside the HTTP client. (Copilot reviews on PR #1012
+        // and #1014 — factory doesn't need the service provider.)
+        services.AddSingleton(_ =>
         {
             var openCodeUrl = configuration["OpenCode:Url"];
             if (string.IsNullOrWhiteSpace(openCodeUrl))

--- a/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
+++ b/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
@@ -26,6 +26,13 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     private Dictionary<string, int>? _providerIdCache;
     private readonly object _cacheLock = new();
 
+    // Shared in-flight warmup task. All concurrent WarmupAsync callers latch
+    // onto the same task so "one DB query per process lifetime" is a real
+    // guarantee — previously two concurrent warmups could each issue their
+    // own round-trip even though only one dictionary got published.
+    // (Copilot review on PR #1013.)
+    private Task? _warmupTask;
+
     /// <summary>
     /// Initializes a new instance of <see cref="SpeechTranscriberFactory"/>.
     /// Providers self-declare their <see cref="ISpeechTranscriber.ProviderKey"/> and
@@ -120,8 +127,12 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     public IReadOnlyCollection<string> GetAvailableProviders() => _providersByKey.Keys.ToArray();
 
     /// <summary>
-    /// Gets the database provider ID for tracking.
-    /// Returns from cache - loaded once at startup, no DB query per call.
+    /// Gets the database provider ID for tracking. The provider-ID cache is
+    /// populated once per process: by <see cref="WarmupAsync"/> at startup
+    /// when the warmup hosted service is wired, otherwise by the first
+    /// GetProviderId call via a synchronous cold-start fallback inside
+    /// <c>EnsureProviderIdCacheLoaded</c>. Subsequent calls are an in-memory
+    /// dictionary lookup with no DB access. (Copilot review on PR #1013.)
     /// </summary>
     public int GetProviderId(string providerName)
     {
@@ -158,10 +169,24 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     /// startup, so the hot path (<see cref="GetProviderId"/>) never has to trigger
     /// the synchronous fallback below.
     /// </summary>
-    public async Task WarmupAsync(CancellationToken cancellationToken = default)
+    public Task WarmupAsync(CancellationToken cancellationToken = default)
     {
-        if (Volatile.Read(ref _providerIdCache) != null) return;
+        if (Volatile.Read(ref _providerIdCache) != null) return Task.CompletedTask;
 
+        // Share the in-flight warmup across concurrent callers so we issue
+        // exactly one DB round-trip, even under a race where two hosted
+        // services both trigger warmup. Future cancellations are honoured by
+        // the first caller's token — see LoadAndPublishAsync.
+        lock (_cacheLock)
+        {
+            if (Volatile.Read(ref _providerIdCache) != null) return Task.CompletedTask;
+            _warmupTask ??= LoadAndPublishAsync(cancellationToken);
+            return _warmupTask;
+        }
+    }
+
+    private async Task LoadAndPublishAsync(CancellationToken cancellationToken)
+    {
         var providers = await _queryProcessor
             .ProcessAsync(new GetProvidersByTypeQuery("stt"), cancellationToken)
             .ConfigureAwait(false);


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Consolidated follow-up handling Copilot review comments on #1013 and #1014.

## Summary
- GetProviderId doc rewritten to reflect \"warmup populates cache at startup when available, otherwise first use triggers a single sync load\" (#1013)
- WarmupAsync now shares an in-flight warmup Task across concurrent callers (hard \"one DB query per process\" guarantee) (#1013)
- OpenCode factory lambda: `sp` → `_` (factory doesn't depend on the service provider) (#1014)

## Test plan
- [x] `dotnet build` 0 errors
- [x] `dotnet test --filter '!~IntegrationTests'` all pass