### PR TITLE
refactor(dictation): extract IDictationOutputChannel from DictationWorker (#969 partial)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.SignalR;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Infrastructure;
 using Olbrasoft.VirtualAssistant.Service.Workers;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 using Olbrasoft.VirtualAssistant.Voice.Configuration;
 using Olbrasoft.VirtualAssistant.Voice.Filters;
@@ -49,17 +50,24 @@ public static class WorkerServicesExtensions
                 sp.GetRequiredService<ILogger<StreamingChunkAssembler>>(),
                 transcription);
 
+            // Bundle the four output-surface dependencies (sounds, keyboard,
+            // SignalR) behind a single IDictationOutputChannel so the worker
+            // ctor shrinks by three deps. (#969 god-class split.)
+            var outputChannel = new DictationOutputChannel(
+                sp.GetRequiredService<ILogger<DictationOutputChannel>>(),
+                sp.GetRequiredService<IKeyboardSimulationService>(),
+                sp.GetRequiredKeyedService<ISoundEffectPlayer>("typing"),
+                sp.GetRequiredKeyedService<ISoundEffectPlayer>("cancel"),
+                sp.GetRequiredService<IHubContext<DictationHub>>());
+
             return new DictationWorker(
                 sp.GetRequiredService<ILogger<DictationWorker>>(),
                 sp.GetRequiredService<IKeyboardMonitor>(),
                 sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
                 sp.GetRequiredKeyedService<IAudioRecordingCoordinator>(DictationKey),
                 transcription,
-                sp.GetRequiredService<IKeyboardSimulationService>(),
-                sp.GetRequiredKeyedService<ISoundEffectPlayer>("typing"),
-                sp.GetRequiredKeyedService<ISoundEffectPlayer>("cancel"),
+                outputChannel,
                 sp.GetRequiredService<IServiceScopeFactory>(),
-                sp.GetRequiredService<IHubContext<DictationHub>>(),
                 sp.GetRequiredService<ICliAppDetector>(),
                 assembler,
                 sp.GetRequiredService<IOptions<DictationOptions>>());

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationOutputChannel.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationOutputChannel.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.SignalR;
+using Olbrasoft.VirtualAssistant.Core.Audio;
+using Olbrasoft.VirtualAssistant.Core.Keyboard;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationOutputChannel : IDictationOutputChannel
+{
+    private readonly ILogger<DictationOutputChannel> _logger;
+    private readonly IKeyboardSimulationService _keyboardSimulation;
+    private readonly ISoundEffectPlayer _typingSound;
+    private readonly ISoundEffectPlayer _cancelSound;
+    private readonly IHubContext<DictationHub> _hubContext;
+
+    public DictationOutputChannel(
+        ILogger<DictationOutputChannel> logger,
+        IKeyboardSimulationService keyboardSimulation,
+        ISoundEffectPlayer typingSound,
+        ISoundEffectPlayer cancelSound,
+        IHubContext<DictationHub> hubContext)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _keyboardSimulation = keyboardSimulation ?? throw new ArgumentNullException(nameof(keyboardSimulation));
+        _typingSound = typingSound ?? throw new ArgumentNullException(nameof(typingSound));
+        _cancelSound = cancelSound ?? throw new ArgumentNullException(nameof(cancelSound));
+        _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
+    }
+
+    public void StartTypingFeedback() => _typingSound.StartLoop();
+
+    public void StopTypingFeedback() => _typingSound.StopLoop();
+
+    public void PlayCancelCue() => _cancelSound.Play();
+
+    public Task<bool> FastPasteAsync(string text, CancellationToken cancellationToken) =>
+        _keyboardSimulation.FastPasteAsync(text, cancellationToken);
+
+    public Task<bool> TypeIntoActiveWindowAsync(string text, CancellationToken cancellationToken) =>
+        _keyboardSimulation.TypeIntoActiveWindowAsync(text, cancellationToken);
+
+    public async Task BroadcastEventAsync(DictationEventType eventType, string? text, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _hubContext.Clients.All.SendAsync(
+                "DictationEvent",
+                new DictationEvent { EventType = eventType, Text = text },
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Broadcasting is best-effort — a SignalR client-side failure must
+            // not take down the dictation pipeline itself.
+            _logger.LogDebug(ex, "Failed to broadcast dictation event to SignalR clients");
+        }
+    }
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationOutputChannel.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationOutputChannel.cs
@@ -1,0 +1,42 @@
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Output surface the dictation worker talks to when producing user-visible
+/// feedback: the typing cue loop, the cancel earcon, the keyboard-injection
+/// backends, and the SignalR broadcast stream. Bundled behind one interface
+/// so <c>DictationWorker</c> depends on a single abstraction instead of the
+/// four disparate services these calls previously required (#969 god-class
+/// split).
+/// </summary>
+public interface IDictationOutputChannel
+{
+    /// <summary>Starts the looped "typing" sound cue that accompanies dictation.</summary>
+    void StartTypingFeedback();
+
+    /// <summary>Stops the looped "typing" sound cue. Safe to call when already stopped.</summary>
+    void StopTypingFeedback();
+
+    /// <summary>Plays the one-shot cancel earcon (used when dictation is aborted).</summary>
+    void PlayCancelCue();
+
+    /// <summary>
+    /// Pastes the supplied text via the platform-native fast path (clipboard
+    /// + paste shortcut), returning true if the paste succeeded.
+    /// </summary>
+    Task<bool> FastPasteAsync(string text, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Types the supplied text into the currently-focused window one character
+    /// at a time, returning true if the injection succeeded.
+    /// </summary>
+    Task<bool> TypeIntoActiveWindowAsync(string text, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Broadcasts a dictation event to all SignalR clients subscribed to the
+    /// dictation hub. Swallows transport errors so a client-side failure
+    /// cannot take down the dictation worker.
+    /// </summary>
+    Task BroadcastEventAsync(DictationEventType eventType, string? text, CancellationToken cancellationToken = default);
+}

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -1,8 +1,6 @@
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
 using Olbrasoft.VirtualAssistant.Core.Audio;
 using Olbrasoft.VirtualAssistant.Core.Configuration;
-using Olbrasoft.VirtualAssistant.Core.Keyboard;
 using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
@@ -11,6 +9,7 @@ using Olbrasoft.VirtualAssistant.Voice.Services;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 
 namespace Olbrasoft.VirtualAssistant.Service.Workers;
@@ -27,11 +26,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly IDictationStateMachine _stateMachine;
     private readonly IAudioRecordingCoordinator _recordingCoordinator;
     private readonly ITranscriptionService _transcriptionService;
-    private readonly IKeyboardSimulationService _keyboardSimulation;
-    private readonly ISoundEffectPlayer _typingSound;
-    private readonly ISoundEffectPlayer _cancelSound;
+    private readonly IDictationOutputChannel _outputChannel;
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IHubContext<DictationHub> _hubContext;
     private readonly ICliAppDetector _cliAppDetector;
     private readonly IStreamingChunkAssembler _streamingAssembler;
     private readonly DictationOptions _options;
@@ -53,11 +49,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         IDictationStateMachine stateMachine,
         IAudioRecordingCoordinator recordingCoordinator,
         ITranscriptionService transcriptionService,
-        IKeyboardSimulationService keyboardSimulation,
-        ISoundEffectPlayer typingSound,
-        ISoundEffectPlayer cancelSound,
+        IDictationOutputChannel outputChannel,
         IServiceScopeFactory scopeFactory,
-        IHubContext<DictationHub> hubContext,
         ICliAppDetector cliAppDetector,
         IStreamingChunkAssembler streamingAssembler,
         IOptions<DictationOptions> options)
@@ -67,11 +60,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
         _recordingCoordinator = recordingCoordinator ?? throw new ArgumentNullException(nameof(recordingCoordinator));
         _transcriptionService = transcriptionService ?? throw new ArgumentNullException(nameof(transcriptionService));
-        _keyboardSimulation = keyboardSimulation ?? throw new ArgumentNullException(nameof(keyboardSimulation));
-        _typingSound = typingSound ?? throw new ArgumentNullException(nameof(typingSound));
-        _cancelSound = cancelSound ?? throw new ArgumentNullException(nameof(cancelSound));
+        _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
-        _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
         _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
         _streamingAssembler = streamingAssembler ?? throw new ArgumentNullException(nameof(streamingAssembler));
         ArgumentNullException.ThrowIfNull(options);
@@ -337,21 +327,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _streamingAssembler.SubmitChunk(e.Index, e.PcmBytes);
     }
 
-    private async Task BroadcastDictationEventAsync(DictationEventType eventType, string? text)
-    {
-        try
-        {
-            await _hubContext.Clients.All.SendAsync("DictationEvent", new DictationEvent
-            {
-                EventType = eventType,
-                Text = text
-            });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to broadcast dictation event to SignalR clients");
-        }
-    }
+    private Task BroadcastDictationEventAsync(DictationEventType eventType, string? text) =>
+        _outputChannel.BroadcastEventAsync(eventType, text);
 
     private async Task StartRecordingAsync()
     {
@@ -420,14 +397,14 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
                 if (string.IsNullOrWhiteSpace(textToPaste))
                 {
                     _logger.LogInformation("Quick dictation: transcription reduced to empty after civility trim — skipping paste");
-                    _typingSound.StopLoop();
+                    _outputChannel.StopTypingFeedback();
                     _stateMachine.TransitionTo(DictationState.Idle);
                     return;
                 }
 
                 // Quick mode: fast paste without clipboard save/restore
-                var pasteSucceeded = await _keyboardSimulation.FastPasteAsync(textToPaste, _transcriptionCts!.Token);
-                _typingSound.StopLoop();
+                var pasteSucceeded = await _outputChannel.FastPasteAsync(textToPaste, _transcriptionCts!.Token);
+                _outputChannel.StopTypingFeedback();
 
                 if (!pasteSucceeded)
                 {
@@ -451,13 +428,13 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         catch (OperationCanceledException)
         {
             _logger.LogInformation("Transcription canceled by user");
-            _typingSound.StopLoop();
+            _outputChannel.StopTypingFeedback();
             _stateMachine.TransitionTo(DictationState.Idle);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error during transcription");
-            _typingSound.StopLoop();
+            _outputChannel.StopTypingFeedback();
             _stateMachine.TransitionTo(DictationState.Idle);
         }
         finally
@@ -507,7 +484,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     /// </summary>
     private async Task<TranscriptionResult?> TranscribeRawWithSoundAsync(byte[] audioData)
     {
-        _typingSound.StartLoop();
+        _outputChannel.StartTypingFeedback();
         _transcriptionCts = new CancellationTokenSource();
 
         TranscriptionResult result;
@@ -535,7 +512,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
         {
             _logger.LogWarning("Quick transcription failed or empty");
-            _typingSound.StopLoop();
+            _outputChannel.StopTypingFeedback();
             _stateMachine.TransitionTo(DictationState.Idle);
             return null;
         }
@@ -550,7 +527,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     /// </summary>
     private async Task<TranscriptionResult?> TranscribeAudioWithSoundAsync(byte[] audioData)
     {
-        _typingSound.StartLoop();
+        _outputChannel.StartTypingFeedback();
         _transcriptionCts = new CancellationTokenSource();
 
         var result = await _transcriptionService.TranscribeAsync(audioData, _transcriptionCts.Token);
@@ -558,7 +535,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
         {
             _logger.LogWarning("Transcription failed or empty");
-            _typingSound.StopLoop();
+            _outputChannel.StopTypingFeedback();
             _stateMachine.TransitionTo(DictationState.Idle);
             return null;
         }
@@ -672,9 +649,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     /// </summary>
     private async Task TypeTextAndFinishAsync(string text)
     {
-        var typed = await _keyboardSimulation.TypeIntoActiveWindowAsync(text, _transcriptionCts!.Token);
+        var typed = await _outputChannel.TypeIntoActiveWindowAsync(text, _transcriptionCts!.Token);
 
-        _typingSound.StopLoop();
+        _outputChannel.StopTypingFeedback();
 
         if (!typed)
         {
@@ -697,7 +674,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             await _recordingCoordinator.EmergencyStopAsync();
 
             // Play cancel sound (paper-rip effect)
-            _cancelSound.Play();
+            _outputChannel.PlayCancelCue();
 
             // Return to Idle without transcription
             _stateMachine.TransitionTo(DictationState.Idle);
@@ -740,10 +717,10 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _logger.LogInformation("CancelTranscription called in state {State}", currentState);
 
             // Stop typing sound immediately
-            _typingSound.StopLoop();
+            _outputChannel.StopTypingFeedback();
 
             // Play cancel sound (paper-rip effect)
-            _cancelSound.Play();
+            _outputChannel.PlayCancelCue();
 
             // If still recording, stop audio capture and discard buffer.
             // Must complete before resetting streaming state so no more

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationOutputChannelTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationOutputChannelTests.cs
@@ -1,0 +1,123 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Audio;
+using Olbrasoft.VirtualAssistant.Core.Keyboard;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the façade contract lifted out of DictationWorker in #969 — each
+/// method forwards to the right dependency, and the broadcast path swallows
+/// SignalR transport errors so a client-side failure cannot take down the
+/// dictation pipeline.
+/// </summary>
+public class DictationOutputChannelTests
+{
+    private readonly Mock<ILogger<DictationOutputChannel>> _loggerMock = new();
+    private readonly Mock<IKeyboardSimulationService> _keyboardMock = new();
+    private readonly Mock<ISoundEffectPlayer> _typingMock = new();
+    private readonly Mock<ISoundEffectPlayer> _cancelMock = new();
+    private readonly Mock<IHubContext<DictationHub>> _hubMock = new();
+    private readonly Mock<IHubClients> _clientsMock = new();
+    private readonly Mock<IClientProxy> _allClientsMock = new();
+
+    private DictationOutputChannel CreateSut()
+    {
+        _hubMock.SetupGet(x => x.Clients).Returns(_clientsMock.Object);
+        _clientsMock.SetupGet(x => x.All).Returns(_allClientsMock.Object);
+        return new DictationOutputChannel(
+            _loggerMock.Object, _keyboardMock.Object, _typingMock.Object, _cancelMock.Object, _hubMock.Object);
+    }
+
+    [Fact]
+    public void StartTypingFeedback_CallsTypingPlayerStartLoop()
+    {
+        var sut = CreateSut();
+        sut.StartTypingFeedback();
+        _typingMock.Verify(x => x.StartLoop(), Times.Once);
+    }
+
+    [Fact]
+    public void StopTypingFeedback_CallsTypingPlayerStopLoop()
+    {
+        var sut = CreateSut();
+        sut.StopTypingFeedback();
+        _typingMock.Verify(x => x.StopLoop(), Times.Once);
+    }
+
+    [Fact]
+    public void PlayCancelCue_CallsCancelPlayerPlay()
+    {
+        var sut = CreateSut();
+        sut.PlayCancelCue();
+        _cancelMock.Verify(x => x.Play(), Times.Once);
+    }
+
+    [Fact]
+    public async Task FastPasteAsync_ForwardsToKeyboardService()
+    {
+        _keyboardMock
+            .Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var sut = CreateSut();
+        var result = await sut.FastPasteAsync("hello", CancellationToken.None);
+
+        Assert.True(result);
+        _keyboardMock.Verify(x => x.FastPasteAsync("hello", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TypeIntoActiveWindowAsync_ForwardsToKeyboardService()
+    {
+        _keyboardMock
+            .Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var sut = CreateSut();
+        var result = await sut.TypeIntoActiveWindowAsync("text", CancellationToken.None);
+
+        Assert.False(result);
+        _keyboardMock.Verify(x => x.TypeIntoActiveWindowAsync("text", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task BroadcastEventAsync_SendsDictationEventToAllClients()
+    {
+        object?[]? capturedArgs = null;
+        _allClientsMock
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((_, args, _) => capturedArgs = args)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        await sut.BroadcastEventAsync(DictationEventType.RecordingStarted, "hello");
+
+        Assert.NotNull(capturedArgs);
+        Assert.Single(capturedArgs!);
+        var evt = Assert.IsType<DictationEvent>(capturedArgs![0]);
+        Assert.Equal(DictationEventType.RecordingStarted, evt.EventType);
+        Assert.Equal("hello", evt.Text);
+    }
+
+    [Fact]
+    public async Task BroadcastEventAsync_SwallowsHubTransportException()
+    {
+        // A faulted hub send must not bubble out — the dictation pipeline is
+        // allowed to keep running even if every SignalR client is gone. The
+        // channel catches the exception at LogDebug level.
+        _allClientsMock
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("clients gone"));
+
+        var sut = CreateSut();
+
+        var ex = await Record.ExceptionAsync(() =>
+            sut.BroadcastEventAsync(DictationEventType.TranscriptionCompleted, null));
+
+        Assert.Null(ex);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -6,14 +5,13 @@ using Moq;
 using Olbrasoft.Testing.Xunit.Attributes;
 using Olbrasoft.VirtualAssistant.Core.Audio;
 using Olbrasoft.VirtualAssistant.Core.Configuration;
-using Olbrasoft.VirtualAssistant.Core.Keyboard;
 using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Core.WindowManagement;
-using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Workers;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 using Olbrasoft.VirtualAssistant.Voice.Services;
 using Olbrasoft.VirtualAssistant.Voice.StateMachine;
@@ -27,14 +25,11 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IDictationStateMachine> _stateMachineMock;
     private readonly Mock<IAudioRecordingCoordinator> _recordingCoordinatorMock;
     private readonly Mock<ITranscriptionService> _transcriptionServiceMock;
-    private readonly Mock<IKeyboardSimulationService> _keyboardSimulationMock;
-    private readonly Mock<ISoundEffectPlayer> _typingSoundMock;
-    private readonly Mock<ISoundEffectPlayer> _cancelSoundMock;
+    private readonly Mock<IDictationOutputChannel> _outputChannelMock;
     private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
     private readonly Mock<IServiceScope> _scopeMock;
     private readonly Mock<IServiceProvider> _serviceProviderMock;
     private readonly Mock<IDictationPersistenceService> _persistenceServiceMock;
-    private readonly Mock<IHubContext<DictationHub>> _hubContextMock;
     private readonly Mock<ICliAppDetector> _cliAppDetectorMock;
     private readonly Mock<IStreamingChunkAssembler> _streamingAssemblerMock;
     private readonly DictationOptions _options;
@@ -49,15 +44,11 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock = new Mock<IDictationStateMachine>();
         _recordingCoordinatorMock = new Mock<IAudioRecordingCoordinator>();
         _transcriptionServiceMock = new Mock<ITranscriptionService>();
-        _keyboardSimulationMock = new Mock<IKeyboardSimulationService>();
-        _typingSoundMock = new Mock<ISoundEffectPlayer>();
-        _cancelSoundMock = new Mock<ISoundEffectPlayer>();
+        _outputChannelMock = new Mock<IDictationOutputChannel>();
         _scopeFactoryMock = new Mock<IServiceScopeFactory>();
         _scopeMock = new Mock<IServiceScope>();
         _serviceProviderMock = new Mock<IServiceProvider>();
         _persistenceServiceMock = new Mock<IDictationPersistenceService>();
-        _hubContextMock = new Mock<IHubContext<DictationHub>>();
-        _hubContextMock.Setup(x => x.Clients).Returns(Mock.Of<IHubClients>());
         _cliAppDetectorMock = new Mock<ICliAppDetector>();
         _streamingAssemblerMock = new Mock<IStreamingChunkAssembler>();
 
@@ -79,11 +70,8 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options));
@@ -100,11 +88,8 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
@@ -119,11 +104,8 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
@@ -138,11 +120,8 @@ public class DictationWorkerTests : IDisposable
             null!,
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
@@ -157,11 +136,8 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
             null!));
@@ -176,11 +152,8 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             null!,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
@@ -195,18 +168,15 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
             null!,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
     [Fact]
-    public void Constructor_NullKeyboardSimulation_ThrowsArgumentNullException()
+    public void Constructor_NullOutputChannel_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object,
@@ -215,48 +185,7 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             null!,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
-            _cliAppDetectorMock.Object,
-            _streamingAssemblerMock.Object,
-            Options.Create(_options)));
-    }
-
-    [Fact]
-    public void Constructor_NullTypingSound_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            null!,
-            _cancelSoundMock.Object,
-            _scopeFactoryMock.Object,
-            _hubContextMock.Object,
-            _cliAppDetectorMock.Object,
-            _streamingAssemblerMock.Object,
-            Options.Create(_options)));
-    }
-
-    [Fact]
-    public void Constructor_NullCancelSound_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            null!,
-            _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
@@ -271,29 +200,7 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
-            null!,
-            _hubContextMock.Object,
-            _cliAppDetectorMock.Object,
-            _streamingAssemblerMock.Object,
-            Options.Create(_options)));
-    }
-
-    [Fact]
-    public void Constructor_NullHubContext_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
-            _scopeFactoryMock.Object,
+            _outputChannelMock.Object,
             null!,
             _cliAppDetectorMock.Object,
             _streamingAssemblerMock.Object,
@@ -309,11 +216,8 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             null!,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
@@ -328,11 +232,8 @@ public class DictationWorkerTests : IDisposable
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
-            _keyboardSimulationMock.Object,
-            _typingSoundMock.Object,
-            _cancelSoundMock.Object,
+            _outputChannelMock.Object,
             _scopeFactoryMock.Object,
-            _hubContextMock.Object,
             _cliAppDetectorMock.Object,
             null!,
             Options.Create(_options)));
@@ -492,8 +393,8 @@ public class DictationWorkerTests : IDisposable
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Pause, IsPressed = false });
         await Task.Delay(100);
 
-        _typingSoundMock.Verify(x => x.StopLoop(), Times.Once);
-        _cancelSoundMock.Verify(x => x.Play(), Times.Once);
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
     }
 
@@ -510,7 +411,7 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(100);
 
         _recordingCoordinatorMock.Verify(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()), Times.Once);
-        _cancelSoundMock.Verify(x => x.Play(), Times.Once);
+        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
     }
 
@@ -532,7 +433,7 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(audioData);
         _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
-        _keyboardSimulationMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         _persistenceServiceMock.Setup(x => x.SaveTranscriptionAsync(
                 It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<LlmCorrectionResult?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -542,7 +443,7 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(300);
 
         _recordingCoordinatorMock.Verify(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()), Times.Once);
-        _typingSoundMock.Verify(x => x.StartLoop(), Times.Once);
+        _outputChannelMock.Verify(x => x.StartTypingFeedback(), Times.Once);
         _transcriptionServiceMock.Verify(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -605,7 +506,7 @@ public class DictationWorkerTests : IDisposable
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(300);
 
-        _typingSoundMock.Verify(x => x.StopLoop(), Times.AtLeastOnce);
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.AtLeastOnce);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
     }
 
@@ -629,7 +530,7 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(audioData);
         _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
-        _keyboardSimulationMock.Setup(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()))
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         _persistenceServiceMock.Setup(x => x.SaveTranscriptionAsync(
                 audioData, "Hello world", null, expectedProviderId, It.IsAny<CancellationToken>()))
@@ -638,10 +539,10 @@ public class DictationWorkerTests : IDisposable
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(400);
 
-        _keyboardSimulationMock.Verify(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()), Times.Once);
+        _outputChannelMock.Verify(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()), Times.Once);
         _persistenceServiceMock.Verify(x => x.SaveTranscriptionAsync(
             audioData, "Hello world", null, expectedProviderId, It.IsAny<CancellationToken>()), Times.Once);
-        _typingSoundMock.Verify(x => x.StopLoop(), Times.AtLeastOnce);
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.AtLeastOnce);
     }
 
     [SkipOnCIFact]
@@ -665,7 +566,7 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(audioData);
         _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
-        _keyboardSimulationMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         _persistenceServiceMock.Setup(x => x.SaveTranscriptionAsync(
                 It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<LlmCorrectionResult?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -704,7 +605,7 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(audioData);
         _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
-        _keyboardSimulationMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         _persistenceServiceMock.Setup(x => x.SaveTranscriptionAsync(
                 It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<LlmCorrectionResult?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -713,7 +614,7 @@ public class DictationWorkerTests : IDisposable
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(400);
 
-        _typingSoundMock.Verify(x => x.StopLoop(), Times.AtLeastOnce);
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.AtLeastOnce);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
     }
 
@@ -787,7 +688,7 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(audioData);
         _transcriptionServiceMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
-        _keyboardSimulationMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _outputChannelMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         await _sut.StopDictationAsync();
@@ -798,8 +699,8 @@ public class DictationWorkerTests : IDisposable
         _transcriptionServiceMock.Verify(x => x.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
 
         // Verify FastPaste used (not TypeIntoActiveWindow)
-        _keyboardSimulationMock.Verify(x => x.FastPasteAsync("Quick test", It.IsAny<CancellationToken>()), Times.Once);
-        _keyboardSimulationMock.Verify(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _outputChannelMock.Verify(x => x.FastPasteAsync("Quick test", It.IsAny<CancellationToken>()), Times.Once);
+        _outputChannelMock.Verify(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [SkipOnCIFact]
@@ -820,7 +721,7 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(audioData);
         _transcriptionServiceMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
-        _keyboardSimulationMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _outputChannelMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         await _sut.StopDictationAsync();
@@ -862,7 +763,7 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(audioData);
         _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
-        _keyboardSimulationMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Second step in the #969 god-class split (parent #967). The worker previously owned four separate output-surface dependencies — `IKeyboardSimulationService`, two `ISoundEffectPlayer` instances, `IHubContext<DictationHub>` — and called into them directly from 14 call sites spread across the recording, transcription, and cancel paths.

## Summary

- Introduces `IDictationOutputChannel` + `DictationOutputChannel` facade that bundles:
  - typing-feedback loop (`StartTypingFeedback`/`StopTypingFeedback`)
  - cancel earcon (`PlayCancelCue`)
  - keyboard injection (`FastPasteAsync`, `TypeIntoActiveWindowAsync`)
  - SignalR broadcast (`BroadcastEventAsync`, with `LogDebug`-and-swallow for transport failures so a dead client cannot take down the pipeline).
- `DictationWorker` shrinks from **13 → 10 ctor deps** and **811 → 788 LOC**; `BroadcastDictationEventAsync` becomes a one-line delegate.
- Worker factory in `WorkerServicesExtensions` constructs the channel inline (same pattern as `StreamingChunkAssembler`) because the keyed sound-effect players and the hub context need service-provider lookup.

## Tests

- `DictationWorkerTests` ctor swap — removes four null-arg tests for the bundled deps, adds `Constructor_NullOutputChannel`, and switches all `Verify`/`Setup` sites to the new single channel mock.
- New `DictationOutputChannelTests` (7 cases): each method forwards to the right dependency; the broadcast path sends the correct `DictationEvent` payload; a thrown hub send is swallowed.

## Progress for #969

- ctor deps: **10** (target ≤ 5)
- worker LOC: **788** (target ≤ 400)
- Remaining extractions (recording/transcription orchestration) deferred to the next phase — this PR stops here to keep the diff reviewable.

## Test plan

- [x] `dotnet build` green
- [x] `dotnet test tests/VirtualAssistant.Service.Tests/` = 346/346 pass locally (+7 new channel tests)
- [ ] CI green
- [ ] Post-deploy dictation smoke (CapsLock recording → paste into chat app) — quick vs typed paths still end in Idle and play correct sound cues