### PR TITLE
refactor(dictation): extract persister + civility trimmer from DictationWorker (#969 partial)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -60,6 +60,16 @@ public static class WorkerServicesExtensions
                 sp.GetRequiredKeyedService<ISoundEffectPlayer>("cancel"),
                 sp.GetRequiredService<IHubContext<DictationHub>>());
 
+            // Persistence + civility trimmer are constructed inline alongside
+            // the worker so each step in the DictationWorker factory is
+            // flat and individually testable. (#969 extractions.)
+            var persister = new DictationTranscriptionPersister(
+                sp.GetRequiredService<IServiceScopeFactory>());
+
+            var civilityTrimmer = new ClaudeCodeCivilityTrimmer(
+                sp.GetRequiredService<ILogger<ClaudeCodeCivilityTrimmer>>(),
+                sp.GetRequiredService<ICliAppDetector>());
+
             return new DictationWorker(
                 sp.GetRequiredService<ILogger<DictationWorker>>(),
                 sp.GetRequiredService<IKeyboardMonitor>(),
@@ -67,8 +77,8 @@ public static class WorkerServicesExtensions
                 sp.GetRequiredKeyedService<IAudioRecordingCoordinator>(DictationKey),
                 transcription,
                 outputChannel,
-                sp.GetRequiredService<IServiceScopeFactory>(),
-                sp.GetRequiredService<ICliAppDetector>(),
+                persister,
+                civilityTrimmer,
                 assembler,
                 sp.GetRequiredService<IOptions<DictationOptions>>());
         });

--- a/src/VirtualAssistant.Service/Workers/Dictation/ClaudeCodeCivilityTrimmer.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/ClaudeCodeCivilityTrimmer.cs
@@ -1,0 +1,58 @@
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class ClaudeCodeCivilityTrimmer : IClaudeCodeCivilityTrimmer
+{
+    private const string ClaudeCodeAppName = "Claude Code";
+
+    private readonly ILogger<ClaudeCodeCivilityTrimmer> _logger;
+    private readonly ICliAppDetector _cliAppDetector;
+
+    public ClaudeCodeCivilityTrimmer(
+        ILogger<ClaudeCodeCivilityTrimmer> logger,
+        ICliAppDetector cliAppDetector)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+    }
+
+    public async Task<string> TrimIfClaudeCodeAsync(string text, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return text;
+        }
+
+        CliAppDetectionResult? cliApp;
+        try
+        {
+            cliApp = await _cliAppDetector.DetectCliAppAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "CLI app detection failed before quick paste — skipping civility trim");
+            return text;
+        }
+
+        if (cliApp is null || !string.Equals(cliApp.AppName, ClaudeCodeAppName, StringComparison.OrdinalIgnoreCase))
+        {
+            return text;
+        }
+
+        var stripped = CivilityTrimmer.StripTrailingCivility(text);
+        if (stripped.Length != text.Length)
+        {
+            _logger.LogInformation(
+                "Quick dictation: stripped trailing civility for Claude Code ({Before} → {After} chars)",
+                text.Length, stripped.Length);
+        }
+        return stripped;
+    }
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationTranscriptionPersister.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationTranscriptionPersister.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.DependencyInjection;
+using Olbrasoft.VirtualAssistant.Core.Models;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.Speech;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationTranscriptionPersister : IDictationTranscriptionPersister
+{
+    // provider_id has a FK constraint on the transcriptions table; when the
+    // active transcriber hasn't set SttProviderId (legacy code path) we fall
+    // back to Whisper so the insert doesn't violate the constraint.
+    private const int WhisperProviderId = 13;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public DictationTranscriptionPersister(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+    }
+
+    public async Task SaveAsync(byte[] audioData, TranscriptionResult result, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(audioData);
+        ArgumentNullException.ThrowIfNull(result);
+
+        // DictationWorker is a singleton but IDictationPersistenceService is
+        // scoped (per-DbContext) — create a fresh scope for each save.
+        using var scope = _scopeFactory.CreateScope();
+        var persistenceService = scope.ServiceProvider.GetRequiredService<IDictationPersistenceService>();
+
+        var originalText = result.OriginalText ?? result.Text;
+        var correctionResult = BuildCorrectionResult(result);
+        var sttProviderId = result.SttProviderId.GetValueOrDefault(WhisperProviderId);
+
+        if (result.RaceGroupId.HasValue)
+        {
+            await persistenceService.SaveTranscriptionWithRacingAsync(
+                audioData,
+                originalText,
+                correctionResult,
+                sttProviderId,
+                result.RaceGroupId.Value,
+                result.RacingLoserTask,
+                cancellationToken);
+        }
+        else
+        {
+            await persistenceService.SaveTranscriptionAsync(
+                audioData,
+                originalText,
+                correctionResult,
+                sttProviderId,
+                cancellationToken);
+        }
+    }
+
+    private static LlmCorrectionResult? BuildCorrectionResult(TranscriptionResult result)
+    {
+        // Only build a correction result when the LLM actually corrected the
+        // text (OriginalText differs from Text AND we have a model id AND
+        // non-zero duration). Partial or missing metadata means no correction
+        // ran — persistence treats null as "no correction".
+        var hasCorrection = result.OriginalText != null
+            && result.Text != result.OriginalText;
+
+        if (!hasCorrection || !result.ModelId.HasValue || result.LlmDurationMs.GetValueOrDefault() <= 0)
+        {
+            return null;
+        }
+
+        return new LlmCorrectionResult(
+            CorrectedText: result.Text,
+            PromptId: result.PromptId,
+            DurationMs: result.LlmDurationMs.Value,
+            ModelId: result.ModelId,
+            InputTokens: result.InputTokens,
+            OutputTokens: result.OutputTokens,
+            ReasoningTokens: result.ReasoningTokens);
+    }
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IClaudeCodeCivilityTrimmer.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IClaudeCodeCivilityTrimmer.cs
@@ -1,0 +1,21 @@
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Applies <c>CivilityTrimmer</c> to dictated text, but only when the active
+/// CLI agent is Claude Code — per the feature request, "Děkuji." is a
+/// legitimate message in chat apps and must pass through untouched. Lifts
+/// the <c>ICliAppDetector</c> dependency out of <c>DictationWorker</c> so
+/// detection errors are contained here (they fall back to returning the
+/// text unchanged, because one stray civility word is cheaper than
+/// mangling valid input when gdbus hiccups).
+/// </summary>
+public interface IClaudeCodeCivilityTrimmer
+{
+    /// <summary>
+    /// Returns the input text trimmed of trailing civility if the currently-
+    /// focused CLI app is Claude Code; otherwise returns <paramref name="text"/>
+    /// unchanged. Propagates <see cref="OperationCanceledException"/>; swallows
+    /// other detection errors as "no trim".
+    /// </summary>
+    Task<string> TrimIfClaudeCodeAsync(string text, CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationTranscriptionPersister.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationTranscriptionPersister.cs
@@ -1,0 +1,27 @@
+using Olbrasoft.VirtualAssistant.Core.Speech;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Owns the "save a completed dictation session to the database" side-quest
+/// that used to live inline on <c>DictationWorker</c>. Encapsulates:
+/// <list type="bullet">
+///   <item>constructing the <c>LlmCorrectionResult</c> from the optional
+///         LLM-correction metadata on <see cref="TranscriptionResult"/>;</item>
+///   <item>applying the Whisper (id = 13) fallback when the active transcriber
+///         hasn't set <c>SttProviderId</c>;</item>
+///   <item>dispatching between the racing-aware and single-provider persistence
+///         overloads based on <c>RaceGroupId</c>;</item>
+///   <item>creating and disposing the scoped DI scope for the scoped
+///         <c>IDictationPersistenceService</c>.</item>
+/// </list>
+/// Lifts <c>IServiceScopeFactory</c> out of the worker's ctor (#969 split).
+/// </summary>
+public interface IDictationTranscriptionPersister
+{
+    /// <summary>
+    /// Persists the completed transcription, honoring racing metadata when
+    /// present. Propagates cancellation via <paramref name="cancellationToken"/>.
+    /// </summary>
+    Task SaveAsync(byte[] audioData, TranscriptionResult result, CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -27,8 +27,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly IAudioRecordingCoordinator _recordingCoordinator;
     private readonly ITranscriptionService _transcriptionService;
     private readonly IDictationOutputChannel _outputChannel;
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ICliAppDetector _cliAppDetector;
+    private readonly IDictationTranscriptionPersister _persister;
+    private readonly IClaudeCodeCivilityTrimmer _civilityTrimmer;
     private readonly IStreamingChunkAssembler _streamingAssembler;
     private readonly DictationOptions _options;
 
@@ -50,8 +50,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         IAudioRecordingCoordinator recordingCoordinator,
         ITranscriptionService transcriptionService,
         IDictationOutputChannel outputChannel,
-        IServiceScopeFactory scopeFactory,
-        ICliAppDetector cliAppDetector,
+        IDictationTranscriptionPersister persister,
+        IClaudeCodeCivilityTrimmer civilityTrimmer,
         IStreamingChunkAssembler streamingAssembler,
         IOptions<DictationOptions> options)
     {
@@ -61,8 +61,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _recordingCoordinator = recordingCoordinator ?? throw new ArgumentNullException(nameof(recordingCoordinator));
         _transcriptionService = transcriptionService ?? throw new ArgumentNullException(nameof(transcriptionService));
         _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
-        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
-        _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+        _persister = persister ?? throw new ArgumentNullException(nameof(persister));
+        _civilityTrimmer = civilityTrimmer ?? throw new ArgumentNullException(nameof(civilityTrimmer));
         _streamingAssembler = streamingAssembler ?? throw new ArgumentNullException(nameof(streamingAssembler));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
@@ -545,104 +545,20 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     }
 
     /// <summary>
-    /// Saves transcription to database using scoped persistence service.
-    /// Note: Creates scope because DictationWorker is singleton but persistence service is scoped.
+    /// Saves transcription to database via <see cref="IDictationTranscriptionPersister"/>,
+    /// which owns the scoped <c>IDictationPersistenceService</c> resolution and
+    /// the racing/non-racing save dispatch. (#969 extraction.)
     /// </summary>
-    private async Task SaveTranscriptionToDatabaseAsync(byte[] audioData, TranscriptionResult result)
-    {
-        using var scope = _scopeFactory.CreateScope();
-        var persistenceService = scope.ServiceProvider.GetRequiredService<IDictationPersistenceService>();
-
-        var originalText = result.OriginalText ?? result.Text;
-        var correctedText = (result.OriginalText != null && result.Text != result.OriginalText) ? result.Text : null;
-
-        // Construct LlmCorrectionResult if LLM correction was applied
-        LlmCorrectionResult? correctionResult = null;
-        if (correctedText != null && result.ModelId.HasValue && result.LlmDurationMs.GetValueOrDefault() > 0)
-        {
-            correctionResult = new LlmCorrectionResult(
-                CorrectedText: correctedText,
-                PromptId: result.PromptId,  // PromptId from TranscriptionService (context-aware prompt selection)
-                DurationMs: result.LlmDurationMs.Value,
-                ModelId: result.ModelId,  // ModelId from LLM provider
-                InputTokens: result.InputTokens,
-                OutputTokens: result.OutputTokens,
-                ReasoningTokens: result.ReasoningTokens
-            );
-        }
-
-        // Get the STT provider ID from the transcription result (set by the active speech transcriber)
-        // Falls back to Whisper (13) if not set - required because provider_id has FK constraint
-        var sttProviderId = result.SttProviderId.GetValueOrDefault(13);
-
-        // Use racing-aware save if race data is present
-        if (result.RaceGroupId.HasValue)
-        {
-            await persistenceService.SaveTranscriptionWithRacingAsync(
-                audioData,
-                originalText,
-                correctionResult,
-                sttProviderId,
-                result.RaceGroupId.Value,
-                result.RacingLoserTask,
-                _transcriptionCts!.Token);
-        }
-        else
-        {
-            await persistenceService.SaveTranscriptionAsync(
-                audioData,
-                originalText,
-                correctionResult,
-                sttProviderId,
-                _transcriptionCts!.Token);
-        }
-    }
+    private Task SaveTranscriptionToDatabaseAsync(byte[] audioData, TranscriptionResult result) =>
+        _persister.SaveAsync(audioData, result, _transcriptionCts!.Token);
 
     /// <summary>
-    /// Applies <see cref="CivilityTrimmer"/> to the dictated text if the active
-    /// CLI app is Claude Code. For any other CLI agent or a plain GUI focus,
-    /// returns the text unchanged — the trimmer is Claude-Code-scoped per the
-    /// feature request ("Děkuji." is a legitimate message in chat apps).
-    /// Detection errors fall back to leaving the text untouched — the worst
-    /// case here is one stray civility word, worth less than mangling valid
-    /// input when gdbus hiccups.
+    /// Thin wrapper around <see cref="IClaudeCodeCivilityTrimmer.TrimIfClaudeCodeAsync"/>
+    /// that the quick-dictation path calls before pasting. (#969 extraction
+    /// moved the detection + trimming into a dedicated helper.)
     /// </summary>
-    private async Task<string> StripCivilityForClaudeCodeAsync(string text, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-        {
-            return text;
-        }
-
-        CliAppDetectionResult? cliApp;
-        try
-        {
-            cliApp = await _cliAppDetector.DetectCliAppAsync(cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "CLI app detection failed before quick paste — skipping civility trim");
-            return text;
-        }
-
-        if (cliApp is null || !string.Equals(cliApp.AppName, "Claude Code", StringComparison.OrdinalIgnoreCase))
-        {
-            return text;
-        }
-
-        var stripped = CivilityTrimmer.StripTrailingCivility(text);
-        if (stripped.Length != text.Length)
-        {
-            _logger.LogInformation(
-                "Quick dictation: stripped trailing civility for Claude Code ({Before} → {After} chars)",
-                text.Length, stripped.Length);
-        }
-        return stripped;
-    }
+    private Task<string> StripCivilityForClaudeCodeAsync(string text, CancellationToken cancellationToken) =>
+        _civilityTrimmer.TrimIfClaudeCodeAsync(text, cancellationToken);
 
     /// <summary>
     /// Types text into active window and transitions to Idle state.

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/ClaudeCodeCivilityTrimmerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/ClaudeCodeCivilityTrimmerTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the Claude-Code scoping the civility trimmer enforces: in chat apps
+/// "Děkuji." is a legitimate message and must pass through untouched, in
+/// Claude Code it's a Whisper hallucination that would poison the prompt.
+/// Detection errors must fall back to "no trim" — one stray civility word
+/// is cheaper than mangling valid input when gdbus hiccups.
+/// </summary>
+public class ClaudeCodeCivilityTrimmerTests
+{
+    private readonly Mock<ILogger<ClaudeCodeCivilityTrimmer>> _loggerMock = new();
+    private readonly Mock<ICliAppDetector> _detectorMock = new();
+
+    private ClaudeCodeCivilityTrimmer CreateSut() =>
+        new(_loggerMock.Object, _detectorMock.Object);
+
+    [Fact]
+    public async Task TrimIfClaudeCodeAsync_EmptyText_ReturnsTextUnchanged_WithoutProbing()
+    {
+        var sut = CreateSut();
+
+        var result = await sut.TrimIfClaudeCodeAsync(string.Empty, CancellationToken.None);
+
+        Assert.Equal(string.Empty, result);
+        _detectorMock.Verify(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TrimIfClaudeCodeAsync_ClaudeCodeActive_StripsTrailingCivility()
+    {
+        // CivilityTrimmer only matches a whole trailing SENTENCE against its
+        // phrase list, so the input must contain a real sentence boundary.
+        _detectorMock
+            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CliAppDetectionResult("Claude Code", "claude.md"));
+
+        var sut = CreateSut();
+        var result = await sut.TrimIfClaudeCodeAsync("Run the build. Děkuji.", CancellationToken.None);
+
+        Assert.DoesNotContain("Děkuji", result);
+        Assert.Equal("Run the build.", result.TrimEnd());
+    }
+
+    [Fact]
+    public async Task TrimIfClaudeCodeAsync_OtherCliApp_ReturnsTextUnchanged()
+    {
+        _detectorMock
+            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CliAppDetectionResult("OpenCode", "opencode.md"));
+
+        var sut = CreateSut();
+        var result = await sut.TrimIfClaudeCodeAsync("hello Děkuji.", CancellationToken.None);
+
+        Assert.Equal("hello Děkuji.", result);
+    }
+
+    [Fact]
+    public async Task TrimIfClaudeCodeAsync_NoCliAppDetected_ReturnsTextUnchanged()
+    {
+        _detectorMock
+            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CliAppDetectionResult?)null);
+
+        var sut = CreateSut();
+        var result = await sut.TrimIfClaudeCodeAsync("hello Děkuji.", CancellationToken.None);
+
+        Assert.Equal("hello Děkuji.", result);
+    }
+
+    [Fact]
+    public async Task TrimIfClaudeCodeAsync_DetectorThrows_ReturnsTextUnchanged()
+    {
+        _detectorMock
+            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("gdbus broken"));
+
+        var sut = CreateSut();
+        var result = await sut.TrimIfClaudeCodeAsync("hello Děkuji.", CancellationToken.None);
+
+        Assert.Equal("hello Děkuji.", result);
+    }
+
+    [Fact]
+    public async Task TrimIfClaudeCodeAsync_DetectorCancelled_Propagates()
+    {
+        _detectorMock
+            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => sut.TrimIfClaudeCodeAsync("hello Děkuji.", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task TrimIfClaudeCodeAsync_AppNameMatchIsCaseInsensitive()
+    {
+        // CliAppDetector has normalized casing in the past — pin that the
+        // trimmer does its own case-insensitive compare so a lowercase
+        // "claude code" from a future detection strategy still triggers.
+        _detectorMock
+            .Setup(x => x.DetectCliAppAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CliAppDetectionResult("claude code", "claude.md"));
+
+        var sut = CreateSut();
+        var result = await sut.TrimIfClaudeCodeAsync("Build. Děkuji.", CancellationToken.None);
+
+        Assert.DoesNotContain("Děkuji", result);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationTranscriptionPersisterTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationTranscriptionPersisterTests.cs
@@ -1,0 +1,198 @@
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Models;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.Speech;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the logic pulled out of DictationWorker.SaveTranscriptionToDatabaseAsync:
+/// null LlmCorrectionResult when the LLM didn't actually correct, the Whisper
+/// (13) fallback for a missing SttProviderId, and the racing-vs-non-racing
+/// dispatch on RaceGroupId. These assertions used to live in the worker's
+/// SkipOnCIFact integration tests; moving them here makes them fast unit
+/// tests independent of the full worker plumbing.
+/// </summary>
+public class DictationTranscriptionPersisterTests
+{
+    private readonly Mock<IDictationPersistenceService> _persistenceMock = new();
+    private readonly Mock<IServiceScopeFactory> _scopeFactoryMock = new();
+
+    private DictationTranscriptionPersister CreateSut()
+    {
+        var scope = new Mock<IServiceScope>();
+        var serviceProvider = new Mock<IServiceProvider>();
+        _scopeFactoryMock.Setup(x => x.CreateScope()).Returns(scope.Object);
+        scope.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
+        serviceProvider.Setup(x => x.GetService(typeof(IDictationPersistenceService)))
+            .Returns(_persistenceMock.Object);
+        return new DictationTranscriptionPersister(_scopeFactoryMock.Object);
+    }
+
+    [Fact]
+    public async Task SaveAsync_NoCorrection_CallsPlainSave_WithNullCorrectionResult()
+    {
+        // OriginalText == Text means the LLM pass was a no-op (or didn't run).
+        // Persister must forward correctionResult=null rather than manufacturing
+        // a zero-duration correction row.
+        var sut = CreateSut();
+        var audio = new byte[] { 1, 2, 3 };
+        var result = new TranscriptionResult("hello", 0.9f)
+        {
+            OriginalText = "hello",
+            SttProviderId = 14,
+        };
+
+        await sut.SaveAsync(audio, result, CancellationToken.None);
+
+        _persistenceMock.Verify(x => x.SaveTranscriptionAsync(
+            audio,
+            "hello",
+            null,
+            14,
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        _persistenceMock.Verify(x => x.SaveTranscriptionWithRacingAsync(
+            It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<LlmCorrectionResult?>(),
+            It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<Task<LlmCorrectionResult?>?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithCorrection_BuildsCorrectionResultAndPreservesOriginalText()
+    {
+        var sut = CreateSut();
+        var audio = new byte[] { 1 };
+        var result = new TranscriptionResult("Hello World", 0.9f)
+        {
+            OriginalText = "hello world",
+            PromptId = 42,
+            ModelId = 3,
+            LlmDurationMs = 150,
+            InputTokens = 20,
+            OutputTokens = 4,
+            ReasoningTokens = 1,
+            SttProviderId = 14,
+        };
+
+        await sut.SaveAsync(audio, result, CancellationToken.None);
+
+        _persistenceMock.Verify(x => x.SaveTranscriptionAsync(
+            audio,
+            "hello world",
+            It.Is<LlmCorrectionResult?>(c =>
+                c != null &&
+                c.CorrectedText == "Hello World" &&
+                c.PromptId == 42 &&
+                c.DurationMs == 150 &&
+                c.ModelId == 3 &&
+                c.InputTokens == 20 &&
+                c.OutputTokens == 4 &&
+                c.ReasoningTokens == 1),
+            14,
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_MissingSttProviderId_FallsBackToWhisperId13()
+    {
+        var sut = CreateSut();
+        var audio = new byte[] { 9 };
+        var result = new TranscriptionResult("x", 0.1f) { OriginalText = "x" };
+
+        await sut.SaveAsync(audio, result, CancellationToken.None);
+
+        _persistenceMock.Verify(x => x.SaveTranscriptionAsync(
+            audio, "x", null, 13, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ZeroLlmDuration_SkipsCorrectionResult()
+    {
+        // A missing/zero LlmDurationMs means LLM correction didn't actually
+        // run even if OriginalText differs from Text (e.g. pre-seeded text).
+        // Persister drops the correction to avoid writing a bogus duration.
+        var sut = CreateSut();
+        var result = new TranscriptionResult("corrected", 0.9f)
+        {
+            OriginalText = "original",
+            ModelId = 3,
+            LlmDurationMs = 0,
+        };
+
+        await sut.SaveAsync(new byte[] { 1 }, result, CancellationToken.None);
+
+        _persistenceMock.Verify(x => x.SaveTranscriptionAsync(
+            It.IsAny<byte[]>(), "original", null, It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_MissingModelId_SkipsCorrectionResult()
+    {
+        // LlmCorrectionResult requires ModelId (FK); without it persistence
+        // can't record which model ran, so the correction is dropped entirely.
+        var sut = CreateSut();
+        var result = new TranscriptionResult("corrected", 0.9f)
+        {
+            OriginalText = "original",
+            LlmDurationMs = 100,
+            ModelId = null,
+        };
+
+        await sut.SaveAsync(new byte[] { 1 }, result, CancellationToken.None);
+
+        _persistenceMock.Verify(x => x.SaveTranscriptionAsync(
+            It.IsAny<byte[]>(), "original", null, It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithRaceGroupId_DispatchesToRacingSave()
+    {
+        var sut = CreateSut();
+        var raceId = Guid.NewGuid();
+        var loserTask = Task.FromResult<LlmCorrectionResult?>(null);
+        var result = new TranscriptionResult("x", 0.9f)
+        {
+            OriginalText = "x",
+            SttProviderId = 14,
+            RaceGroupId = raceId,
+            RacingLoserTask = loserTask,
+        };
+
+        await sut.SaveAsync(new byte[] { 1 }, result, CancellationToken.None);
+
+        _persistenceMock.Verify(x => x.SaveTranscriptionWithRacingAsync(
+            It.IsAny<byte[]>(),
+            "x",
+            null,
+            14,
+            raceId,
+            loserTask,
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        _persistenceMock.Verify(x => x.SaveTranscriptionAsync(
+            It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<LlmCorrectionResult?>(),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveAsync_UsesTextAsOriginalText_WhenOriginalTextNull()
+    {
+        // Backwards-compat: legacy transcribers that don't populate OriginalText
+        // get their final Text stored as the original — the persistence table
+        // still requires a non-null originalText column.
+        var sut = CreateSut();
+        var result = new TranscriptionResult("final", 0.9f) { OriginalText = null };
+
+        await sut.SaveAsync(new byte[] { 1 }, result, CancellationToken.None);
+
+        _persistenceMock.Verify(x => x.SaveTranscriptionAsync(
+            It.IsAny<byte[]>(), "final", null, It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -26,11 +26,8 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IAudioRecordingCoordinator> _recordingCoordinatorMock;
     private readonly Mock<ITranscriptionService> _transcriptionServiceMock;
     private readonly Mock<IDictationOutputChannel> _outputChannelMock;
-    private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
-    private readonly Mock<IServiceScope> _scopeMock;
-    private readonly Mock<IServiceProvider> _serviceProviderMock;
-    private readonly Mock<IDictationPersistenceService> _persistenceServiceMock;
-    private readonly Mock<ICliAppDetector> _cliAppDetectorMock;
+    private readonly Mock<IDictationTranscriptionPersister> _persisterMock;
+    private readonly Mock<IClaudeCodeCivilityTrimmer> _civilityTrimmerMock;
     private readonly Mock<IStreamingChunkAssembler> _streamingAssemblerMock;
     private readonly DictationOptions _options;
     private readonly DictationWorker _sut;
@@ -45,19 +42,18 @@ public class DictationWorkerTests : IDisposable
         _recordingCoordinatorMock = new Mock<IAudioRecordingCoordinator>();
         _transcriptionServiceMock = new Mock<ITranscriptionService>();
         _outputChannelMock = new Mock<IDictationOutputChannel>();
-        _scopeFactoryMock = new Mock<IServiceScopeFactory>();
-        _scopeMock = new Mock<IServiceScope>();
-        _serviceProviderMock = new Mock<IServiceProvider>();
-        _persistenceServiceMock = new Mock<IDictationPersistenceService>();
-        _cliAppDetectorMock = new Mock<ICliAppDetector>();
+        _persisterMock = new Mock<IDictationTranscriptionPersister>();
+        _civilityTrimmerMock = new Mock<IClaudeCodeCivilityTrimmer>();
         _streamingAssemblerMock = new Mock<IStreamingChunkAssembler>();
 
         _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
 
-        _scopeFactoryMock.Setup(x => x.CreateScope()).Returns(_scopeMock.Object);
-        _scopeMock.Setup(x => x.ServiceProvider).Returns(_serviceProviderMock.Object);
-        _serviceProviderMock.Setup(x => x.GetService(typeof(IDictationPersistenceService)))
-            .Returns(_persistenceServiceMock.Object);
+        // The civility trimmer is always on the quick-dictation path; without
+        // an explicit passthrough setup, the Mock default returns null/empty
+        // which trips the "reduced to empty" short-circuit and skips paste.
+        _civilityTrimmerMock
+            .Setup(x => x.TrimIfClaudeCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((text, _) => Task.FromResult(text));
 
         _keyboardMonitorMock.SetupAdd(x => x.KeyReleased += It.IsAny<EventHandler<KeyEventArgs>>())
             .Callback<EventHandler<KeyEventArgs>>(handler => _capturedKeyReleasedHandler = handler);
@@ -71,8 +67,8 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options));
     }
@@ -89,8 +85,8 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
@@ -105,8 +101,8 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
@@ -121,8 +117,8 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
@@ -137,8 +133,8 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             null!));
     }
@@ -153,8 +149,8 @@ public class DictationWorkerTests : IDisposable
             null!,
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
@@ -169,8 +165,8 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             null!,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
@@ -185,14 +181,14 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             null!,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
     [Fact]
-    public void Constructor_NullScopeFactory_ThrowsArgumentNullException()
+    public void Constructor_NullPersister_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object,
@@ -202,13 +198,13 @@ public class DictationWorkerTests : IDisposable
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
             null!,
-            _cliAppDetectorMock.Object,
+            _civilityTrimmerMock.Object,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
     [Fact]
-    public void Constructor_NullCliAppDetector_ThrowsArgumentNullException()
+    public void Constructor_NullCivilityTrimmer_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object,
@@ -217,7 +213,7 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
+            _persisterMock.Object,
             null!,
             _streamingAssemblerMock.Object,
             Options.Create(_options)));
@@ -233,8 +229,8 @@ public class DictationWorkerTests : IDisposable
             _recordingCoordinatorMock.Object,
             _transcriptionServiceMock.Object,
             _outputChannelMock.Object,
-            _scopeFactoryMock.Object,
-            _cliAppDetectorMock.Object,
+            _persisterMock.Object,
+            _civilityTrimmerMock.Object,
             null!,
             Options.Create(_options)));
     }
@@ -435,9 +431,6 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        _persistenceServiceMock.Setup(x => x.SaveTranscriptionAsync(
-                It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<LlmCorrectionResult?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(300);
@@ -532,16 +525,18 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        _persistenceServiceMock.Setup(x => x.SaveTranscriptionAsync(
-                audioData, "Hello world", null, expectedProviderId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(400);
 
         _outputChannelMock.Verify(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()), Times.Once);
-        _persistenceServiceMock.Verify(x => x.SaveTranscriptionAsync(
-            audioData, "Hello world", null, expectedProviderId, It.IsAny<CancellationToken>()), Times.Once);
+        // The LlmCorrectionResult building + STT-provider fallback live in the
+        // persister now; the worker's contract is just "forward the raw
+        // TranscriptionResult". DictationTranscriptionPersisterTests cover the
+        // details.
+        _persisterMock.Verify(x => x.SaveAsync(
+            audioData, It.Is<TranscriptionResult>(r => r.Text == "Hello world" && r.SttProviderId == expectedProviderId), It.IsAny<CancellationToken>()),
+            Times.Once);
         _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.AtLeastOnce);
     }
 
@@ -568,23 +563,23 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        _persistenceServiceMock.Setup(x => x.SaveTranscriptionAsync(
-                It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<LlmCorrectionResult?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(400);
 
-        _persistenceServiceMock.Verify(x => x.SaveTranscriptionAsync(
+        // Worker just forwards the TranscriptionResult (incl. LLM-correction
+        // metadata) to the persister; the LlmCorrectionResult construction is
+        // pinned in DictationTranscriptionPersisterTests.
+        _persisterMock.Verify(x => x.SaveAsync(
             audioData,
-            "hello world",
-            It.Is<LlmCorrectionResult?>(r =>
-                r != null &&
-                r.CorrectedText == "Hello world corrected" &&
+            It.Is<TranscriptionResult>(r =>
+                r.Text == "Hello world corrected" &&
+                r.OriginalText == "hello world" &&
                 r.PromptId == 42 &&
-                r.DurationMs == 150),
-            It.IsAny<int>(),
-            It.IsAny<CancellationToken>()), Times.Once);
+                r.ModelId == 1 &&
+                r.LlmDurationMs == 150),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [SkipOnCIFact]
@@ -607,9 +602,6 @@ public class DictationWorkerTests : IDisposable
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
-        _persistenceServiceMock.Setup(x => x.SaveTranscriptionAsync(
-                It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<LlmCorrectionResult?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(400);


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Third step in the #969 god-class split (parent #967). Continues the extraction work from #1021 (streaming assembler) and #1025 (output channel).

## Summary

Two remaining inline-logic blocks on `DictationWorker` pulled into focused helpers:

- **`IDictationTranscriptionPersister`** + `DictationTranscriptionPersister` — owns `IServiceScopeFactory`, encapsulates:
  - `LlmCorrectionResult` construction (null when `Text == OriginalText`, or no `ModelId`, or zero duration)
  - Whisper (13) fallback for missing `SttProviderId` (replaced magic literal with `WhisperProviderId` const)
  - Racing-vs-non-racing save dispatch on `RaceGroupId`
  - Scoped DI scope lifecycle
- **`IClaudeCodeCivilityTrimmer`** + `ClaudeCodeCivilityTrimmer` — owns `ICliAppDetector`, keeps the "trim only when Claude Code is active" scoping plus the "gdbus hiccup falls back to no-trim" policy in one place.

## Impact on DictationWorker

- LOC: **788 → 704** (peak was 811 before #969 began)
- Two heavyweights (`IServiceScopeFactory`, `ICliAppDetector`) leave the ctor — replaced by two focused helpers, so the dep count stays at 10 but each dep is now single-responsibility.
- Two inline methods (`SaveTranscriptionToDatabaseAsync`, `StripCivilityForClaudeCodeAsync`) become one-line delegates.

## Tests

- `DictationWorkerTests` — new helper mocks injected; drops `IServiceScope` / `IServiceProvider` / `IDictationPersistenceService` / `ICliAppDetector` mocks (no longer the worker's surface). Renames `Constructor_NullScopeFactory` → `Constructor_NullPersister`, adds `Constructor_NullCivilityTrimmer`. Constructor-level civility passthrough keeps existing quick-dictation tests green (default empty return used to short-circuit paste).
- New `DictationTranscriptionPersisterTests` (7 cases): null correction on missing LLM metadata, Whisper-13 fallback, correction-result field passthrough, racing dispatch, legacy null-`OriginalText`.
- New `ClaudeCodeCivilityTrimmerTests` (7 cases): empty text short-circuit, Claude-Code trim, case-insensitive app match, passthrough for other / no CLI app, exception swallowed, `OperationCanceledException` propagates.

## Progress for #969

- worker LOC: **704** (target ≤ 400)
- worker ctor deps: **10** (target ≤ 5)
- Remaining: recording/transcription orchestration pipeline — deferred to the next PR to keep this diff reviewable.

## Test plan

- [x] `dotnet build` green
- [x] `dotnet test tests/VirtualAssistant.Service.Tests/` = 360/360 (+14 new helper tests, −4 obsoleted worker tests merged into 1)
- [ ] CI green
- [ ] Post-deploy dictation smoke (CapsLock quick-path into Claude Code terminal strips trailing "Děkuji.", into WhatsApp keeps it)