### PR TITLE
docs(streaming): Copilot wording follow-up on #1022

### DIFF
--- a/src/VirtualAssistant.Service/Workers/Streaming/IStreamingChunkAssembler.cs
+++ b/src/VirtualAssistant.Service/Workers/Streaming/IStreamingChunkAssembler.cs
@@ -7,8 +7,9 @@ namespace Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 /// worker calls <see cref="Reset"/> at StartRecording (which clears the
 /// previous session's state and installs a fresh CTS), forwards audio chunks
 /// through <see cref="SubmitChunk"/>, and at Stop awaits <see cref="CombineAsync"/>
-/// for the aggregated text. DI registers a single assembler alongside the
-/// singleton <c>DictationWorker</c>.
+/// for the aggregated text. In the current setup the singleton
+/// <c>DictationWorker</c> factory constructs one assembler inline and reuses
+/// it across sessions; the interface is not itself registered in DI.
 /// </summary>
 public interface IStreamingChunkAssembler
 {

--- a/tests/VirtualAssistant.Service.Tests/Workers/Streaming/StreamingChunkAssemblerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Streaming/StreamingChunkAssemblerTests.cs
@@ -113,8 +113,9 @@ public class StreamingChunkAssemblerTests
     [Fact]
     public async Task CancelAndClear_CancelsInFlightTasks_AndClearsState()
     {
-        // Force the chunk task to sit on ct.WaitHandle so we can deterministically
-        // observe the cancellation path without depending on wall-clock delays.
+        // Force the chunk task to wait on an infinite delay canceled by ct so we
+        // can deterministically observe the cancellation path without depending
+        // on wall-clock delays.
         var sut = CreateSut();
         var enteredHandler = new TaskCompletionSource();
         _transcriptionMock


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Tiny doc-only follow-up to address the two comments from Copilot's post-merge review on #1022. No behavior change.

## Summary

- `IStreamingChunkAssembler` xmldoc: dropped the claim that DI registers the interface — in reality `WorkerServicesExtensions` constructs the assembler inline inside the singleton `DictationWorker` factory. Kept the "reused across sessions" part that the earlier review asked for.
- `StreamingChunkAssemblerTests` cancel test comment: said the task "sits on ct.WaitHandle", but the code uses `Task.Delay(Timeout.Infinite, ct)`. Updated wording to match.

## Test plan

- [x] Comment-only changes — no new behavior
- [ ] CI green on the merge