### PR TITLE
refactor(streaming): Copilot cancel-rethrow + test-assertion follow-up on #1025

### DIFF
--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationOutputChannel.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationOutputChannel.cs
@@ -49,6 +49,13 @@ public sealed class DictationOutputChannel : IDictationOutputChannel
                 new DictationEvent { EventType = eventType, Text = text },
                 cancellationToken);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Host shutdown / cooperative cancel: rethrow so callers see the
+            // cancellation rather than swallowing it as a transport failure.
+            // (Copilot review on PR #1025.)
+            throw;
+        }
         catch (Exception ex)
         {
             // Broadcasting is best-effort — a SignalR client-side failure must

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationOutputChannelTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationOutputChannelTests.cs
@@ -120,4 +120,23 @@ public class DictationOutputChannelTests
 
         Assert.Null(ex);
     }
+
+    [Fact]
+    public async Task BroadcastEventAsync_RethrowsCancellation_WhenTokenCancelled()
+    {
+        // Host shutdown and cooperative cancellation must NOT be swallowed as
+        // transport failures — otherwise the caller can't tell its own cancel
+        // landed and the shutdown may hang waiting for "success". The channel
+        // only swallows transport errors. (Copilot review on PR #1025.)
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _allClientsMock
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sut.BroadcastEventAsync(DictationEventType.RecordingStarted, null, cts.Token));
+    }
 }

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -10,6 +10,7 @@ using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Workers;
 using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
@@ -719,8 +720,14 @@ public class DictationWorkerTests : IDisposable
         await _sut.StopDictationAsync();
         await Task.Delay(400);
 
-        // Should still transition to Idle on failure
+        // Should still transition to Idle on failure — AND must not emit the
+        // QuickTranscriptionCompleted broadcast, since the paste didn't land
+        // (remote UI would otherwise light up as if the text went through).
+        // (Copilot review on PR #1025.)
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(DictationEventType.QuickTranscriptionCompleted, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [SkipOnCIFact]


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Two findings from Copilot's post-merge review on #1025.

## Summary

- **Cancellation semantics fix in `DictationOutputChannel.BroadcastEventAsync`**: the catch-all previously swallowed `OperationCanceledException`, meaning a host-shutdown / cooperative cancel was silently logged as "transport failure". Now rethrows `OperationCanceledException` when `cancellationToken.IsCancellationRequested`; unrelated transport errors still fall through to the `LogDebug` swallow as the xmldoc promises.
- **Assertion tightened in `QuickDictation_WhenFastPasteFails_DoesNotBroadcastQuickTranscriptionCompleted`**: the test's name promised a non-broadcast assertion but the body only checked the Idle transition. Added explicit `Verify` that `BroadcastEventAsync` is never called for `QuickTranscriptionCompleted` on the fast-paste-failure path.

New test `DictationOutputChannelTests.BroadcastEventAsync_RethrowsCancellation_WhenTokenCancelled` pins the cancellation-rethrow behavior.

## Test plan

- [x] `dotnet build` green
- [x] `dotnet test tests/VirtualAssistant.Service.Tests/` = 361/361 (+1 new, 1 tightened)
- [ ] CI green on the merge