### PR TITLE
fix: address Copilot findings on PRs #1015 and #1016

### DIFF
--- a/src/VirtualAssistant.Core/Events/IEventBus.cs
+++ b/src/VirtualAssistant.Core/Events/IEventBus.cs
@@ -16,8 +16,12 @@ public interface IEventBus
         where TEvent : class;
 
     /// <summary>
-    /// Subscribes a handler to events of type TEvent.
-    /// Handlers are invoked in the order they were registered.
+    /// Subscribes a handler to events of type TEvent. Invocation order across
+    /// multiple handlers is NOT guaranteed — <see cref="PublishAsync"/> runs
+    /// them in parallel via <c>Task.WhenAll</c>, so subscribers must not rely
+    /// on their relative ordering. (Earlier wording claimed registration
+    /// order was preserved; that was never true of the parallel dispatch and
+    /// is removed to match the implementation.)
     /// </summary>
     /// <param name="handler">The handler to invoke when event is published.</param>
     /// <returns>Subscription token for unsubscribing.</returns>

--- a/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
+++ b/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
@@ -26,11 +26,13 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     private Dictionary<string, int>? _providerIdCache;
     private readonly object _cacheLock = new();
 
-    // Shared in-flight warmup task. All concurrent WarmupAsync callers latch
-    // onto the same task so "one DB query per process lifetime" is a real
-    // guarantee — previously two concurrent warmups could each issue their
-    // own round-trip even though only one dictionary got published.
-    // (Copilot review on PR #1013.)
+    // Shared in-flight warmup task. Concurrent WarmupAsync callers latch
+    // onto the same task so only one DB round-trip fires while a warmup is
+    // in flight; EnsureProviderIdCacheLoaded also observes this task so the
+    // sync cold-start path doesn't issue a second query while warmup is
+    // still running. Reset to null when the task completes unsuccessfully
+    // (cancellation or fault) so a later WarmupAsync can retry the load.
+    // (Copilot reviews on PR #1013 and #1016.)
     private Task? _warmupTask;
 
     /// <summary>
@@ -173,46 +175,70 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     {
         if (Volatile.Read(ref _providerIdCache) != null) return Task.CompletedTask;
 
-        // Share the in-flight warmup across concurrent callers so we issue
-        // exactly one DB round-trip, even under a race where two hosted
-        // services both trigger warmup. Future cancellations are honoured by
-        // the first caller's token — see LoadAndPublishAsync.
+        // Share the in-flight warmup across concurrent callers so exactly one
+        // DB round-trip fires while a warmup is running. Per-caller
+        // cancellation is honoured via WaitAsync — the underlying warmup keeps
+        // running so a cancelling caller doesn't abort the shared load for
+        // siblings. (Copilot review on PR #1016.)
+        Task warmup;
         lock (_cacheLock)
         {
             if (Volatile.Read(ref _providerIdCache) != null) return Task.CompletedTask;
-            _warmupTask ??= LoadAndPublishAsync(cancellationToken);
-            return _warmupTask;
+            _warmupTask ??= LoadAndPublishAsync();
+            warmup = _warmupTask;
         }
+
+        return cancellationToken.CanBeCanceled
+            ? warmup.WaitAsync(cancellationToken)
+            : warmup;
     }
 
-    private async Task LoadAndPublishAsync(CancellationToken cancellationToken)
+    private async Task LoadAndPublishAsync()
     {
-        var providers = await _queryProcessor
-            .ProcessAsync(new GetProvidersByTypeQuery("stt"), cancellationToken)
-            .ConfigureAwait(false);
-
-        Dictionary<string, int> published;
-        lock (_cacheLock)
+        try
         {
-            var existing = Volatile.Read(ref _providerIdCache);
-            if (existing != null)
-            {
-                published = existing;
-            }
-            else
-            {
-                published = providers.ToDictionary(
-                    p => p.Name,
-                    p => p.Id,
-                    StringComparer.OrdinalIgnoreCase);
-                Volatile.Write(ref _providerIdCache, published);
-            }
-        }
+            var providers = await _queryProcessor
+                .ProcessAsync(new GetProvidersByTypeQuery("stt"), CancellationToken.None)
+                .ConfigureAwait(false);
 
-        _logger.LogInformation(
-            "Warmed {Count} STT providers from database: {Providers}",
-            published.Count,
-            string.Join(", ", published.Select(p => $"{p.Key}={p.Value}")));
+            Dictionary<string, int> published;
+            lock (_cacheLock)
+            {
+                var existing = Volatile.Read(ref _providerIdCache);
+                if (existing != null)
+                {
+                    published = existing;
+                }
+                else
+                {
+                    published = providers.ToDictionary(
+                        p => p.Name,
+                        p => p.Id,
+                        StringComparer.OrdinalIgnoreCase);
+                    Volatile.Write(ref _providerIdCache, published);
+                }
+            }
+
+            _logger.LogInformation(
+                "Warmed {Count} STT providers from database: {Providers}",
+                published.Count,
+                string.Join(", ", published.Select(p => $"{p.Key}={p.Value}")));
+        }
+        catch
+        {
+            // Reset so a later WarmupAsync or GetProviderId can retry. Without
+            // this a transient DB failure would pin the factory to the sync
+            // cold-start path for the process lifetime. (Copilot review on
+            // PR #1016.)
+            lock (_cacheLock)
+            {
+                if (Volatile.Read(ref _providerIdCache) == null)
+                {
+                    _warmupTask = null;
+                }
+            }
+            throw;
+        }
     }
 
     /// <summary>
@@ -229,6 +255,31 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
     {
         var existing = Volatile.Read(ref _providerIdCache);
         if (existing != null) return existing;
+
+        // If WarmupAsync is in flight, wait for it instead of issuing a
+        // second DB round-trip. Read _warmupTask under the lock (publication
+        // via Volatile doesn't apply to non-null task references assigned
+        // inside the lock) but await outside the lock. (Copilot review on
+        // PR #1016.)
+        Task? warmup;
+        lock (_cacheLock)
+        {
+            warmup = _warmupTask;
+        }
+
+        if (warmup != null)
+        {
+            try
+            {
+                warmup.GetAwaiter().GetResult();
+                existing = Volatile.Read(ref _providerIdCache);
+                if (existing != null) return existing;
+            }
+            catch
+            {
+                // Warmup failed; fall through to the sync cold-start below.
+            }
+        }
 
         lock (_cacheLock)
         {

--- a/tests/VirtualAssistant.Core.Tests/Events/InMemoryEventBusTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Events/InMemoryEventBusTests.cs
@@ -123,21 +123,29 @@ public class InMemoryEventBusTests
     }
 
     [Fact]
-    public void Subscribe_MultipleTimesSameHandler_CreatesMultipleRegistrations()
+    public async Task Subscribe_MultipleTimesSameHandler_DisposingOneKeepsOther()
     {
         // Subscribe returns a per-call IDisposable that removes exactly that
-        // registration. Disposing one should not remove the other, otherwise
-        // the "remove-by-reference" semantics would collapse. This test pins
-        // the per-subscription disposal contract.
+        // registration. Disposing one must not remove the other, otherwise
+        // the "remove-by-reference" semantics would collapse. Copilot on
+        // PR #1015 pointed out the earlier version of this test never
+        // published or asserted — the test would have passed even if Subscribe
+        // deduped handlers or Dispose removed all registrations for the same
+        // delegate. Fixed by publishing after the partial dispose.
         var sut = CreateSut();
-        Func<TestEvent, CancellationToken, Task> handler = (_, _) => Task.CompletedTask;
+        var callCount = 0;
+        Func<TestEvent, CancellationToken, Task> handler = (_, _) =>
+        {
+            Interlocked.Increment(ref callCount);
+            return Task.CompletedTask;
+        };
         var sub1 = sut.Subscribe(handler);
         var sub2 = sut.Subscribe(handler);
 
         sub1.Dispose();
-        sub2.Dispose();
+        await sut.PublishAsync(new TestEvent("x"));
 
-        // No assertion needed — the check is that double-dispose doesn't throw
-        // and that the bus cleans up both registrations cleanly.
+        Assert.Equal(1, callCount);
+        sub2.Dispose();
     }
 }

--- a/tests/VirtualAssistant.Core.Tests/Services/ClaudeDispatchOptionsTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Services/ClaudeDispatchOptionsTests.cs
@@ -33,9 +33,8 @@ public class ClaudeDispatchOptionsTests
     [Fact]
     public void GetExpandedWorkingDirectory_WithRelativePath_ReturnsUnchanged()
     {
-        // Only a leading "~/" is expanded. A bare "~" without slash or any
-        // other relative path is left as-is so the caller can feed it
-        // straight into ProcessStartInfo.WorkingDirectory.
+        // Only a leading "~/" is expanded. Other relative paths are left as-is
+        // so the caller can feed them straight into ProcessStartInfo.
         var options = new ClaudeDispatchOptions { DefaultWorkingDirectory = "foo/bar" };
 
         var expanded = options.GetExpandedWorkingDirectory();
@@ -44,11 +43,27 @@ public class ClaudeDispatchOptionsTests
     }
 
     [Fact]
-    public void Defaults_MatchDocumentedValues()
+    public void GetExpandedWorkingDirectory_WithBareTilde_ReturnsUnchanged()
+    {
+        // A bare "~" without the trailing "/" is NOT expanded. The expansion
+        // rule is explicitly "~/" prefix only — this pins the edge case
+        // Copilot on PR #1015 asked for so a future refactor doesn't silently
+        // start expanding plain "~".
+        var options = new ClaudeDispatchOptions { DefaultWorkingDirectory = "~" };
+
+        var expanded = options.GetExpandedWorkingDirectory();
+
+        Assert.Equal("~", expanded);
+    }
+
+    [Fact]
+    public void Ctor_DefaultValues_MatchDocumentedContract()
     {
         // The default values are contract: ClaudeDispatchService caller sites
         // fall back to them when the options section is missing. Pin so a
-        // silent change surfaces here instead of in a deploy drift.
+        // silent change surfaces here instead of in a deploy drift. Renamed
+        // to Member_Scenario_Expected per the project's naming convention
+        // (Copilot review on PR #1015).
         var options = new ClaudeDispatchOptions();
 
         Assert.Equal(string.Empty, options.NotifyUrl);


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Consolidated follow-up addressing Copilot's review comments on #1015 (core tests) and #1016 (STT factory concurrency).

## Summary

**#1015 — test robustness:**
- InMemoryEventBusTests.Subscribe_MultipleTimes: missing publish/assert added so the test actually pins per-subscription removal
- IEventBus doc: remove the inaccurate \"invoked in registration order\" claim (PublishAsync runs in parallel)
- ClaudeDispatchOptionsTests: added bare-tilde test; renamed `Defaults_MatchDocumentedValues` → `Ctor_DefaultValues_MatchDocumentedContract` for naming consistency

**#1016 — STT factory concurrency:**
- Per-caller cancellation honoured via `WaitAsync(token)`
- Reset `_warmupTask` on fault/cancellation so retries work
- `EnsureProviderIdCacheLoaded` now waits on in-flight warmup instead of issuing its own DB query
- Tightened field comment to stop overclaiming \"one DB query per process lifetime\"

## Test plan
- [x] `dotnet build` 0 errors
- [x] `dotnet test --filter '!~IntegrationTests'` all pass