### PR TITLE
refactor(dictation): extract StreamingChunkAssembler (#969 partial)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.SignalR;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Infrastructure;
 using Olbrasoft.VirtualAssistant.Service.Workers;
+using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 using Olbrasoft.VirtualAssistant.Voice.Configuration;
 using Olbrasoft.VirtualAssistant.Voice.Filters;
 using Olbrasoft.VirtualAssistant.Voice.Services;
@@ -39,18 +40,28 @@ public static class WorkerServicesExtensions
 
         services.AddSingleton(sp =>
         {
+            // Streaming assembler is created inline so it binds to the SAME
+            // keyed ITranscriptionService the worker uses — otherwise a
+            // second (non-keyed) transcription instance would be resolved
+            // for per-chunk calls. (#969 extraction.)
+            var transcription = sp.GetRequiredKeyedService<ITranscriptionService>(DictationKey);
+            var assembler = new StreamingChunkAssembler(
+                sp.GetRequiredService<ILogger<StreamingChunkAssembler>>(),
+                transcription);
+
             return new DictationWorker(
                 sp.GetRequiredService<ILogger<DictationWorker>>(),
                 sp.GetRequiredService<IKeyboardMonitor>(),
                 sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
                 sp.GetRequiredKeyedService<IAudioRecordingCoordinator>(DictationKey),
-                sp.GetRequiredKeyedService<ITranscriptionService>(DictationKey),
+                transcription,
                 sp.GetRequiredService<IKeyboardSimulationService>(),
                 sp.GetRequiredKeyedService<ISoundEffectPlayer>("typing"),
                 sp.GetRequiredKeyedService<ISoundEffectPlayer>("cancel"),
                 sp.GetRequiredService<IServiceScopeFactory>(),
                 sp.GetRequiredService<IHubContext<DictationHub>>(),
                 sp.GetRequiredService<ICliAppDetector>(),
+                assembler,
                 sp.GetRequiredService<IOptions<DictationOptions>>());
         });
 

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -11,6 +11,7 @@ using Olbrasoft.VirtualAssistant.Voice.Services;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
+using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 
 namespace Olbrasoft.VirtualAssistant.Service.Workers;
 
@@ -32,19 +33,13 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IHubContext<DictationHub> _hubContext;
     private readonly ICliAppDetector _cliAppDetector;
+    private readonly IStreamingChunkAssembler _streamingAssembler;
     private readonly DictationOptions _options;
 
     private CancellationTokenSource? _transcriptionCts;
     private bool _dictationEnabled = true;
     private bool _quickDictationMode;
     private volatile bool _streamingTranscriptionEnabled;
-
-    // Streaming chunk transcription state — populated during Recording when streaming is on.
-    // On Stop (quick mode): assembled into the final raw text. On Stop (slow mode): discarded.
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<int, string> _streamChunkResults = new();
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<int, Task> _streamChunkTasks = new();
-    private CancellationTokenSource? _streamChunksCts;
-    private bool _streamingActiveForSession;  // frozen snapshot at StartRecording time
 
     /// <inheritdoc/>
     public DictationState State => _stateMachine.CurrentState;
@@ -64,6 +59,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         IServiceScopeFactory scopeFactory,
         IHubContext<DictationHub> hubContext,
         ICliAppDetector cliAppDetector,
+        IStreamingChunkAssembler streamingAssembler,
         IOptions<DictationOptions> options)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -77,6 +73,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
         _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+        _streamingAssembler = streamingAssembler ?? throw new ArgumentNullException(nameof(streamingAssembler));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
     }
@@ -168,9 +165,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // If user picked slow mode but streaming was pre-transcribing chunks,
             // cancel those background tasks — they'd be discarded anyway, no point
             // burning GPU/serializing the Whisper semaphore for them.
-            if (!quickMode && _streamingActiveForSession)
+            if (!quickMode && _streamingAssembler.IsActive)
             {
-                try { _streamChunksCts?.Cancel(); } catch { /* best effort */ }
+                _streamingAssembler.CancelAndClear();
                 _recordingCoordinator.DisableChunking();
                 _logger.LogInformation("Slow-mode override: canceled pending streaming chunk transcriptions");
             }
@@ -330,78 +327,14 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     }
 
     /// <summary>
-    /// Handles a streaming audio chunk by launching a background Whisper call.
-    /// Results are keyed by chunk index in <see cref="_streamChunkResults"/> and assembled
-    /// in order on Stop when quick-mode streaming finalizes. Ignored if streaming is not
-    /// active for this session or if the chunk arrived outside Recording state.
+    /// Forwards a streaming audio chunk to <see cref="IStreamingChunkAssembler"/>
+    /// which runs the per-chunk Whisper call on a background task and stores
+    /// the result keyed by chunk index. Ignored when streaming is not active
+    /// for the current session.
     /// </summary>
     private void OnChunkAvailable(object? sender, AudioChunkEventArgs e)
     {
-        if (!_streamingActiveForSession) return;
-        if (_streamChunksCts == null || _streamChunksCts.IsCancellationRequested) return;
-
-        var ct = _streamChunksCts.Token;
-        var task = Task.Run(async () =>
-        {
-            try
-            {
-                var sw = System.Diagnostics.Stopwatch.StartNew();
-                var text = await _transcriptionService.TranscribeChunkRawAsync(e.PcmBytes, ct);
-                sw.Stop();
-                _streamChunkResults[e.Index] = text ?? string.Empty;
-                _logger.LogInformation(
-                    "Streaming chunk {Index} transcribed in {ElapsedMs}ms: '{Preview}'",
-                    e.Index,
-                    sw.ElapsedMilliseconds,
-                    (text ?? string.Empty).Length > 60 ? (text ?? string.Empty)[..60] + "…" : text);
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogDebug("Streaming chunk {Index} canceled", e.Index);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Streaming chunk {Index} transcription failed", e.Index);
-                _streamChunkResults[e.Index] = string.Empty;
-            }
-        }, ct);
-
-        _streamChunkTasks[e.Index] = task;
-    }
-
-    /// <summary>
-    /// Awaits pending chunk transcription tasks and concatenates their ordered results.
-    /// Returns null if no chunks were produced (streaming not active or no audio).
-    /// </summary>
-    private async Task<string?> CombineStreamingChunksAsync(CancellationToken cancellationToken)
-    {
-        if (!_streamingActiveForSession) return null;
-
-        // Wait for all background chunk transcriptions to complete.
-        var pending = _streamChunkTasks.Values.ToArray();
-        if (pending.Length == 0)
-        {
-            _logger.LogInformation("CombineStreamingChunks: no chunks produced");
-            return null;
-        }
-
-        try
-        {
-            await Task.WhenAll(pending).WaitAsync(cancellationToken);
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "One or more streaming chunk tasks faulted; proceeding with available results");
-        }
-
-        var ordered = _streamChunkResults
-            .OrderBy(kvp => kvp.Key)
-            .Select(kvp => kvp.Value?.Trim() ?? string.Empty)
-            .Where(t => t.Length > 0);
-
-        var combined = string.Join(" ", ordered);
-        return System.Text.RegularExpressions.Regex.Replace(combined, @"\s+", " ").Trim();
+        _streamingAssembler.SubmitChunk(e.Index, e.PcmBytes);
     }
 
     private async Task BroadcastDictationEventAsync(DictationEventType eventType, string? text)
@@ -428,15 +361,11 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _stateMachine.TransitionTo(DictationState.Recording);
 
             // Freeze streaming choice for this session — toggles mid-recording have no effect
-            _streamingActiveForSession = _streamingTranscriptionEnabled;
-            _streamChunkResults.Clear();
-            _streamChunkTasks.Clear();
-            _streamChunksCts?.Dispose();
-            _streamChunksCts = null;
+            var streamingActive = _streamingTranscriptionEnabled;
+            _streamingAssembler.Reset(streamingActive);
 
-            if (_streamingActiveForSession)
+            if (streamingActive)
             {
-                _streamChunksCts = new CancellationTokenSource();
                 _recordingCoordinator.EnableChunking(TimeSpan.FromSeconds(8));
                 _logger.LogInformation("Streaming transcription active for this session (8s chunks)");
             }
@@ -541,19 +470,12 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
     /// <summary>
     /// Clears streaming chunk state after a dictation session completes (any path).
+    /// Delegates the concurrent-collection cleanup to <see cref="IStreamingChunkAssembler"/>;
+    /// the worker still owns the recording-coordinator's chunking flag.
     /// </summary>
     private void ResetStreamingSessionState()
     {
-        try
-        {
-            _streamChunksCts?.Cancel();
-            _streamChunksCts?.Dispose();
-        }
-        catch { /* best effort */ }
-        _streamChunksCts = null;
-        _streamChunkResults.Clear();
-        _streamChunkTasks.Clear();
-        _streamingActiveForSession = false;
+        _streamingAssembler.CancelAndClear();
         _recordingCoordinator.DisableChunking();
     }
 
@@ -589,9 +511,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _transcriptionCts = new CancellationTokenSource();
 
         TranscriptionResult result;
-        if (_streamingActiveForSession)
+        if (_streamingAssembler.IsActive)
         {
-            var combined = await CombineStreamingChunksAsync(_transcriptionCts.Token);
+            var combined = await _streamingAssembler.CombineAsync(_transcriptionCts.Token);
             if (string.IsNullOrWhiteSpace(combined))
             {
                 _logger.LogWarning("Streaming quick transcription produced empty text; falling back to full-buffer Whisper");
@@ -601,7 +523,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             {
                 _logger.LogInformation(
                     "Streaming quick transcription: combined {Count} chunks into {Length} chars",
-                    _streamChunkResults.Count, combined.Length);
+                    _streamingAssembler.CompletedChunkCount, combined.Length);
                 result = await _transcriptionService.FinalizePreTranscribedRawAsync(combined, _transcriptionCts.Token);
             }
         }

--- a/src/VirtualAssistant.Service/Workers/Streaming/IStreamingChunkAssembler.cs
+++ b/src/VirtualAssistant.Service/Workers/Streaming/IStreamingChunkAssembler.cs
@@ -1,0 +1,52 @@
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
+
+/// <summary>
+/// Encapsulates the per-session streaming-chunk state that used to live
+/// directly on <c>DictationWorker</c> (#969 god-class split). One instance
+/// corresponds to one dictation session: the worker calls <see cref="Reset"/>
+/// at StartRecording, forwards audio chunks through <see cref="SubmitChunk"/>,
+/// and at Stop awaits <see cref="CombineAsync"/> for the aggregated text.
+/// </summary>
+public interface IStreamingChunkAssembler
+{
+    /// <summary>
+    /// Whether streaming is active for the current session — mirrors the
+    /// DictationWorker's frozen-at-start flag so stale chunks that arrive
+    /// after a mode switch are silently ignored.
+    /// </summary>
+    bool IsActive { get; }
+
+    /// <summary>
+    /// Clears all per-session state and installs a fresh CTS. If <paramref name="active"/>
+    /// is false, future <see cref="SubmitChunk"/> calls are no-ops.
+    /// </summary>
+    void Reset(bool active);
+
+    /// <summary>
+    /// Cancels all in-flight chunk transcriptions and clears the aggregated
+    /// results. Safe to call repeatedly; used on both Stop (slow mode that
+    /// discards streaming results) and on dictation cancel.
+    /// </summary>
+    void CancelAndClear();
+
+    /// <summary>
+    /// Launches a background transcription for one recording chunk. No-op if
+    /// streaming is not active for this session or the session has already
+    /// been cancelled.
+    /// </summary>
+    void SubmitChunk(int index, byte[] pcmBytes);
+
+    /// <summary>
+    /// Awaits all in-flight chunk transcriptions and returns the combined
+    /// text, or <c>null</c> if streaming is not active or produced no chunks.
+    /// Honours <paramref name="cancellationToken"/> for the caller's wait; the
+    /// underlying per-chunk tasks are driven by this assembler's own token.
+    /// </summary>
+    Task<string?> CombineAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Number of chunks whose transcription has completed (successful or
+    /// empty). Exposed for the worker's post-combine logging.
+    /// </summary>
+    int CompletedChunkCount { get; }
+}

--- a/src/VirtualAssistant.Service/Workers/Streaming/StreamingChunkAssembler.cs
+++ b/src/VirtualAssistant.Service/Workers/Streaming/StreamingChunkAssembler.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Olbrasoft.VirtualAssistant.Voice.Services;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
+
+/// <inheritdoc />
+public class StreamingChunkAssembler : IStreamingChunkAssembler
+{
+    private static readonly Regex CollapseWhitespace = new(@"\s+", RegexOptions.Compiled);
+
+    private readonly ILogger<StreamingChunkAssembler> _logger;
+    private readonly ITranscriptionService _transcriptionService;
+
+    private readonly ConcurrentDictionary<int, string> _results = new();
+    private readonly ConcurrentDictionary<int, Task> _tasks = new();
+    private CancellationTokenSource? _cts;
+    private bool _active;
+
+    public StreamingChunkAssembler(
+        ILogger<StreamingChunkAssembler> logger,
+        ITranscriptionService transcriptionService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _transcriptionService = transcriptionService ?? throw new ArgumentNullException(nameof(transcriptionService));
+    }
+
+    public bool IsActive => _active;
+
+    public int CompletedChunkCount => _results.Count;
+
+    public void Reset(bool active)
+    {
+        CancelAndClear();
+        _active = active;
+        if (active)
+        {
+            _cts = new CancellationTokenSource();
+        }
+    }
+
+    public void CancelAndClear()
+    {
+        try
+        {
+            _cts?.Cancel();
+            _cts?.Dispose();
+        }
+        catch
+        {
+            // best effort — Cancel/Dispose can race with in-flight handlers
+        }
+        _cts = null;
+        _results.Clear();
+        _tasks.Clear();
+        _active = false;
+    }
+
+    public void SubmitChunk(int index, byte[] pcmBytes)
+    {
+        if (!_active) return;
+        if (_cts == null || _cts.IsCancellationRequested) return;
+
+        var ct = _cts.Token;
+        var task = Task.Run(async () =>
+        {
+            try
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                var text = await _transcriptionService.TranscribeChunkRawAsync(pcmBytes, ct);
+                sw.Stop();
+                _results[index] = text ?? string.Empty;
+                _logger.LogInformation(
+                    "Streaming chunk {Index} transcribed in {ElapsedMs}ms: '{Preview}'",
+                    index,
+                    sw.ElapsedMilliseconds,
+                    (text ?? string.Empty).Length > 60 ? (text ?? string.Empty)[..60] + "…" : text);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Streaming chunk {Index} canceled", index);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Streaming chunk {Index} transcription failed", index);
+                _results[index] = string.Empty;
+            }
+        }, ct);
+
+        _tasks[index] = task;
+    }
+
+    public async Task<string?> CombineAsync(CancellationToken cancellationToken)
+    {
+        if (!_active) return null;
+
+        var pending = _tasks.Values.ToArray();
+        if (pending.Length == 0)
+        {
+            _logger.LogInformation("CombineStreamingChunks: no chunks produced");
+            return null;
+        }
+
+        try
+        {
+            await Task.WhenAll(pending).WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "One or more streaming chunk tasks faulted; proceeding with available results");
+        }
+
+        var ordered = _results
+            .OrderBy(kvp => kvp.Key)
+            .Select(kvp => kvp.Value?.Trim() ?? string.Empty)
+            .Where(t => t.Length > 0);
+
+        var combined = string.Join(" ", ordered);
+        return CollapseWhitespace.Replace(combined, " ").Trim();
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -35,6 +35,7 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IDictationPersistenceService> _persistenceServiceMock;
     private readonly Mock<IHubContext<DictationHub>> _hubContextMock;
     private readonly Mock<ICliAppDetector> _cliAppDetectorMock;
+    private readonly Mock<Olbrasoft.VirtualAssistant.Service.Workers.Streaming.IStreamingChunkAssembler> _streamingAssemblerMock;
     private readonly DictationOptions _options;
     private readonly DictationWorker _sut;
 
@@ -57,6 +58,7 @@ public class DictationWorkerTests : IDisposable
         _hubContextMock = new Mock<IHubContext<DictationHub>>();
         _hubContextMock.Setup(x => x.Clients).Returns(Mock.Of<IHubClients>());
         _cliAppDetectorMock = new Mock<ICliAppDetector>();
+        _streamingAssemblerMock = new Mock<Olbrasoft.VirtualAssistant.Service.Workers.Streaming.IStreamingChunkAssembler>();
 
         _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
 
@@ -82,6 +84,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options));
     }
 
@@ -102,6 +105,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -120,6 +124,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -138,6 +143,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -156,6 +162,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             null!));
     }
 
@@ -174,6 +181,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -192,6 +200,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -210,6 +219,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -228,6 +238,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -246,6 +257,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -264,6 +276,7 @@ public class DictationWorkerTests : IDisposable
             null!,
             _hubContextMock.Object,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -282,6 +295,7 @@ public class DictationWorkerTests : IDisposable
             _scopeFactoryMock.Object,
             null!,
             _cliAppDetectorMock.Object,
+            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -299,6 +313,26 @@ public class DictationWorkerTests : IDisposable
             _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
             _hubContextMock.Object,
+            null!,
+            _streamingAssemblerMock.Object,
+            Options.Create(_options)));
+    }
+
+    [Fact]
+    public void Constructor_NullStreamingAssembler_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
+            _loggerMock.Object,
+            _keyboardMonitorMock.Object,
+            _stateMachineMock.Object,
+            _recordingCoordinatorMock.Object,
+            _transcriptionServiceMock.Object,
+            _keyboardSimulationMock.Object,
+            _typingSoundMock.Object,
+            _cancelSoundMock.Object,
+            _scopeFactoryMock.Object,
+            _hubContextMock.Object,
+            _cliAppDetectorMock.Object,
             null!,
             Options.Create(_options)));
     }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Partial progress on #969 — issue stays open for the remaining extractions.

## Summary
First slice of the DictationWorker god-class split. Extracts the streaming-chunk aggregation into a focused `IStreamingChunkAssembler` / `StreamingChunkAssembler` pair under `Workers/Streaming/`. Removes ~90 LOC of concurrent-dictionary management, two fields, three helper methods, and makes chunk aggregation independently testable.

### What moved
- `_streamChunkResults`, `_streamChunkTasks`, `_streamChunksCts`, `_streamingActiveForSession` fields
- `OnChunkAvailable` → delegates to `_streamingAssembler.SubmitChunk`
- `CombineStreamingChunksAsync` → `_streamingAssembler.CombineAsync`
- `ResetStreamingSessionState` → `_streamingAssembler.CancelAndClear` + DisableChunking

### What still lives on DictationWorker (follow-ups)
- `DictationAudioProcessor` extraction (ValidateAndPrepareAudio, TranscribeRawWithSound, TranscribeAudioWithSound)
- `DictationOutputHandler` extraction (TypeTextAndFinish, civility stripping, FastPaste orchestration)
- Ctor-dependency reduction to ≤ 5 (still 13 — this PR adds IStreamingChunkAssembler; removing that many at once would have been too much test churn for one PR)

## Test plan
- [x] `dotnet build` 0 errors
- [x] `dotnet test --filter '!~IntegrationTests'` all pass (953 ok — +1 new Constructor_NullStreamingAssembler test)