### PR TITLE
test(core): add coverage for TranscriptionResult + NotificationService + ContinuousListenerOptions (#979)

### DIFF
--- a/tests/VirtualAssistant.Core.Tests/Configuration/ContinuousListenerOptionsTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Configuration/ContinuousListenerOptionsTests.cs
@@ -1,0 +1,89 @@
+using Olbrasoft.VirtualAssistant.Core.Configuration;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.Configuration;
+
+/// <summary>
+/// Pins the three computed byte-math properties and the two path-resolution
+/// branches of GetFullWhisperModelPath that don't require filesystem access.
+/// The filename-only branch delegates to WhisperModelLocator which walks
+/// real XDG directories and is covered separately.
+/// </summary>
+public class ContinuousListenerOptionsTests
+{
+    [Fact]
+    public void ChunkSizeBytes_UsesSampleRateAndVadChunkMs_At16BitsPerSample()
+    {
+        // 16000 Hz * 32 ms / 1000 * 2 bytes = 1024 bytes per VAD chunk.
+        var options = new ContinuousListenerOptions { SampleRate = 16000, VadChunkMs = 32 };
+
+        Assert.Equal(1024, options.ChunkSizeBytes);
+    }
+
+    [Fact]
+    public void ChunkSizeBytes_ReflectsCustomSampleRate()
+    {
+        // 48000 Hz * 10 ms / 1000 * 2 bytes = 960 bytes per VAD chunk.
+        var options = new ContinuousListenerOptions { SampleRate = 48000, VadChunkMs = 10 };
+
+        Assert.Equal(960, options.ChunkSizeBytes);
+    }
+
+    [Fact]
+    public void PreBufferMaxBytes_ScalesWithSampleRateAndPreBufferMs()
+    {
+        // 16000 * 1000 / 1000 * 2 = 32000 bytes for a one-second pre-buffer at 16kHz.
+        var options = new ContinuousListenerOptions { SampleRate = 16000, PreBufferMs = 1000 };
+
+        Assert.Equal(32000, options.PreBufferMaxBytes);
+    }
+
+    [Fact]
+    public void MaxSegmentBytes_UsesLongMath_ToAvoidInt32Overflow()
+    {
+        // 96kHz * 600s would overflow int32 at the SampleRate*MaxSegmentMs
+        // multiplication step. The computed property promotes to long, so we
+        // should get 96000 * 600000 / 1000 * 2 = 115,200,000 bytes.
+        var options = new ContinuousListenerOptions { SampleRate = 96000, MaxSegmentMs = 600000 };
+
+        Assert.Equal(115_200_000, options.MaxSegmentBytes);
+    }
+
+    [Fact]
+    public void GetFullWhisperModelPath_AbsolutePath_IsReturnedVerbatim()
+    {
+        var abs = Path.Combine(Path.GetTempPath(), "some-model.bin");
+        var options = new ContinuousListenerOptions { WhisperModelPath = abs };
+
+        Assert.Equal(abs, options.GetFullWhisperModelPath());
+    }
+
+    [Fact]
+    public void GetFullWhisperModelPath_RelativeWithSeparator_IsJoinedToBaseDirectory()
+    {
+        // Contains a path separator → falls through the filename-only shortcut
+        // and is combined with AppContext.BaseDirectory.
+        var options = new ContinuousListenerOptions { WhisperModelPath = "models/foo.bin" };
+
+        var expected = Path.Combine(AppContext.BaseDirectory, "models/foo.bin");
+        Assert.Equal(expected, options.GetFullWhisperModelPath());
+    }
+
+    [Fact]
+    public void Defaults_AreReasonableForContinuousListening()
+    {
+        var options = new ContinuousListenerOptions();
+
+        Assert.Equal(16000, options.SampleRate);
+        Assert.Equal(32, options.VadChunkMs);
+        Assert.Equal(1000, options.PreBufferMs);
+        Assert.Equal(1500, options.PostSilenceMs);
+        Assert.Equal(800, options.MinRecordingMs);
+        Assert.Equal("cs", options.WhisperLanguage);
+        Assert.True(options.UseGpu);
+        Assert.Equal(60000, options.MaxSegmentMs);
+        Assert.Equal(5053, options.LogViewerPort);
+        Assert.False(options.StartMuted);
+        Assert.Equal(string.Empty, options.SileroVadModelPath);
+        Assert.Equal(string.Empty, options.WhisperModelPath);
+    }
+}

--- a/tests/VirtualAssistant.Core.Tests/Services/NotificationServiceTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Services/NotificationServiceTests.cs
@@ -1,0 +1,207 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.Data.Cqrs;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Data.Commands.NotificationCommands;
+using Olbrasoft.VirtualAssistant.Data.Entities;
+using Olbrasoft.VirtualAssistant.Data.Enums;
+using Olbrasoft.VirtualAssistant.Data.Queries.NotificationQueries;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.Services;
+
+/// <summary>
+/// Pins the CQRS orchestration inside NotificationService: each public method
+/// must forward to the right command/query, and the early-exit branches
+/// (empty id lists on the batch-update and associated-issue queries) must
+/// skip the executor entirely.
+/// </summary>
+public class NotificationServiceTests
+{
+    private readonly Mock<ICommandExecutor> _commandExecutorMock = new();
+    private readonly Mock<IQueryProcessor> _queryProcessorMock = new();
+    private readonly Mock<ILogger<NotificationService>> _loggerMock = new();
+
+    private NotificationService CreateSut() =>
+        new(_commandExecutorMock.Object, _queryProcessorMock.Object, _loggerMock.Object);
+
+    [Fact]
+    public async Task CreateNotificationAsync_ForwardsAllFieldsToCommand_AndReturnsNewId()
+    {
+        CreateNotificationCommand? captured = null;
+        _commandExecutorMock
+            .Setup(x => x.ExecuteAsync(It.IsAny<ICommand<int>>(), It.IsAny<CancellationToken>()))
+            .Callback<ICommand<int>, CancellationToken>((cmd, _) => captured = (CreateNotificationCommand)cmd)
+            .ReturnsAsync(42);
+
+        var sut = CreateSut();
+        var issueIds = new[] { 1, 2, 3 };
+
+        var id = await sut.CreateNotificationAsync(
+            text: "hello",
+            agentName: "claude-code",
+            issueIds: issueIds,
+            providerName: "anthropic",
+            modelName: "claude-opus-4-7");
+
+        Assert.Equal(42, id);
+        Assert.NotNull(captured);
+        Assert.Equal("hello", captured!.Text);
+        Assert.Equal("claude-code", captured.AgentName);
+        Assert.Equal(issueIds, captured.IssueIds);
+        Assert.Equal("anthropic", captured.ProviderName);
+        Assert.Equal("claude-opus-4-7", captured.ModelName);
+    }
+
+    [Fact]
+    public async Task CreateNotificationAsync_WithoutOptionals_StillDispatchesCommand()
+    {
+        CreateNotificationCommand? captured = null;
+        _commandExecutorMock
+            .Setup(x => x.ExecuteAsync(It.IsAny<ICommand<int>>(), It.IsAny<CancellationToken>()))
+            .Callback<ICommand<int>, CancellationToken>((cmd, _) => captured = (CreateNotificationCommand)cmd)
+            .ReturnsAsync(7);
+
+        var sut = CreateSut();
+        var id = await sut.CreateNotificationAsync("x", "opencode");
+
+        Assert.Equal(7, id);
+        Assert.Null(captured!.IssueIds);
+        Assert.Null(captured.ProviderName);
+        Assert.Null(captured.ModelName);
+    }
+
+    [Fact]
+    public async Task GetNewNotificationsAsync_ForwardsQuery_AndReturnsResult()
+    {
+        var expected = new List<Notification>
+        {
+            new() { Id = 1, Text = "a" },
+            new() { Id = 2, Text = "b" },
+        };
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<IQuery<IReadOnlyList<Notification>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var sut = CreateSut();
+        var result = await sut.GetNewNotificationsAsync();
+
+        Assert.Same(expected, result);
+        _queryProcessorMock.Verify(
+            x => x.ProcessAsync(It.IsAny<GetNewNotificationsQuery>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_Single_ForwardsCommand_WithIdAndStatus()
+    {
+        UpdateNotificationStatusCommand? captured = null;
+        _commandExecutorMock
+            .Setup(x => x.ExecuteAsync(It.IsAny<ICommand<bool>>(), It.IsAny<CancellationToken>()))
+            .Callback<ICommand<bool>, CancellationToken>((cmd, _) => captured = cmd as UpdateNotificationStatusCommand)
+            .ReturnsAsync(true);
+
+        var sut = CreateSut();
+        await sut.UpdateStatusAsync(99, NotificationStatusEnum.Played);
+
+        Assert.NotNull(captured);
+        Assert.Equal(99, captured!.NotificationId);
+        Assert.Equal(NotificationStatusEnum.Played, captured.NewStatus);
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_Batch_EmptyIds_DoesNotInvokeExecutor()
+    {
+        var sut = CreateSut();
+
+        await sut.UpdateStatusAsync(Array.Empty<int>(), NotificationStatusEnum.Played);
+
+        _commandExecutorMock.Verify(
+            x => x.ExecuteAsync(It.IsAny<ICommand<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_Batch_WithIds_ForwardsBatchCommand()
+    {
+        UpdateNotificationStatusBatchCommand? captured = null;
+        _commandExecutorMock
+            .Setup(x => x.ExecuteAsync(It.IsAny<ICommand<int>>(), It.IsAny<CancellationToken>()))
+            .Callback<ICommand<int>, CancellationToken>((cmd, _) => captured = cmd as UpdateNotificationStatusBatchCommand)
+            .ReturnsAsync(3);
+
+        var sut = CreateSut();
+        await sut.UpdateStatusAsync(new[] { 1, 2, 3 }, NotificationStatusEnum.Played);
+
+        Assert.NotNull(captured);
+        Assert.Equal(new[] { 1, 2, 3 }, captured!.NotificationIds);
+        Assert.Equal(NotificationStatusEnum.Played, captured.NewStatus);
+    }
+
+    [Fact]
+    public async Task GetAssociatedIssueIdsAsync_EmptyIds_ReturnsEmpty_WithoutQuerying()
+    {
+        var sut = CreateSut();
+
+        var result = await sut.GetAssociatedIssueIdsAsync(Array.Empty<int>());
+
+        Assert.Empty(result);
+        _queryProcessorMock.Verify(
+            x => x.ProcessAsync(It.IsAny<GetAssociatedIssueIdsQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAssociatedIssueIdsAsync_WithIds_ForwardsQuery_AndReturnsResult()
+    {
+        IReadOnlyList<int> expected = new[] { 100, 200 };
+        GetAssociatedIssueIdsQuery? captured = null;
+        _queryProcessorMock
+            .Setup(x => x.ProcessAsync(It.IsAny<IQuery<IReadOnlyList<int>>>(), It.IsAny<CancellationToken>()))
+            .Callback<IQuery<IReadOnlyList<int>>, CancellationToken>((q, _) => captured = q as GetAssociatedIssueIdsQuery)
+            .ReturnsAsync(expected);
+
+        var sut = CreateSut();
+        var result = await sut.GetAssociatedIssueIdsAsync(new[] { 5, 6 });
+
+        Assert.Equal(expected, result);
+        Assert.NotNull(captured);
+        Assert.Equal(new[] { 5, 6 }, captured!.NotificationIds);
+    }
+
+    [Fact]
+    public async Task RecordTtsOutcomeAsync_ForwardsAllFields_ToCommand()
+    {
+        RecordTtsOutcomeCommand? captured = null;
+        _commandExecutorMock
+            .Setup(x => x.ExecuteAsync(It.IsAny<ICommand<bool>>(), It.IsAny<CancellationToken>()))
+            .Callback<ICommand<bool>, CancellationToken>((cmd, _) => captured = cmd as RecordTtsOutcomeCommand)
+            .ReturnsAsync(true);
+
+        var sut = CreateSut();
+        await sut.RecordTtsOutcomeAsync(77, "azure", "success", 250);
+
+        Assert.NotNull(captured);
+        Assert.Equal(77, captured!.NotificationId);
+        Assert.Equal("azure", captured.ProviderName);
+        Assert.Equal("success", captured.Status);
+        Assert.Equal(250, captured.DurationMs);
+    }
+
+    [Fact]
+    public async Task RecordTtsOutcomeAsync_WithNullProvider_AllowsNullProviderInCommand()
+    {
+        RecordTtsOutcomeCommand? captured = null;
+        _commandExecutorMock
+            .Setup(x => x.ExecuteAsync(It.IsAny<ICommand<bool>>(), It.IsAny<CancellationToken>()))
+            .Callback<ICommand<bool>, CancellationToken>((cmd, _) => captured = cmd as RecordTtsOutcomeCommand)
+            .ReturnsAsync(false);
+
+        var sut = CreateSut();
+        await sut.RecordTtsOutcomeAsync(1, providerName: null, status: "all_failed");
+
+        Assert.NotNull(captured);
+        Assert.Null(captured!.ProviderName);
+        Assert.Equal("all_failed", captured.Status);
+        Assert.Null(captured.DurationMs);
+    }
+}

--- a/tests/VirtualAssistant.Core.Tests/Speech/TranscriptionResultTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Speech/TranscriptionResultTests.cs
@@ -1,0 +1,103 @@
+using Olbrasoft.VirtualAssistant.Core.Speech;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.Speech;
+
+/// <summary>
+/// Pins the two-constructor contract on TranscriptionResult: the success
+/// constructor owns Text/Confidence and nulls ErrorMessage, the failure
+/// constructor zeroes out transcription fields and surfaces the error.
+/// Init-only metadata (LLM duration, token counts, race info) must be
+/// assignable on both shapes so the pipeline can enrich either outcome.
+/// </summary>
+public class TranscriptionResultTests
+{
+    [Fact]
+    public void SuccessConstructor_SetsTextAndConfidence_AndMarksSuccess()
+    {
+        var result = new TranscriptionResult("hello world", 0.95f);
+
+        Assert.Equal("hello world", result.Text);
+        Assert.Equal(0.95f, result.Confidence);
+        Assert.True(result.Success);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void FailureConstructor_ZeroesTextAndConfidence_AndSurfacesError()
+    {
+        var result = new TranscriptionResult("whisper timed out");
+
+        Assert.Equal(string.Empty, result.Text);
+        Assert.Equal(0.0f, result.Confidence);
+        Assert.False(result.Success);
+        Assert.Equal("whisper timed out", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void InitOnlyMetadata_FlowsThroughOnSuccess()
+    {
+        var raceId = Guid.NewGuid();
+        var loserTask = Task.FromResult<Olbrasoft.VirtualAssistant.Core.Models.LlmCorrectionResult?>(null);
+
+        var result = new TranscriptionResult("done", 0.82f)
+        {
+            OriginalText = "raw",
+            FilteredText = "filtered",
+            LlmDurationMs = 120,
+            PromptId = 7,
+            ModelId = 3,
+            SttProviderId = 11,
+            InputTokens = 40,
+            OutputTokens = 8,
+            ReasoningTokens = 2,
+            RaceGroupId = raceId,
+            RacingLoserTask = loserTask,
+            RacingLoserProviderName = "zen",
+        };
+
+        Assert.Equal("raw", result.OriginalText);
+        Assert.Equal("filtered", result.FilteredText);
+        Assert.Equal(120, result.LlmDurationMs);
+        Assert.Equal(7, result.PromptId);
+        Assert.Equal(3, result.ModelId);
+        Assert.Equal(11, result.SttProviderId);
+        Assert.Equal(40, result.InputTokens);
+        Assert.Equal(8, result.OutputTokens);
+        Assert.Equal(2, result.ReasoningTokens);
+        Assert.Equal(raceId, result.RaceGroupId);
+        Assert.Same(loserTask, result.RacingLoserTask);
+        Assert.Equal("zen", result.RacingLoserProviderName);
+    }
+
+    [Fact]
+    public void InitOnlyMetadata_DefaultsToNull_WhenNotSet()
+    {
+        var result = new TranscriptionResult("x", 0.5f);
+
+        Assert.Null(result.OriginalText);
+        Assert.Null(result.FilteredText);
+        Assert.Null(result.LlmDurationMs);
+        Assert.Null(result.PromptId);
+        Assert.Null(result.ModelId);
+        Assert.Null(result.SttProviderId);
+        Assert.Null(result.InputTokens);
+        Assert.Null(result.OutputTokens);
+        Assert.Null(result.ReasoningTokens);
+        Assert.Null(result.RaceGroupId);
+        Assert.Null(result.RacingLoserTask);
+        Assert.Null(result.RacingLoserProviderName);
+    }
+
+    [Fact]
+    public void SuccessConstructor_AcceptsEmptyText_AndZeroConfidence()
+    {
+        // The pipeline emits empty-text successes for silent audio; pin that
+        // this doesn't get conflated with the failure path.
+        var result = new TranscriptionResult(string.Empty, 0f);
+
+        Assert.Equal(string.Empty, result.Text);
+        Assert.Equal(0f, result.Confidence);
+        Assert.True(result.Success);
+        Assert.Null(result.ErrorMessage);
+    }
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Advances #979 (raise Core coverage from ~16%). Phase A — three focused test files on previously untested logic-bearing units, 22 new tests total.

## Summary

- **TranscriptionResultTests** (5 cases): pins the two-constructor contract (success vs failure shape), init-only metadata flow-through, and the empty-text-on-success edge case for silent audio.
- **NotificationServiceTests** (10 cases): covers every public method on `NotificationService` via `IQueryProcessor`/`ICommandExecutor` mocks, including the two early-exit branches (empty `NotificationIds` and empty issue-id list) that must skip executor invocation.
- **ContinuousListenerOptionsTests** (7 cases): pins the byte-math computed properties (`ChunkSizeBytes`, `PreBufferMaxBytes`, `MaxSegmentBytes` with long-cast overflow safety at 96 kHz × 600 s), the absolute-path and relative-with-separator branches of `GetFullWhisperModelPath`, and the default values downstream audio code depends on.

Filesystem- and subprocess-heavy classes (`WhisperModelLocator`, `XDoToolKeyboardService`, `TerminalCliAppDetector`) deferred to later phases that will need process abstractions.

## Test plan

- [x] `dotnet build` green
- [x] `dotnet test tests/VirtualAssistant.Core.Tests/` = 133/133 pass locally (22 new + 111 existing)
- [ ] CI green