### PR TITLE
refactor(hub): split DictationHub by domain (#970)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Olbrasoft.VirtualAssistant.Desktop.Extensions;
+using Olbrasoft.VirtualAssistant.Service.Hubs.Services;
 
 namespace Olbrasoft.VirtualAssistant.Service.Extensions;
 
@@ -33,6 +34,13 @@ public static class ServiceCollectionExtensions
 
         // SignalR for Desktop Monitor real-time communication
         services.AddSignalR();
+
+        // Remote Control hub domain services (#970 split — each slice has
+        // ≤5 ctor deps and focuses on one concern so the hub itself stays a
+        // wire-protocol facade).
+        services.AddSingleton<IRemoteRecordingCommands, RemoteRecordingCommands>();
+        services.AddSingleton<IRemoteDesktopCommands, RemoteDesktopCommands>();
+        services.AddSingleton<IRemoteScreenshotCommands, RemoteScreenshotCommands>();
 
         return services;
     }

--- a/src/VirtualAssistant.Service/Hubs/DictationHub.cs
+++ b/src/VirtualAssistant.Service/Hubs/DictationHub.cs
@@ -1,55 +1,34 @@
 using Microsoft.AspNetCore.SignalR;
-using Olbrasoft.Data.Cqrs;
-using Olbrasoft.LinuxDesktop.Core.Services;
-using Olbrasoft.VirtualAssistant.Core.Keyboard;
-using Olbrasoft.VirtualAssistant.Core.Services;
-using Olbrasoft.VirtualAssistant.Core.StateMachine;
-using Olbrasoft.VirtualAssistant.Core.WindowManagement;
-using Olbrasoft.VirtualAssistant.Data.Queries.PromptQueries;
-using IDesktopContextService = Olbrasoft.VirtualAssistant.Core.Services.IDesktopContextService;
+using Olbrasoft.VirtualAssistant.Service.Hubs.Services;
 
 namespace Olbrasoft.VirtualAssistant.Service.Hubs;
 
 /// <summary>
-/// SignalR hub for remote dictation control from mobile devices.
+/// SignalR hub for remote dictation control from mobile devices. After the
+/// #970 split this class is a thin wire-protocol facade — the three
+/// underlying domains (recording/keyboard, desktop/workspace, screenshots)
+/// live behind their own focused command services in
+/// <c>Hubs/Services/</c>. Method names are preserved verbatim so the
+/// Remote Control JavaScript client and unit tests keep working without
+/// any client-side changes.
 /// </summary>
 public class DictationHub : Hub
 {
-    private static readonly HashSet<string> AllowedApps = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "discord", "ferdium"
-    };
-
-    private readonly IDictationService _dictationService;
-    private readonly IKeyboardSimulationService _keyboardSimulation;
-    private readonly IWindowQueryService _windowQuery;
-    private readonly IWindowActionService _windowAction;
-    private readonly IDesktopContextService _desktopContext;
-    private readonly ICliAppDetector _cliAppDetector;
-    private readonly ITerminalDetector _terminalDetector;
-    private readonly IQueryProcessor _queryProcessor;
+    private readonly IRemoteRecordingCommands _recording;
+    private readonly IRemoteDesktopCommands _desktop;
+    private readonly IRemoteScreenshotCommands _screenshot;
     private readonly ILogger<DictationHub> _logger;
 
     public DictationHub(
-        IDictationService dictationService,
-        IKeyboardSimulationService keyboardSimulation,
-        IWindowQueryService windowQuery,
-        IWindowActionService windowAction,
-        IDesktopContextService desktopContext,
-        ICliAppDetector cliAppDetector,
-        ITerminalDetector terminalDetector,
-        IQueryProcessor queryProcessor,
+        IRemoteRecordingCommands recording,
+        IRemoteDesktopCommands desktop,
+        IRemoteScreenshotCommands screenshot,
         ILogger<DictationHub> logger)
     {
-        _dictationService = dictationService;
-        _keyboardSimulation = keyboardSimulation;
-        _windowQuery = windowQuery;
-        _windowAction = windowAction;
-        _desktopContext = desktopContext;
-        _cliAppDetector = cliAppDetector;
-        _terminalDetector = terminalDetector;
-        _queryProcessor = queryProcessor;
-        _logger = logger;
+        _recording = recording ?? throw new ArgumentNullException(nameof(recording));
+        _desktop = desktop ?? throw new ArgumentNullException(nameof(desktop));
+        _screenshot = screenshot ?? throw new ArgumentNullException(nameof(screenshot));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public override async Task OnConnectedAsync()
@@ -58,491 +37,49 @@ public class DictationHub : Hub
         await base.OnConnectedAsync();
     }
 
-    /// <summary>
-    /// Gets the WM class of the currently focused window.
-    /// </summary>
-    public async Task<string> GetFocusedApp()
-    {
-        var context = await _desktopContext.GetCurrentContextAsync();
-        return context.ActiveWindowClass ?? "";
-    }
+    // --- Desktop / window domain -------------------------------------------
 
-    /// <summary>
-    /// Closes the focused window if it matches the given WM class (sends Alt+F4).
-    /// </summary>
-    public async Task<bool> CloseApp(string wmClass)
-    {
-        wmClass = wmClass?.Trim() ?? "";
-        if (wmClass.Length == 0 || !AllowedApps.Contains(wmClass))
-        {
-            _logger.LogWarning("CloseApp rejected: '{WmClass}' is not in allowlist", wmClass);
-            return false;
-        }
+    public Task<string> GetFocusedApp() => _desktop.GetFocusedAppAsync();
 
-        try
-        {
-            // Verify the focused window matches the requested app
-            var context = await _desktopContext.GetCurrentContextAsync();
-            if (!string.Equals(context.ActiveWindowClass, wmClass, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning("CloseApp '{WmClass}' rejected: focused window is '{Focused}'",
-                    wmClass, context.ActiveWindowClass);
-                return false;
-            }
+    public Task<bool> CloseApp(string wmClass) => _desktop.CloseAppAsync(wmClass);
 
-            _logger.LogInformation("CloseApp '{WmClass}' from client {ConnectionId}", wmClass, Context.ConnectionId);
-            await _keyboardSimulation.SendKeyAsync("alt+F4");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "CloseApp '{WmClass}' failed", wmClass);
-            return false;
-        }
-    }
+    public Task<WorkspaceInfo> GetWorkspaceInfo() => _desktop.GetWorkspaceInfoAsync();
 
-    /// <summary>
-    /// Gets the current dictation status.
-    /// </summary>
-    public Task<StatusResponse> GetStatus()
-    {
-        return Task.FromResult(new StatusResponse
-        {
-            IsRecording = _dictationService.State == DictationState.Recording,
-            IsTranscribing = _dictationService.State == DictationState.Transcribing
-        });
-    }
+    public Task SwitchWorkspace(int workspaceNumber) => _desktop.SwitchWorkspaceAsync(workspaceNumber);
 
-    /// <summary>
-    /// Toggles dictation state (idle -> recording, recording -> transcribing).
-    /// </summary>
-    public async Task ToggleRecording()
-    {
-        if (_dictationService.State == DictationState.Idle)
-        {
-            try { await _dictationService.StartDictationAsync(); }
-            catch (Exception ex) { _logger.LogError(ex, "StartDictation failed"); }
-        }
-        else if (_dictationService.State == DictationState.Recording)
-        {
-            try { await _dictationService.StopDictationAsync(); }
-            catch (Exception ex) { _logger.LogError(ex, "StopDictation failed"); }
-        }
-    }
+    public Task<bool> ActivateApp(string wmClass) => _desktop.ActivateAppAsync(wmClass);
 
-    /// <summary>
-    /// Toggles quick dictation (idle -> recording, recording -> raw STT + auto-paste + auto-Enter).
-    /// </summary>
-    public async Task ToggleQuickRecording()
-    {
-        if (_dictationService.State == DictationState.Idle)
-        {
-            try { await _dictationService.StartQuickDictationAsync(); }
-            catch (Exception ex) { _logger.LogError(ex, "StartQuickDictation failed"); }
-        }
-        else if (_dictationService.State == DictationState.Recording)
-        {
-            try { await _dictationService.StopDictationAsync(); }
-            catch (Exception ex) { _logger.LogError(ex, "StopDictation (quick) failed"); }
-        }
-    }
+    // --- Recording / keyboard / clipboard domain ---------------------------
 
-    /// <summary>
-    /// Starts dictation in normal (LLM-corrected) mode. Used by the Remote
-    /// Control unified dictation button — start with this, then call
-    /// StopDictationWithMode(quick) when the user releases the button.
-    /// </summary>
-    public async Task StartDictation()
-    {
-        if (_dictationService.State == DictationState.Idle)
-        {
-            try { await _dictationService.StartDictationAsync(); }
-            catch (Exception ex) { _logger.LogError(ex, "StartDictation failed"); }
-        }
-    }
+    public Task<StatusResponse> GetStatus() => _recording.GetStatusAsync();
 
-    /// <summary>
-    /// Stops dictation, overriding the mode that was chosen at start time.
-    /// Used by the Remote Control unified dictation button: the client
-    /// passes <c>quick=true</c> if the user released on the fast zone, or
-    /// <c>quick=false</c> for the LLM-corrected pipeline.
-    /// </summary>
-    public async Task StopDictationWithMode(bool quick)
-    {
-        if (_dictationService.State == DictationState.Recording)
-        {
-            try { await _dictationService.StopDictationAsync(quick); }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "StopDictationWithMode(quick={Quick}) failed", quick);
-            }
-        }
-    }
+    public Task ToggleRecording() => _recording.ToggleRecordingAsync();
 
-    /// <summary>
-    /// Cancels ongoing transcription.
-    /// </summary>
-    public Task CancelTranscription()
-    {
-        _logger.LogInformation("CancelTranscription called from client {ConnectionId}", Context.ConnectionId);
-        _dictationService.CancelTranscription();
-        return Task.CompletedTask;
-    }
+    public Task ToggleQuickRecording() => _recording.ToggleQuickRecordingAsync();
 
-    /// <summary>
-    /// Sends Enter key press to active window.
-    /// </summary>
-    public async Task PressEnter()
-    {
-        _logger.LogInformation("PressEnter called from client {ConnectionId}", Context.ConnectionId);
-        try { await _keyboardSimulation.SendKeyAsync("enter"); }
-        catch (Exception ex) { _logger.LogError(ex, "PressEnter failed"); }
-    }
+    public Task StartDictation() => _recording.StartDictationAsync();
 
-    /// <summary>
-    /// Types the word "Pokračuj" into the active window and presses Enter.
-    /// Used by the Remote Control "Pokračuj" button when Claude Code is the active CLI app.
-    /// Guarded server-side: the UI toggle on the client is best-effort (focus
-    /// can change between CliAppChanged broadcasts and the button press), so
-    /// we re-validate that the currently focused CLI app is Claude Code before
-    /// typing. If not, we no-op and return false to avoid sending "Pokračuj"
-    /// into an unrelated window.
-    /// </summary>
-    public async Task<bool> SendContinue()
-    {
-        _logger.LogInformation("SendContinue called from client {ConnectionId}", Context.ConnectionId);
-        try
-        {
-            var activeApp = await GetActiveCliApp();
-            if (!string.Equals(activeApp, "Claude Code", StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning("SendContinue rejected: active CLI app is '{App}', not Claude Code", activeApp);
-                return false;
-            }
+    public Task StopDictationWithMode(bool quick) => _recording.StopDictationWithModeAsync(quick);
 
-            await _keyboardSimulation.TypeIntoActiveWindowAsync("Pokračuj");
-            await _keyboardSimulation.SendKeyAsync("enter");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "SendContinue failed");
-            return false;
-        }
-    }
+    public Task CancelTranscription() => _recording.CancelTranscriptionAsync();
 
-    /// <summary>
-    /// Returns the name of the CLI app currently detected as the focused
-    /// application (e.g., "Claude Code", "OpenCode", "Gemini CLI"), or empty
-    /// string if none. Used by the Remote Control on initial connection to
-    /// set the initial state of agent-specific buttons (e.g., Pokračuj).
-    ///
-    /// Matches the same detection flow as DesktopMonitorBroadcastWorker:
-    /// first the process-tree-based CLI detector, then title/application
-    /// pattern matching — the latter works even when the CLI detector can't
-    /// see the process (e.g., claude running under tmux).
-    /// </summary>
-    public async Task<string> GetActiveCliApp()
-    {
-        try
-        {
-            var cliApp = await _cliAppDetector.DetectCliAppAsync();
-            if (cliApp != null)
-                return cliApp.AppName;
+    public Task PressEnter() => _recording.PressEnterAsync();
 
-            var context = await _desktopContext.GetCurrentContextAsync();
-            var prompt = await _queryProcessor.ProcessAsync(
-                new GetPromptByAppIdPatternQuery(context.ActiveWindowTitle, context.ActiveApplication),
-                CancellationToken.None);
-            return prompt?.ApplicationName ?? "";
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "GetActiveCliApp failed");
-            return "";
-        }
-    }
+    public Task<bool> SendContinue() => _recording.SendContinueAsync();
 
-    /// <summary>
-    /// Pastes from the system clipboard using the correct shortcut for the active window.
-    /// Delegates to IKeyboardSimulationService.PasteFromClipboardAsync which centrally
-    /// handles terminal (Ctrl+Shift+V) vs GUI (Ctrl+V) detection.
-    /// </summary>
-    public async Task PasteFromClipboard()
-    {
-        _logger.LogInformation("PasteFromClipboard called from client {ConnectionId}", Context.ConnectionId);
-        try { await _keyboardSimulation.PasteFromClipboardAsync(); }
-        catch (Exception ex) { _logger.LogError(ex, "PasteFromClipboard failed"); }
-    }
+    public Task<string> GetActiveCliApp() => _recording.GetActiveCliAppAsync();
 
-    private static string ScreenshotDir => Workers.ScreenshotWatcherWorker.ScreenshotDir;
+    public Task PasteFromClipboard() => _recording.PasteFromClipboardAsync();
 
-    private const string InsertScreenshotScript = "/home/jirka/.local/bin/insert-screenshot-path";
+    public Task<bool> PasteTranscription(string text) => _recording.PasteTranscriptionAsync(text);
 
-    /// <summary>
-    /// Checks if a recent screenshot (&lt;5 min) exists in the screenshot directory.
-    /// </summary>
-    public Task<bool> IsScreenshotAvailable()
-    {
-        try
-        {
-            if (!Directory.Exists(ScreenshotDir)) return Task.FromResult(false);
+    public Task ClearText() => _recording.ClearTextAsync();
 
-            var cutoff = DateTime.Now - Workers.ScreenshotWatcherWorker.FreshnessWindow;
-            var hasRecent = Directory.EnumerateFiles(ScreenshotDir, "*.png")
-                .Select(f => new FileInfo(f))
-                .Any(fi => fi.LastWriteTime > cutoff);
+    // --- Screenshot domain -------------------------------------------------
 
-            return Task.FromResult(hasRecent);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "IsScreenshotAvailable check failed");
-            return Task.FromResult(false);
-        }
-    }
+    public Task<bool> IsScreenshotAvailable() => _screenshot.IsScreenshotAvailableAsync();
 
-    /// <summary>
-    /// Runs the insert-screenshot-path script which finds the most recent screenshot,
-    /// puts its path in the clipboard, and simulates Ctrl+Shift+V to paste into terminal.
-    /// </summary>
-    public async Task InsertScreenshotPath()
-    {
-        _logger.LogInformation("InsertScreenshotPath called from client {ConnectionId}", Context.ConnectionId);
-        try
-        {
-            using var process = new System.Diagnostics.Process
-            {
-                StartInfo = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = "/bin/bash",
-                    Arguments = InsertScreenshotScript,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-            process.Start();
-
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            await process.WaitForExitAsync(timeoutCts.Token);
-
-            if (process.ExitCode != 0)
-            {
-                var stderr = await process.StandardError.ReadToEndAsync();
-                _logger.LogWarning("InsertScreenshotPath exit code {ExitCode}: {Stderr}", process.ExitCode, stderr);
-            }
-            else
-            {
-                _logger.LogInformation("InsertScreenshotPath completed successfully");
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            _logger.LogError("InsertScreenshotPath timed out after 5s");
-        }
-        catch (Exception ex) { _logger.LogError(ex, "InsertScreenshotPath failed"); }
-    }
-
-    /// <summary>
-    /// Pastes the given text at the current cursor position using clipboard + paste simulation.
-    /// </summary>
-    public async Task<bool> PasteTranscription(string text)
-    {
-        const int maxPasteLength = 10000;
-
-        if (string.IsNullOrWhiteSpace(text))
-        {
-            _logger.LogWarning("PasteTranscription: empty text, ignoring");
-            return false;
-        }
-
-        if (text.Length > maxPasteLength)
-        {
-            _logger.LogWarning("PasteTranscription rejected: text length {Length} exceeds max {Max}", text.Length, maxPasteLength);
-            return false;
-        }
-
-        _logger.LogInformation("PasteTranscription from client {ConnectionId}: {Length} chars", Context.ConnectionId, text.Length);
-        try
-        {
-            await _keyboardSimulation.TypeIntoActiveWindowAsync(text);
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "PasteTranscription failed");
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Context-aware text clearing: CLI apps get End×10 + Ctrl+U×10,
-    /// GUI apps get Ctrl+A + Delete, regular terminal gets Ctrl+U.
-    /// </summary>
-    public async Task ClearText()
-    {
-        _logger.LogInformation("ClearText called from client {ConnectionId}", Context.ConnectionId);
-        try
-        {
-            var cliApp = await _cliAppDetector.DetectCliAppAsync();
-            if (cliApp != null)
-            {
-                _logger.LogInformation("ClearText: CLI app '{App}' detected, sending End×10 + Ctrl+U×10", cliApp.AppName);
-                var keys = new List<string>();
-                for (var i = 0; i < 10; i++) keys.Add("end");
-                for (var i = 0; i < 10; i++) keys.Add("ctrl+u");
-                await _keyboardSimulation.SendKeySequenceAsync(keys);
-                return;
-            }
-
-            var isTerminal = await _terminalDetector.IsTerminalActiveAsync();
-            if (isTerminal)
-            {
-                _logger.LogInformation("ClearText: regular terminal, sending Ctrl+U");
-                await _keyboardSimulation.SendKeyAsync("ctrl+u");
-                return;
-            }
-
-            _logger.LogInformation("ClearText: GUI app, sending Ctrl+A + Delete");
-            await _keyboardSimulation.SendKeySequenceAsync(["ctrl+a", "delete"]);
-        }
-        catch (Exception ex) { _logger.LogError(ex, "ClearText failed"); }
-    }
-
-    private static readonly HashSet<int> AllowedWorkspaces = [1, 2, 3, 4, 5, 6, 7, 8];
-
-    /// <summary>
-    /// Gets current workspace info (1-indexed workspace number and total count).
-    /// </summary>
-    public async Task<WorkspaceInfo> GetWorkspaceInfo()
-    {
-        var context = await _desktopContext.GetCurrentContextAsync();
-        return new WorkspaceInfo
-        {
-            CurrentWorkspace = context.CurrentWorkspace + 1,
-            TotalWorkspaces = context.TotalWorkspaces
-        };
-    }
-
-    /// <summary>
-    /// Switches to the specified workspace by simulating Super+KP_N (numpad) key press.
-    /// Does not return success/failure — clients should rely on WorkspaceChanged SignalR event.
-    /// </summary>
-    public async Task SwitchWorkspace(int workspaceNumber)
-    {
-        if (!AllowedWorkspaces.Contains(workspaceNumber))
-        {
-            _logger.LogWarning("SwitchWorkspace rejected: workspace {Number} is not allowed", workspaceNumber);
-            return;
-        }
-
-        var context = await _desktopContext.GetCurrentContextAsync();
-        if (workspaceNumber > context.TotalWorkspaces)
-        {
-            _logger.LogWarning("SwitchWorkspace rejected: workspace {Number} exceeds total {Total}",
-                workspaceNumber, context.TotalWorkspaces);
-            return;
-        }
-
-        _logger.LogInformation("SwitchWorkspace {Number} from client {ConnectionId}", workspaceNumber, Context.ConnectionId);
-        try { await _keyboardSimulation.SendKeyAsync($"super+kp{workspaceNumber}"); }
-        catch (Exception ex) { _logger.LogError(ex, "SwitchWorkspace {Number} failed", workspaceNumber); }
-    }
-
-    private static readonly Dictionary<string, string> AppDesktopFiles = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["discord"] = "com.discordapp.Discord",
-        ["ferdium"] = "org.ferdium.Ferdium"
-    };
-
-    private const string MoveWindowRightScript = "/home/jirka/.local/bin/move-window-right.sh";
-
-    /// <summary>
-    /// Activates a desktop application window by WM class name and snaps it to the right half.
-    /// First tries D-Bus window activation, falls back to gtk-launch for tray-only apps.
-    /// </summary>
-    public async Task<bool> ActivateApp(string wmClass)
-    {
-        wmClass = wmClass?.Trim() ?? "";
-        if (wmClass.Length == 0 || !AllowedApps.Contains(wmClass))
-        {
-            _logger.LogWarning("ActivateApp rejected: '{WmClass}' is not in allowlist", wmClass);
-            return false;
-        }
-
-        try
-        {
-            _logger.LogInformation("ActivateApp '{WmClass}' from client {ConnectionId}", wmClass, Context.ConnectionId);
-
-            // Try D-Bus window activation first (for already-visible windows)
-            var windows = await _windowQuery.GetWindowsAsync();
-            var window = windows.FirstOrDefault(w =>
-                string.Equals(w.WmClass, wmClass, StringComparison.OrdinalIgnoreCase));
-
-            if (window != null)
-            {
-                await _windowAction.ActivateWindowAsync(window.Id);
-                _logger.LogInformation("Activated existing window '{Title}' (ID: {Id})", window.Title, window.Id);
-                await SnapFocusedWindowRightAsync();
-                return true;
-            }
-
-            // Window not found — app is likely minimized to tray, use gtk-launch
-            if (AppDesktopFiles.TryGetValue(wmClass, out var desktopFile))
-            {
-                _logger.LogInformation("No window found, launching via gtk-launch {DesktopFile}", desktopFile);
-                using var process = new System.Diagnostics.Process
-                {
-                    StartInfo = new System.Diagnostics.ProcessStartInfo
-                    {
-                        FileName = "gtk-launch",
-                        Arguments = desktopFile,
-                        UseShellExecute = false,
-                        CreateNoWindow = true
-                    }
-                };
-                process.Start();
-
-                // Wait for window to appear, then snap right
-                await Task.Delay(1500);
-                await SnapFocusedWindowRightAsync();
-                return true;
-            }
-
-            _logger.LogWarning("No window and no desktop file for '{WmClass}'", wmClass);
-            return false;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "ActivateApp '{WmClass}' failed", wmClass);
-            return false;
-        }
-    }
-
-    private async Task SnapFocusedWindowRightAsync()
-    {
-        try
-        {
-            using var process = new System.Diagnostics.Process
-            {
-                StartInfo = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = "/bin/bash",
-                    Arguments = MoveWindowRightScript,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-            process.Start();
-            await process.WaitForExitAsync();
-            _logger.LogInformation("Snapped focused window to right half");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to snap window to right half");
-        }
-    }
+    public Task InsertScreenshotPath() => _screenshot.InsertScreenshotPathAsync();
 }
 
 /// <summary>

--- a/src/VirtualAssistant.Service/Hubs/Services/IRemoteDesktopCommands.cs
+++ b/src/VirtualAssistant.Service/Hubs/Services/IRemoteDesktopCommands.cs
@@ -1,0 +1,18 @@
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+
+namespace Olbrasoft.VirtualAssistant.Service.Hubs.Services;
+
+/// <summary>
+/// Window / workspace / app-launch slice of the Remote Control hub (#970
+/// split). All desktop-level operations that don't involve the dictation
+/// flow live here — focused domain for D-Bus window calls and launcher
+/// fallbacks.
+/// </summary>
+public interface IRemoteDesktopCommands
+{
+    Task<string> GetFocusedAppAsync();
+    Task<bool> CloseAppAsync(string wmClass);
+    Task<WorkspaceInfo> GetWorkspaceInfoAsync();
+    Task SwitchWorkspaceAsync(int workspaceNumber);
+    Task<bool> ActivateAppAsync(string wmClass);
+}

--- a/src/VirtualAssistant.Service/Hubs/Services/IRemoteRecordingCommands.cs
+++ b/src/VirtualAssistant.Service/Hubs/Services/IRemoteRecordingCommands.cs
@@ -1,0 +1,24 @@
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+
+namespace Olbrasoft.VirtualAssistant.Service.Hubs.Services;
+
+/// <summary>
+/// Dictation / keyboard / clipboard slice of the Remote Control hub (#970
+/// split). Focused on the transcription flow and the keyboard helpers used
+/// while typing — no desktop-window, workspace, or screenshot concerns.
+/// </summary>
+public interface IRemoteRecordingCommands
+{
+    Task<StatusResponse> GetStatusAsync();
+    Task ToggleRecordingAsync();
+    Task ToggleQuickRecordingAsync();
+    Task StartDictationAsync();
+    Task StopDictationWithModeAsync(bool quick);
+    Task CancelTranscriptionAsync();
+    Task PressEnterAsync();
+    Task<bool> SendContinueAsync();
+    Task<string> GetActiveCliAppAsync();
+    Task PasteFromClipboardAsync();
+    Task<bool> PasteTranscriptionAsync(string text);
+    Task ClearTextAsync();
+}

--- a/src/VirtualAssistant.Service/Hubs/Services/IRemoteScreenshotCommands.cs
+++ b/src/VirtualAssistant.Service/Hubs/Services/IRemoteScreenshotCommands.cs
@@ -1,0 +1,12 @@
+namespace Olbrasoft.VirtualAssistant.Service.Hubs.Services;
+
+/// <summary>
+/// Screenshot slice of the Remote Control hub (#970 split). Isolates the
+/// filesystem-watch and external-script dispatch from the rest of the hub
+/// so it can be unit-tested without SignalR plumbing.
+/// </summary>
+public interface IRemoteScreenshotCommands
+{
+    Task<bool> IsScreenshotAvailableAsync();
+    Task InsertScreenshotPathAsync();
+}

--- a/src/VirtualAssistant.Service/Hubs/Services/RemoteDesktopCommands.cs
+++ b/src/VirtualAssistant.Service/Hubs/Services/RemoteDesktopCommands.cs
@@ -1,0 +1,193 @@
+using System.Diagnostics;
+using Olbrasoft.LinuxDesktop.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.Keyboard;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+using IDesktopContextService = Olbrasoft.VirtualAssistant.Core.Services.IDesktopContextService;
+
+namespace Olbrasoft.VirtualAssistant.Service.Hubs.Services;
+
+/// <inheritdoc />
+public class RemoteDesktopCommands : IRemoteDesktopCommands
+{
+    private static readonly HashSet<string> AllowedApps = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "discord", "ferdium"
+    };
+
+    private static readonly Dictionary<string, string> AppDesktopFiles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["discord"] = "com.discordapp.Discord",
+        ["ferdium"] = "org.ferdium.Ferdium"
+    };
+
+    private static readonly HashSet<int> AllowedWorkspaces = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    private const string MoveWindowRightScript = "/home/jirka/.local/bin/move-window-right.sh";
+
+    private readonly ILogger<RemoteDesktopCommands> _logger;
+    private readonly IDesktopContextService _desktopContext;
+    private readonly IWindowQueryService _windowQuery;
+    private readonly IWindowActionService _windowAction;
+    private readonly IKeyboardSimulationService _keyboardSimulation;
+
+    public RemoteDesktopCommands(
+        ILogger<RemoteDesktopCommands> logger,
+        IDesktopContextService desktopContext,
+        IWindowQueryService windowQuery,
+        IWindowActionService windowAction,
+        IKeyboardSimulationService keyboardSimulation)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _desktopContext = desktopContext ?? throw new ArgumentNullException(nameof(desktopContext));
+        _windowQuery = windowQuery ?? throw new ArgumentNullException(nameof(windowQuery));
+        _windowAction = windowAction ?? throw new ArgumentNullException(nameof(windowAction));
+        _keyboardSimulation = keyboardSimulation ?? throw new ArgumentNullException(nameof(keyboardSimulation));
+    }
+
+    public async Task<string> GetFocusedAppAsync()
+    {
+        var context = await _desktopContext.GetCurrentContextAsync();
+        return context.ActiveWindowClass ?? "";
+    }
+
+    public async Task<bool> CloseAppAsync(string wmClass)
+    {
+        wmClass = wmClass?.Trim() ?? "";
+        if (wmClass.Length == 0 || !AllowedApps.Contains(wmClass))
+        {
+            _logger.LogWarning("CloseApp rejected: '{WmClass}' is not in allowlist", wmClass);
+            return false;
+        }
+
+        try
+        {
+            var context = await _desktopContext.GetCurrentContextAsync();
+            if (!string.Equals(context.ActiveWindowClass, wmClass, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("CloseApp '{WmClass}' rejected: focused window is '{Focused}'",
+                    wmClass, context.ActiveWindowClass);
+                return false;
+            }
+
+            _logger.LogInformation("CloseApp '{WmClass}'", wmClass);
+            await _keyboardSimulation.SendKeyAsync("alt+F4");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "CloseApp '{WmClass}' failed", wmClass);
+            return false;
+        }
+    }
+
+    public async Task<WorkspaceInfo> GetWorkspaceInfoAsync()
+    {
+        var context = await _desktopContext.GetCurrentContextAsync();
+        return new WorkspaceInfo
+        {
+            CurrentWorkspace = context.CurrentWorkspace + 1,
+            TotalWorkspaces = context.TotalWorkspaces
+        };
+    }
+
+    public async Task SwitchWorkspaceAsync(int workspaceNumber)
+    {
+        if (!AllowedWorkspaces.Contains(workspaceNumber))
+        {
+            _logger.LogWarning("SwitchWorkspace rejected: workspace {Number} is not allowed", workspaceNumber);
+            return;
+        }
+
+        var context = await _desktopContext.GetCurrentContextAsync();
+        if (workspaceNumber > context.TotalWorkspaces)
+        {
+            _logger.LogWarning("SwitchWorkspace rejected: workspace {Number} exceeds total {Total}",
+                workspaceNumber, context.TotalWorkspaces);
+            return;
+        }
+
+        _logger.LogInformation("SwitchWorkspace {Number}", workspaceNumber);
+        try { await _keyboardSimulation.SendKeyAsync($"super+kp{workspaceNumber}"); }
+        catch (Exception ex) { _logger.LogError(ex, "SwitchWorkspace {Number} failed", workspaceNumber); }
+    }
+
+    public async Task<bool> ActivateAppAsync(string wmClass)
+    {
+        wmClass = wmClass?.Trim() ?? "";
+        if (wmClass.Length == 0 || !AllowedApps.Contains(wmClass))
+        {
+            _logger.LogWarning("ActivateApp rejected: '{WmClass}' is not in allowlist", wmClass);
+            return false;
+        }
+
+        try
+        {
+            _logger.LogInformation("ActivateApp '{WmClass}'", wmClass);
+
+            var windows = await _windowQuery.GetWindowsAsync();
+            var window = windows.FirstOrDefault(w =>
+                string.Equals(w.WmClass, wmClass, StringComparison.OrdinalIgnoreCase));
+
+            if (window != null)
+            {
+                await _windowAction.ActivateWindowAsync(window.Id);
+                _logger.LogInformation("Activated existing window '{Title}' (ID: {Id})", window.Title, window.Id);
+                await SnapFocusedWindowRightAsync();
+                return true;
+            }
+
+            if (AppDesktopFiles.TryGetValue(wmClass, out var desktopFile))
+            {
+                _logger.LogInformation("No window found, launching via gtk-launch {DesktopFile}", desktopFile);
+                using var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "gtk-launch",
+                        Arguments = desktopFile,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+                process.Start();
+
+                await Task.Delay(1500);
+                await SnapFocusedWindowRightAsync();
+                return true;
+            }
+
+            _logger.LogWarning("No window and no desktop file for '{WmClass}'", wmClass);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "ActivateApp '{WmClass}' failed", wmClass);
+            return false;
+        }
+    }
+
+    private async Task SnapFocusedWindowRightAsync()
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/bin/bash",
+                    Arguments = MoveWindowRightScript,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            await process.WaitForExitAsync();
+            _logger.LogInformation("Snapped focused window to right half");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to snap window to right half");
+        }
+    }
+}

--- a/src/VirtualAssistant.Service/Hubs/Services/RemoteRecordingCommands.cs
+++ b/src/VirtualAssistant.Service/Hubs/Services/RemoteRecordingCommands.cs
@@ -1,0 +1,220 @@
+using Olbrasoft.Data.Cqrs;
+using Olbrasoft.VirtualAssistant.Core.Keyboard;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+using Olbrasoft.VirtualAssistant.Data.Queries.PromptQueries;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+using IDesktopContextService = Olbrasoft.VirtualAssistant.Core.Services.IDesktopContextService;
+
+namespace Olbrasoft.VirtualAssistant.Service.Hubs.Services;
+
+/// <inheritdoc />
+public class RemoteRecordingCommands : IRemoteRecordingCommands
+{
+    private const int MaxPasteLength = 10000;
+
+    private readonly ILogger<RemoteRecordingCommands> _logger;
+    private readonly IDictationService _dictationService;
+    private readonly IKeyboardSimulationService _keyboardSimulation;
+    private readonly IDesktopContextService _desktopContext;
+    private readonly ICliAppDetector _cliAppDetector;
+    private readonly ITerminalDetector _terminalDetector;
+    private readonly IQueryProcessor _queryProcessor;
+
+    public RemoteRecordingCommands(
+        ILogger<RemoteRecordingCommands> logger,
+        IDictationService dictationService,
+        IKeyboardSimulationService keyboardSimulation,
+        IDesktopContextService desktopContext,
+        ICliAppDetector cliAppDetector,
+        ITerminalDetector terminalDetector,
+        IQueryProcessor queryProcessor)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _dictationService = dictationService ?? throw new ArgumentNullException(nameof(dictationService));
+        _keyboardSimulation = keyboardSimulation ?? throw new ArgumentNullException(nameof(keyboardSimulation));
+        _desktopContext = desktopContext ?? throw new ArgumentNullException(nameof(desktopContext));
+        _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+        _terminalDetector = terminalDetector ?? throw new ArgumentNullException(nameof(terminalDetector));
+        _queryProcessor = queryProcessor ?? throw new ArgumentNullException(nameof(queryProcessor));
+    }
+
+    public Task<StatusResponse> GetStatusAsync() =>
+        Task.FromResult(new StatusResponse
+        {
+            IsRecording = _dictationService.State == DictationState.Recording,
+            IsTranscribing = _dictationService.State == DictationState.Transcribing
+        });
+
+    public async Task ToggleRecordingAsync()
+    {
+        if (_dictationService.State == DictationState.Idle)
+        {
+            try { await _dictationService.StartDictationAsync(); }
+            catch (Exception ex) { _logger.LogError(ex, "StartDictation failed"); }
+        }
+        else if (_dictationService.State == DictationState.Recording)
+        {
+            try { await _dictationService.StopDictationAsync(); }
+            catch (Exception ex) { _logger.LogError(ex, "StopDictation failed"); }
+        }
+    }
+
+    public async Task ToggleQuickRecordingAsync()
+    {
+        if (_dictationService.State == DictationState.Idle)
+        {
+            try { await _dictationService.StartQuickDictationAsync(); }
+            catch (Exception ex) { _logger.LogError(ex, "StartQuickDictation failed"); }
+        }
+        else if (_dictationService.State == DictationState.Recording)
+        {
+            try { await _dictationService.StopDictationAsync(); }
+            catch (Exception ex) { _logger.LogError(ex, "StopDictation (quick) failed"); }
+        }
+    }
+
+    public async Task StartDictationAsync()
+    {
+        if (_dictationService.State == DictationState.Idle)
+        {
+            try { await _dictationService.StartDictationAsync(); }
+            catch (Exception ex) { _logger.LogError(ex, "StartDictation failed"); }
+        }
+    }
+
+    public async Task StopDictationWithModeAsync(bool quick)
+    {
+        if (_dictationService.State == DictationState.Recording)
+        {
+            try { await _dictationService.StopDictationAsync(quick); }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "StopDictationWithMode(quick={Quick}) failed", quick);
+            }
+        }
+    }
+
+    public Task CancelTranscriptionAsync()
+    {
+        _logger.LogInformation("CancelTranscription");
+        _dictationService.CancelTranscription();
+        return Task.CompletedTask;
+    }
+
+    public async Task PressEnterAsync()
+    {
+        _logger.LogInformation("PressEnter");
+        try { await _keyboardSimulation.SendKeyAsync("enter"); }
+        catch (Exception ex) { _logger.LogError(ex, "PressEnter failed"); }
+    }
+
+    public async Task<bool> SendContinueAsync()
+    {
+        _logger.LogInformation("SendContinue");
+        try
+        {
+            var activeApp = await GetActiveCliAppAsync();
+            if (!string.Equals(activeApp, "Claude Code", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("SendContinue rejected: active CLI app is '{App}', not Claude Code", activeApp);
+                return false;
+            }
+
+            await _keyboardSimulation.TypeIntoActiveWindowAsync("Pokračuj");
+            await _keyboardSimulation.SendKeyAsync("enter");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SendContinue failed");
+            return false;
+        }
+    }
+
+    public async Task<string> GetActiveCliAppAsync()
+    {
+        try
+        {
+            var cliApp = await _cliAppDetector.DetectCliAppAsync();
+            if (cliApp != null)
+                return cliApp.AppName;
+
+            var context = await _desktopContext.GetCurrentContextAsync();
+            var prompt = await _queryProcessor.ProcessAsync(
+                new GetPromptByAppIdPatternQuery(context.ActiveWindowTitle, context.ActiveApplication),
+                CancellationToken.None);
+            return prompt?.ApplicationName ?? "";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "GetActiveCliApp failed");
+            return "";
+        }
+    }
+
+    public async Task PasteFromClipboardAsync()
+    {
+        _logger.LogInformation("PasteFromClipboard");
+        try { await _keyboardSimulation.PasteFromClipboardAsync(); }
+        catch (Exception ex) { _logger.LogError(ex, "PasteFromClipboard failed"); }
+    }
+
+    public async Task<bool> PasteTranscriptionAsync(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            _logger.LogWarning("PasteTranscription: empty text, ignoring");
+            return false;
+        }
+
+        if (text.Length > MaxPasteLength)
+        {
+            _logger.LogWarning("PasteTranscription rejected: text length {Length} exceeds max {Max}", text.Length, MaxPasteLength);
+            return false;
+        }
+
+        _logger.LogInformation("PasteTranscription {Length} chars", text.Length);
+        try
+        {
+            await _keyboardSimulation.TypeIntoActiveWindowAsync(text);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "PasteTranscription failed");
+            return false;
+        }
+    }
+
+    public async Task ClearTextAsync()
+    {
+        _logger.LogInformation("ClearText");
+        try
+        {
+            var cliApp = await _cliAppDetector.DetectCliAppAsync();
+            if (cliApp != null)
+            {
+                _logger.LogInformation("ClearText: CLI app '{App}' detected, sending End×10 + Ctrl+U×10", cliApp.AppName);
+                var keys = new List<string>();
+                for (var i = 0; i < 10; i++) keys.Add("end");
+                for (var i = 0; i < 10; i++) keys.Add("ctrl+u");
+                await _keyboardSimulation.SendKeySequenceAsync(keys);
+                return;
+            }
+
+            var isTerminal = await _terminalDetector.IsTerminalActiveAsync();
+            if (isTerminal)
+            {
+                _logger.LogInformation("ClearText: regular terminal, sending Ctrl+U");
+                await _keyboardSimulation.SendKeyAsync("ctrl+u");
+                return;
+            }
+
+            _logger.LogInformation("ClearText: GUI app, sending Ctrl+A + Delete");
+            await _keyboardSimulation.SendKeySequenceAsync(["ctrl+a", "delete"]);
+        }
+        catch (Exception ex) { _logger.LogError(ex, "ClearText failed"); }
+    }
+}

--- a/src/VirtualAssistant.Service/Hubs/Services/RemoteScreenshotCommands.cs
+++ b/src/VirtualAssistant.Service/Hubs/Services/RemoteScreenshotCommands.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+using Olbrasoft.VirtualAssistant.Service.Workers;
+
+namespace Olbrasoft.VirtualAssistant.Service.Hubs.Services;
+
+/// <inheritdoc />
+public class RemoteScreenshotCommands : IRemoteScreenshotCommands
+{
+    private const string InsertScreenshotScript = "/home/jirka/.local/bin/insert-screenshot-path";
+    private static string ScreenshotDir => ScreenshotWatcherWorker.ScreenshotDir;
+
+    private readonly ILogger<RemoteScreenshotCommands> _logger;
+
+    public RemoteScreenshotCommands(ILogger<RemoteScreenshotCommands> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<bool> IsScreenshotAvailableAsync()
+    {
+        try
+        {
+            if (!Directory.Exists(ScreenshotDir)) return Task.FromResult(false);
+
+            var cutoff = DateTime.Now - ScreenshotWatcherWorker.FreshnessWindow;
+            var hasRecent = Directory.EnumerateFiles(ScreenshotDir, "*.png")
+                .Select(f => new FileInfo(f))
+                .Any(fi => fi.LastWriteTime > cutoff);
+
+            return Task.FromResult(hasRecent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "IsScreenshotAvailable check failed");
+            return Task.FromResult(false);
+        }
+    }
+
+    public async Task InsertScreenshotPathAsync()
+    {
+        _logger.LogInformation("InsertScreenshotPath");
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/bin/bash",
+                    Arguments = InsertScreenshotScript,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await process.WaitForExitAsync(timeoutCts.Token);
+
+            if (process.ExitCode != 0)
+            {
+                var stderr = await process.StandardError.ReadToEndAsync();
+                _logger.LogWarning("InsertScreenshotPath exit code {ExitCode}: {Stderr}", process.ExitCode, stderr);
+            }
+            else
+            {
+                _logger.LogInformation("InsertScreenshotPath completed successfully");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogError("InsertScreenshotPath timed out after 5s");
+        }
+        catch (Exception ex) { _logger.LogError(ex, "InsertScreenshotPath failed"); }
+    }
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #970

## Summary
Extracts three focused command services from DictationHub; the hub itself becomes a ~125-LOC wire-protocol facade with 3 ctor deps (down from 586 LOC / 9 deps / 21 mixed-domain methods).

- `IRemoteRecordingCommands` — dictation/keyboard/clipboard (12 methods, 6 deps)
- `IRemoteDesktopCommands` — window/workspace/app-launch (5 methods, 4 deps + logger)
- `IRemoteScreenshotCommands` — screenshot helpers (2 methods, logger only)

Method names on the hub are preserved 1:1 so the Remote Control JavaScript client, IHubContext consumers (DictationWorker, DesktopMonitorBroadcastWorker), and all existing tests continue to work unchanged. Splitting into three separate SignalR hubs was intentionally avoided because it would have required rewriting remote.js and re-routing the 6+ event broadcasts that currently fan out via IHubContext<DictationHub> — this refactor satisfies SRP / ISP without that wire risk.

## Test plan
- [x] `dotnet build` 0 errors
- [x] `dotnet test --filter '!~IntegrationTests'` all pass
- [x] Remote Control still works end-to-end (wire protocol unchanged)