### PR TITLE
fix: address Copilot findings on PRs #1017 and #1018

### DIFF
--- a/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
+++ b/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactory.cs
@@ -179,12 +179,16 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
         // DB round-trip fires while a warmup is running. Per-caller
         // cancellation is honoured via WaitAsync — the underlying warmup keeps
         // running so a cancelling caller doesn't abort the shared load for
-        // siblings. (Copilot review on PR #1016.)
+        // siblings. The FIRST caller's token is what drives the actual DB
+        // query inside LoadAndPublishAsync, so pass ApplicationStopping from
+        // SpeechTranscriberFactoryWarmupService (the primary startup caller)
+        // to let the host abort the query cleanly on shutdown. (Copilot
+        // reviews on PR #1016 and #1017.)
         Task warmup;
         lock (_cacheLock)
         {
             if (Volatile.Read(ref _providerIdCache) != null) return Task.CompletedTask;
-            _warmupTask ??= LoadAndPublishAsync();
+            _warmupTask ??= LoadAndPublishAsync(cancellationToken);
             warmup = _warmupTask;
         }
 
@@ -193,12 +197,12 @@ public class SpeechTranscriberFactory : ISpeechTranscriberFactory
             : warmup;
     }
 
-    private async Task LoadAndPublishAsync()
+    private async Task LoadAndPublishAsync(CancellationToken cancellationToken)
     {
         try
         {
             var providers = await _queryProcessor
-                .ProcessAsync(new GetProvidersByTypeQuery("stt"), CancellationToken.None)
+                .ProcessAsync(new GetProvidersByTypeQuery("stt"), cancellationToken)
                 .ConfigureAwait(false);
 
             Dictionary<string, int> published;

--- a/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactoryWarmupService.cs
+++ b/src/VirtualAssistant.Voice/Services/SpeechTranscriberFactoryWarmupService.cs
@@ -13,21 +13,35 @@ namespace Olbrasoft.VirtualAssistant.Voice.Services;
 public class SpeechTranscriberFactoryWarmupService : IHostedService
 {
     private readonly ISpeechTranscriberFactory _factory;
+    private readonly IHostApplicationLifetime _lifetime;
     private readonly ILogger<SpeechTranscriberFactoryWarmupService> _logger;
 
     public SpeechTranscriberFactoryWarmupService(
         ISpeechTranscriberFactory factory,
+        IHostApplicationLifetime lifetime,
         ILogger<SpeechTranscriberFactoryWarmupService> logger)
     {
         _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        _lifetime = lifetime ?? throw new ArgumentNullException(nameof(lifetime));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // Use ApplicationStopping instead of the IHostedService.StartAsync
+        // token so the DB query can still be aborted cleanly once the host
+        // begins shutting down. The StartAsync token covers only the startup
+        // window itself. (Copilot review on PR #1017.)
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, _lifetime.ApplicationStopping);
+
         try
         {
-            await _factory.WarmupAsync(cancellationToken).ConfigureAwait(false);
+            await _factory.WarmupAsync(linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (linked.Token.IsCancellationRequested)
+        {
+            // Host is shutting down / startup is being canceled — stay silent.
         }
         catch (Exception ex)
         {

--- a/tests/VirtualAssistant.Core.Tests/Events/InMemoryEventBusTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Events/InMemoryEventBusTests.cs
@@ -154,15 +154,17 @@ public class InMemoryEventBusTests
     [Fact]
     public async Task Subscribe_SameDelegateTwice_DisposingOneRemovesBoth()
     {
-        // Documents the current InMemoryEventBus behaviour for the
+        // Documents the current InMemoryEventBus behavior for the
         // "subscribe the same delegate twice" edge case: Unsubscribe uses
         // ReferenceEquals, so a single Dispose removes every registration
         // that shares the delegate instance. This is arguably a latent
         // bug (per-subscription tokens should be independent), but pinning
-        // the current behaviour prevents silent regressions and makes a
+        // the current behavior prevents silent regressions and makes a
         // future fix visible as a test breakage. CI on commit 5f08bc1
         // failed because an earlier version of the adjacent test assumed
-        // the opposite semantics.
+        // the opposite semantics. (Copilot review on PR #1018 flagged the
+        // inconsistent "behaviour" spelling — switched to "behavior" to
+        // match the project's existing identifiers.)
         var sut = CreateSut();
         var callCount = 0;
         Func<TestEvent, CancellationToken, Task> handler = (_, _) =>


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Consolidated follow-up for Copilot comments on #1017 (lifetime token) and #1018 (spelling).

## Summary
- **#1017** — LoadAndPublishAsync now passes the first WarmupAsync caller's token through to the DB query; SpeechTranscriberFactoryWarmupService uses IHostApplicationLifetime.ApplicationStopping so shutdown truly aborts an in-flight warmup (previous code used CancellationToken.None).
- **#1018** — \"behaviour\" → \"behavior\" in the new test's comment for consistency with the file's identifiers.

## Test plan
- [x] `dotnet build` 0 errors
- [x] `dotnet test --filter '!~IntegrationTests'` all pass