### PR TITLE
refactor(streaming): Copilot follow-up on PR #1021

### DIFF
--- a/src/VirtualAssistant.Service/Workers/Streaming/IStreamingChunkAssembler.cs
+++ b/src/VirtualAssistant.Service/Workers/Streaming/IStreamingChunkAssembler.cs
@@ -2,10 +2,13 @@ namespace Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 
 /// <summary>
 /// Encapsulates the per-session streaming-chunk state that used to live
-/// directly on <c>DictationWorker</c> (#969 god-class split). One instance
-/// corresponds to one dictation session: the worker calls <see cref="Reset"/>
-/// at StartRecording, forwards audio chunks through <see cref="SubmitChunk"/>,
-/// and at Stop awaits <see cref="CombineAsync"/> for the aggregated text.
+/// directly on <c>DictationWorker</c> (#969 god-class split). The assembler
+/// *holds per-session state* but is typically reused across sessions — the
+/// worker calls <see cref="Reset"/> at StartRecording (which clears the
+/// previous session's state and installs a fresh CTS), forwards audio chunks
+/// through <see cref="SubmitChunk"/>, and at Stop awaits <see cref="CombineAsync"/>
+/// for the aggregated text. DI registers a single assembler alongside the
+/// singleton <c>DictationWorker</c>.
 /// </summary>
 public interface IStreamingChunkAssembler
 {

--- a/src/VirtualAssistant.Service/Workers/Streaming/StreamingChunkAssembler.cs
+++ b/src/VirtualAssistant.Service/Workers/Streaming/StreamingChunkAssembler.cs
@@ -15,7 +15,7 @@ public class StreamingChunkAssembler : IStreamingChunkAssembler
     private readonly ConcurrentDictionary<int, string> _results = new();
     private readonly ConcurrentDictionary<int, Task> _tasks = new();
     private CancellationTokenSource? _cts;
-    private bool _active;
+    private volatile bool _active;
 
     public StreamingChunkAssembler(
         ILogger<StreamingChunkAssembler> logger,
@@ -32,36 +32,58 @@ public class StreamingChunkAssembler : IStreamingChunkAssembler
     public void Reset(bool active)
     {
         CancelAndClear();
-        _active = active;
         if (active)
         {
+            // Publish the fresh CTS before flipping _active so any submitter that
+            // observes _active==true via the volatile read below always sees a
+            // non-null _cts.
             _cts = new CancellationTokenSource();
         }
+        _active = active;
     }
 
     public void CancelAndClear()
     {
-        try
+        // Flip inactive first so concurrent SubmitChunk callers bail out before
+        // we dispose the CTS.
+        _active = false;
+
+        // Atomically swap the CTS out so only one caller disposes it even if
+        // Reset/CancelAndClear race.
+        var cts = Interlocked.Exchange(ref _cts, null);
+        if (cts != null)
         {
-            _cts?.Cancel();
-            _cts?.Dispose();
+            try { cts.Cancel(); } catch { /* best effort — handlers may have raced */ }
+            cts.Dispose();
         }
-        catch
-        {
-            // best effort — Cancel/Dispose can race with in-flight handlers
-        }
-        _cts = null;
+
         _results.Clear();
         _tasks.Clear();
-        _active = false;
     }
 
     public void SubmitChunk(int index, byte[] pcmBytes)
     {
         if (!_active) return;
-        if (_cts == null || _cts.IsCancellationRequested) return;
 
-        var ct = _cts.Token;
+        // Snapshot _cts so a racing CancelAndClear can't null/dispose it out
+        // from under us between the null-check and the Token read. An
+        // ObjectDisposedException is still possible if Dispose has already
+        // completed on the snapshot — swallow it and treat as inactive.
+        // (Copilot review on PR #1021.)
+        var cts = _cts;
+        if (cts == null) return;
+
+        CancellationToken ct;
+        try
+        {
+            if (cts.IsCancellationRequested) return;
+            ct = cts.Token;
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
         var task = Task.Run(async () =>
         {
             try
@@ -97,7 +119,7 @@ public class StreamingChunkAssembler : IStreamingChunkAssembler
         var pending = _tasks.Values.ToArray();
         if (pending.Length == 0)
         {
-            _logger.LogInformation("CombineStreamingChunks: no chunks produced");
+            _logger.LogInformation("StreamingChunkAssembler.CombineAsync: no chunks produced");
             return null;
         }
 

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -14,6 +14,7 @@ using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Core.WindowManagement;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Workers;
+using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 using Olbrasoft.VirtualAssistant.Voice.Services;
 using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 
@@ -35,7 +36,7 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IDictationPersistenceService> _persistenceServiceMock;
     private readonly Mock<IHubContext<DictationHub>> _hubContextMock;
     private readonly Mock<ICliAppDetector> _cliAppDetectorMock;
-    private readonly Mock<Olbrasoft.VirtualAssistant.Service.Workers.Streaming.IStreamingChunkAssembler> _streamingAssemblerMock;
+    private readonly Mock<IStreamingChunkAssembler> _streamingAssemblerMock;
     private readonly DictationOptions _options;
     private readonly DictationWorker _sut;
 
@@ -58,7 +59,7 @@ public class DictationWorkerTests : IDisposable
         _hubContextMock = new Mock<IHubContext<DictationHub>>();
         _hubContextMock.Setup(x => x.Clients).Returns(Mock.Of<IHubClients>());
         _cliAppDetectorMock = new Mock<ICliAppDetector>();
-        _streamingAssemblerMock = new Mock<Olbrasoft.VirtualAssistant.Service.Workers.Streaming.IStreamingChunkAssembler>();
+        _streamingAssemblerMock = new Mock<IStreamingChunkAssembler>();
 
         _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
 

--- a/tests/VirtualAssistant.Service.Tests/Workers/Streaming/StreamingChunkAssemblerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Streaming/StreamingChunkAssemblerTests.cs
@@ -1,0 +1,200 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
+using Olbrasoft.VirtualAssistant.Voice.Services;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Streaming;
+
+/// <summary>
+/// Pins the extraction contract lifted out of DictationWorker in PR #1021:
+/// Reset(false) disables submissions, ordered combine respects chunk index,
+/// CancelAndClear stops in-flight work, and the null-return paths fire when
+/// the assembler is idle or empty. Copilot's post-merge review on #1021
+/// flagged that the new class had no focused unit tests.
+/// </summary>
+public class StreamingChunkAssemblerTests
+{
+    private readonly Mock<ILogger<StreamingChunkAssembler>> _loggerMock = new();
+    private readonly Mock<ITranscriptionService> _transcriptionMock = new();
+
+    private StreamingChunkAssembler CreateSut() => new(_loggerMock.Object, _transcriptionMock.Object);
+
+    [Fact]
+    public void Reset_False_MakesSubmitChunk_ANoOp()
+    {
+        var sut = CreateSut();
+        sut.Reset(active: false);
+
+        sut.SubmitChunk(0, new byte[] { 1, 2, 3 });
+
+        Assert.False(sut.IsActive);
+        Assert.Equal(0, sut.CompletedChunkCount);
+        _transcriptionMock.Verify(
+            x => x.TranscribeChunkRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void Reset_True_EnablesSubmitChunk()
+    {
+        var sut = CreateSut();
+        _transcriptionMock
+            .Setup(x => x.TranscribeChunkRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("ok");
+
+        sut.Reset(active: true);
+        sut.SubmitChunk(0, new byte[] { 1 });
+
+        Assert.True(sut.IsActive);
+    }
+
+    [Fact]
+    public async Task CombineAsync_CombinesChunksInIndexOrder_RegardlessOfSubmissionOrder()
+    {
+        var sut = CreateSut();
+        var perChunk = new Dictionary<byte, string>
+        {
+            [0] = "first",
+            [1] = "second",
+            [2] = "third",
+        };
+        _transcriptionMock
+            .Setup(x => x.TranscribeChunkRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .Returns<byte[], CancellationToken>((bytes, _) => Task.FromResult(perChunk[bytes[0]]));
+
+        sut.Reset(active: true);
+        sut.SubmitChunk(2, new byte[] { 2 });
+        sut.SubmitChunk(0, new byte[] { 0 });
+        sut.SubmitChunk(1, new byte[] { 1 });
+
+        var combined = await sut.CombineAsync(CancellationToken.None);
+
+        Assert.Equal("first second third", combined);
+        Assert.Equal(3, sut.CompletedChunkCount);
+    }
+
+    [Fact]
+    public async Task CombineAsync_CollapsesInteriorWhitespaceAndTrims()
+    {
+        var sut = CreateSut();
+        _transcriptionMock
+            .Setup(x => x.TranscribeChunkRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("  hello   world  ");
+
+        sut.Reset(active: true);
+        sut.SubmitChunk(0, new byte[] { 1 });
+
+        var combined = await sut.CombineAsync(CancellationToken.None);
+
+        Assert.Equal("hello world", combined);
+    }
+
+    [Fact]
+    public async Task CombineAsync_WhenInactive_ReturnsNull()
+    {
+        var sut = CreateSut();
+
+        var combined = await sut.CombineAsync(CancellationToken.None);
+
+        Assert.Null(combined);
+    }
+
+    [Fact]
+    public async Task CombineAsync_WhenActiveWithNoChunks_ReturnsNull()
+    {
+        var sut = CreateSut();
+        sut.Reset(active: true);
+
+        var combined = await sut.CombineAsync(CancellationToken.None);
+
+        Assert.Null(combined);
+    }
+
+    [Fact]
+    public async Task CancelAndClear_CancelsInFlightTasks_AndClearsState()
+    {
+        // Force the chunk task to sit on ct.WaitHandle so we can deterministically
+        // observe the cancellation path without depending on wall-clock delays.
+        var sut = CreateSut();
+        var enteredHandler = new TaskCompletionSource();
+        _transcriptionMock
+            .Setup(x => x.TranscribeChunkRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .Returns<byte[], CancellationToken>(async (_, ct) =>
+            {
+                enteredHandler.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct);
+                return "unreachable";
+            });
+
+        sut.Reset(active: true);
+        sut.SubmitChunk(0, new byte[] { 1 });
+        await enteredHandler.Task;
+
+        sut.CancelAndClear();
+
+        Assert.False(sut.IsActive);
+        Assert.Equal(0, sut.CompletedChunkCount);
+
+        // Combine on the now-idle assembler returns null — state is fully reset.
+        var combined = await sut.CombineAsync(CancellationToken.None);
+        Assert.Null(combined);
+    }
+
+    [Fact]
+    public async Task SubmitChunk_AfterCancelAndClear_DoesNotInvokeTranscription()
+    {
+        var sut = CreateSut();
+        sut.Reset(active: true);
+        sut.CancelAndClear();
+
+        sut.SubmitChunk(0, new byte[] { 1 });
+        await Task.Yield();
+
+        _transcriptionMock.Verify(
+            x => x.TranscribeChunkRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CombineAsync_FaultedChunk_DoesNotThrow_AndReturnsSurvivingChunks()
+    {
+        var sut = CreateSut();
+        _transcriptionMock
+            .Setup(x => x.TranscribeChunkRawAsync(It.Is<byte[]>(b => b[0] == 0), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        _transcriptionMock
+            .Setup(x => x.TranscribeChunkRawAsync(It.Is<byte[]>(b => b[0] == 1), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("survivor");
+
+        sut.Reset(active: true);
+        sut.SubmitChunk(0, new byte[] { 0 });
+        sut.SubmitChunk(1, new byte[] { 1 });
+
+        var combined = await sut.CombineAsync(CancellationToken.None);
+
+        // Faulted chunk is recorded as empty string, surviving chunk contributes
+        // its text; Where(t => t.Length > 0) drops the empty entry cleanly.
+        Assert.Equal("survivor", combined);
+    }
+
+    [Fact]
+    public async Task Reset_True_AfterPriorSession_ClearsCompletedCount()
+    {
+        // Pins the across-sessions reuse contract the xmldoc describes: the
+        // assembler is a singleton reused across sessions, so Reset must
+        // discard the prior session's results.
+        var sut = CreateSut();
+        _transcriptionMock
+            .Setup(x => x.TranscribeChunkRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("x");
+
+        sut.Reset(active: true);
+        sut.SubmitChunk(0, new byte[] { 1 });
+        await sut.CombineAsync(CancellationToken.None);
+        Assert.Equal(1, sut.CompletedChunkCount);
+
+        sut.Reset(active: true);
+
+        Assert.Equal(0, sut.CompletedChunkCount);
+    }
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to #1021 (closes the review comment batch from Copilot's post-merge review on that PR). Parent refactor tracked under #969.

## Summary

- **Race fix in `SubmitChunk`**: snapshot `_cts` to a local before the null/cancel checks, make `_active` volatile, flip `_active=false` before disposing the CTS in `CancelAndClear`, and swap `_cts` via `Interlocked.Exchange` so `Reset`/`CancelAndClear` are race-safe against themselves.
- **Log message**: `"CombineStreamingChunks: no chunks produced"` -> `"StreamingChunkAssembler.CombineAsync: no chunks produced"` so journalctl searches line up with the current class/method name.
- **Interface xmldoc**: rewrote to describe per-session state *reused across sessions* (matches the singleton DI registration instead of the stale "one instance per session" wording).
- **Test consistency**: added `using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;` to `DictationWorkerTests` and switched `Mock<Olbrasoft.VirtualAssistant.Service.Workers.Streaming.IStreamingChunkAssembler>` to the short `Mock<IStreamingChunkAssembler>`.
- **Focused unit tests** (new): `StreamingChunkAssemblerTests` with 10 cases — Reset(false) no-op, ordered combine regardless of submit order, whitespace collapse, inactive/empty null returns, CancelAndClear cancels in-flight, faulted-chunk survivor combine, cross-session state reuse.

## Test plan

- [x] `dotnet build` green
- [x] `dotnet test tests/VirtualAssistant.Service.Tests/` = 342/342 pass locally (10 new StreamingChunkAssembler tests + existing)
- [ ] CI green on the merge
- [ ] Post-deploy: dictation streaming chunks still combine correctly in production (smoke via `/api/dictation` after next deploy)