### PR TITLE
test(core): add coverage for DictationOptions + SpeechProviderSettings (#979 phase B)

### DIFF
--- a/tests/VirtualAssistant.Core.Tests/Configuration/DictationOptionsTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Configuration/DictationOptionsTests.cs
@@ -1,0 +1,46 @@
+using Olbrasoft.VirtualAssistant.Core.Configuration;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.Configuration;
+
+/// <summary>
+/// Mirrors the ContinuousListenerOptions tests for the dictation-specific
+/// path-resolution branches. The filename-only branch delegates to
+/// WhisperModelLocator which walks real XDG directories; that path needs
+/// a filesystem fixture and is covered separately.
+/// </summary>
+public class DictationOptionsTests
+{
+    [Fact]
+    public void GetFullWhisperModelPath_AbsolutePath_IsReturnedVerbatim()
+    {
+        var abs = Path.Combine(Path.GetTempPath(), "ggml-large-v3-turbo.bin");
+        var options = new DictationOptions { WhisperModelPath = abs };
+
+        Assert.Equal(abs, options.GetFullWhisperModelPath());
+    }
+
+    [Fact]
+    public void GetFullWhisperModelPath_RelativeWithSeparator_IsJoinedToBaseDirectory()
+    {
+        var options = new DictationOptions { WhisperModelPath = "models/custom.bin" };
+
+        var expected = Path.Combine(AppContext.BaseDirectory, "models/custom.bin");
+        Assert.Equal(expected, options.GetFullWhisperModelPath());
+    }
+
+    [Fact]
+    public void Defaults_MatchDictationTunedWhisperTurbo()
+    {
+        // Dictation picks the larger "-turbo" variant (more accurate than the
+        // "medium" the continuous listener runs) because the user waits for it
+        // synchronously. Pin the defaults so a silent config drift doesn't
+        // downgrade dictation quality.
+        var options = new DictationOptions();
+
+        Assert.Equal("ggml-large-v3-turbo.bin", options.WhisperModelPath);
+        Assert.Equal("cs", options.WhisperLanguage);
+        Assert.Equal(16000, options.SampleRate);
+        Assert.Equal(50, options.KeyboardLedSettleTimeMs);
+        Assert.Equal(300, options.MaxDurationSeconds);
+    }
+}

--- a/tests/VirtualAssistant.Core.Tests/Configuration/SpeechProviderSettingsTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Configuration/SpeechProviderSettingsTests.cs
@@ -1,0 +1,30 @@
+using Olbrasoft.VirtualAssistant.Core.Configuration;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.Configuration;
+
+/// <summary>
+/// Pins the defaults on SpeechProviderSettings: the whole fallback chain
+/// depends on Primary=google / Fallback=whisper / Enable=true wiring so
+/// production starts with Google STT and degrades to local Whisper on API
+/// errors. A silent default drift would flip the production behavior.
+/// </summary>
+public class SpeechProviderSettingsTests
+{
+    [Fact]
+    public void Defaults_MatchProductionFallbackChain()
+    {
+        var settings = new SpeechProviderSettings();
+
+        Assert.Equal("google", settings.PrimaryProvider);
+        Assert.Equal("whisper", settings.FallbackProvider);
+        Assert.True(settings.EnableFallback);
+    }
+
+    [Fact]
+    public void SectionName_IsStableConstant()
+    {
+        // Binding to "SpeechProvider" is how appsettings.json reaches this
+        // type; a rename here would break every deployed config silently.
+        Assert.Equal("SpeechProvider", SpeechProviderSettings.SectionName);
+    }
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Phase B of the #979 Core coverage push (phase A was #1024). Focused on configuration options that gate production behavior.

## Summary

- **`DictationOptionsTests`** (3 cases) — mirrors the `ContinuousListenerOptions` path-resolution coverage: absolute path passes through verbatim, relative-with-separator joins to `AppContext.BaseDirectory`, and defaults pin the larger `ggml-large-v3-turbo.bin` model the dictation path relies on (if a silent drift swapped this for "medium", dictation accuracy would quietly regress).
- **`SpeechProviderSettingsTests`** (2 cases) — pins Primary=google / Fallback=whisper / Enable=true: the whole fallback chain in `SpeechTranscriberFactory` assumes these defaults, so a missing appsettings.json section still starts production in the right shape. Also pins the `SectionName` constant so a rename here wouldn't silently break every deployed config.

## Test plan

- [x] `dotnet build` green
- [x] `dotnet test tests/VirtualAssistant.Core.Tests/` = 138/138 (5 new)
- [ ] CI green