### PR TITLE
refactor(dictation): extract IDictationTranscriber from DictationWorker (#969 partial)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -41,14 +41,22 @@ public static class WorkerServicesExtensions
 
         services.AddSingleton(sp =>
         {
-            // Streaming assembler is created inline so it binds to the SAME
-            // keyed ITranscriptionService the worker uses — otherwise a
-            // second (non-keyed) transcription instance would be resolved
-            // for per-chunk calls. (#969 extraction.)
+            // Streaming assembler and transcriber are constructed inline so
+            // they bind to the SAME keyed ITranscriptionService — otherwise a
+            // second (non-keyed) transcription instance would be resolved for
+            // per-chunk calls. (#969 extraction.)
             var transcription = sp.GetRequiredKeyedService<ITranscriptionService>(DictationKey);
             var assembler = new StreamingChunkAssembler(
                 sp.GetRequiredService<ILogger<StreamingChunkAssembler>>(),
                 transcription);
+
+            // Bundle ITranscriptionService + IStreamingChunkAssembler behind
+            // the transcriber abstraction so the worker talks to one façade
+            // for both streaming-lifecycle and transcription calls. (#969.)
+            var transcriber = new DictationTranscriber(
+                sp.GetRequiredService<ILogger<DictationTranscriber>>(),
+                transcription,
+                assembler);
 
             // Bundle the four output-surface dependencies (sounds, keyboard,
             // SignalR) behind a single IDictationOutputChannel so the worker
@@ -75,11 +83,10 @@ public static class WorkerServicesExtensions
                 sp.GetRequiredService<IKeyboardMonitor>(),
                 sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
                 sp.GetRequiredKeyedService<IAudioRecordingCoordinator>(DictationKey),
-                transcription,
+                transcriber,
                 outputChannel,
                 persister,
                 civilityTrimmer,
-                assembler,
                 sp.GetRequiredService<IOptions<DictationOptions>>());
         });
 

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationTranscriber.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationTranscriber.cs
@@ -1,0 +1,67 @@
+using Olbrasoft.VirtualAssistant.Core.Speech;
+using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
+using Olbrasoft.VirtualAssistant.Voice.Services;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationTranscriber : IDictationTranscriber
+{
+    private readonly ILogger<DictationTranscriber> _logger;
+    private readonly ITranscriptionService _transcriptionService;
+    private readonly IStreamingChunkAssembler _streamingAssembler;
+
+    public DictationTranscriber(
+        ILogger<DictationTranscriber> logger,
+        ITranscriptionService transcriptionService,
+        IStreamingChunkAssembler streamingAssembler)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _transcriptionService = transcriptionService ?? throw new ArgumentNullException(nameof(transcriptionService));
+        _streamingAssembler = streamingAssembler ?? throw new ArgumentNullException(nameof(streamingAssembler));
+
+        // Forward the backend's RawTranscriptionReady event so consumers
+        // bind against IDictationTranscriber, not ITranscriptionService.
+        _transcriptionService.RawTranscriptionReady += OnBackendRawReady;
+    }
+
+    public event Action<string>? RawTranscriptionReady;
+
+    public bool IsStreamingActive => _streamingAssembler.IsActive;
+
+    private void OnBackendRawReady(string text) => RawTranscriptionReady?.Invoke(text);
+
+    public void BeginSession(bool streamingActive) => _streamingAssembler.Reset(streamingActive);
+
+    public void ForwardChunk(int index, byte[] pcmBytes) => _streamingAssembler.SubmitChunk(index, pcmBytes);
+
+    public void EndSession() => _streamingAssembler.CancelAndClear();
+
+    public async Task<TranscriptionResult> TranscribeRawAsync(byte[] audio, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(audio);
+
+        if (_streamingAssembler.IsActive)
+        {
+            var combined = await _streamingAssembler.CombineAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(combined))
+            {
+                _logger.LogWarning("Streaming quick transcription produced empty text; falling back to full-buffer Whisper");
+                return await _transcriptionService.TranscribeRawAsync(audio, cancellationToken);
+            }
+
+            _logger.LogInformation(
+                "Streaming quick transcription: combined {Count} chunks into {Length} chars",
+                _streamingAssembler.CompletedChunkCount, combined.Length);
+            return await _transcriptionService.FinalizePreTranscribedRawAsync(combined, cancellationToken);
+        }
+
+        return await _transcriptionService.TranscribeRawAsync(audio, cancellationToken);
+    }
+
+    public Task<TranscriptionResult> TranscribeFullAsync(byte[] audio, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(audio);
+        return _transcriptionService.TranscribeAsync(audio, cancellationToken);
+    }
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationTranscriber.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationTranscriber.cs
@@ -44,9 +44,17 @@ public sealed class DictationTranscriber : IDictationTranscriber
         if (_streamingAssembler.IsActive)
         {
             var combined = await _streamingAssembler.CombineAsync(cancellationToken);
+            if (combined is null)
+            {
+                _logger.LogInformation(
+                    "Streaming quick transcription produced no chunks; falling back to full-buffer Whisper");
+                return await _transcriptionService.TranscribeRawAsync(audio, cancellationToken);
+            }
+
             if (string.IsNullOrWhiteSpace(combined))
             {
-                _logger.LogWarning("Streaming quick transcription produced empty text; falling back to full-buffer Whisper");
+                _logger.LogWarning(
+                    "Streaming quick transcription produced whitespace-only text; falling back to full-buffer Whisper");
                 return await _transcriptionService.TranscribeRawAsync(audio, cancellationToken);
             }
 

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationTranscriber.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationTranscriber.cs
@@ -1,0 +1,69 @@
+using Olbrasoft.VirtualAssistant.Core.Speech;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Per-session transcription pipeline lifted out of <c>DictationWorker</c>
+/// (#969 god-class split). Bundles the stream-chunk state machine
+/// (<c>IStreamingChunkAssembler</c>) and the transcription service
+/// (<c>ITranscriptionService</c>) behind one abstraction so the worker
+/// only handles orchestration/UX and never touches the two backends
+/// directly. The raw transcription method is streaming-aware — when
+/// <see cref="BeginSession"/> was called with <c>streamingActive=true</c>
+/// and chunks were forwarded via <see cref="ForwardChunk"/>, the combined
+/// streaming result is used instead of running Whisper on the full buffer.
+/// </summary>
+public interface IDictationTranscriber
+{
+    /// <summary>
+    /// Raised when a raw transcription (pre-LLM-correction) becomes available.
+    /// Forwarded from the underlying <c>ITranscriptionService</c> so the worker
+    /// can broadcast without having to know which transcription backend is
+    /// wired up. Delivery is one-per-transcription, on the threadpool.
+    /// </summary>
+    event Action<string>? RawTranscriptionReady;
+
+    /// <summary>
+    /// Whether a streaming session is currently active (<see cref="BeginSession"/>
+    /// was called with <c>streamingActive=true</c> and <see cref="EndSession"/>
+    /// hasn't run yet). Exposed so the worker can skip streaming-specific
+    /// cleanup when slow-mode overrides the start-time choice.
+    /// </summary>
+    bool IsStreamingActive { get; }
+
+    /// <summary>
+    /// Start a new transcription session; resets the streaming-chunk state.
+    /// Pass <c>streamingActive=true</c> only when the worker will forward
+    /// <see cref="ForwardChunk"/> calls during recording.
+    /// </summary>
+    void BeginSession(bool streamingActive);
+
+    /// <summary>
+    /// Forwards an audio chunk from the recording coordinator to the
+    /// streaming assembler. Ignored if streaming is not active for the
+    /// current session.
+    /// </summary>
+    void ForwardChunk(int index, byte[] pcmBytes);
+
+    /// <summary>
+    /// Ends the current transcription session; cancels in-flight streaming
+    /// tasks and clears the chunk state. Safe to call repeatedly.
+    /// </summary>
+    void EndSession();
+
+    /// <summary>
+    /// Raw (no-LLM-correction) transcription. When the session was started
+    /// with streaming and chunks were forwarded, combines the cached
+    /// per-chunk transcriptions; otherwise runs the raw Whisper pass on
+    /// the full buffer. Falls back to the full-buffer pass if the
+    /// streaming combine produced empty text.
+    /// </summary>
+    Task<TranscriptionResult> TranscribeRawAsync(byte[] audio, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Full transcription with LLM correction, filters, and racing as
+    /// configured on <c>ITranscriptionService</c>. Not streaming-aware —
+    /// this path runs on the full buffer regardless of session state.
+    /// </summary>
+    Task<TranscriptionResult> TranscribeFullAsync(byte[] audio, CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationTranscriber.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationTranscriber.cs
@@ -19,7 +19,9 @@ public interface IDictationTranscriber
     /// Raised when a raw transcription (pre-LLM-correction) becomes available.
     /// Forwarded from the underlying <c>ITranscriptionService</c> so the worker
     /// can broadcast without having to know which transcription backend is
-    /// wired up. Delivery is one-per-transcription, on the threadpool.
+    /// wired up. Raised once per transcription before any LLM correction.
+    /// Handlers should be fast and non-blocking; no specific thread affinity
+    /// is guaranteed.
     /// </summary>
     event Action<string>? RawTranscriptionReady;
 

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -5,12 +5,10 @@ using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
 using Olbrasoft.VirtualAssistant.Core.WindowManagement;
-using Olbrasoft.VirtualAssistant.Voice.Services;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
-using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
 
 namespace Olbrasoft.VirtualAssistant.Service.Workers;
 
@@ -25,11 +23,10 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly IKeyboardMonitor _keyboardMonitor;
     private readonly IDictationStateMachine _stateMachine;
     private readonly IAudioRecordingCoordinator _recordingCoordinator;
-    private readonly ITranscriptionService _transcriptionService;
+    private readonly IDictationTranscriber _transcriber;
     private readonly IDictationOutputChannel _outputChannel;
     private readonly IDictationTranscriptionPersister _persister;
     private readonly IClaudeCodeCivilityTrimmer _civilityTrimmer;
-    private readonly IStreamingChunkAssembler _streamingAssembler;
     private readonly DictationOptions _options;
 
     private CancellationTokenSource? _transcriptionCts;
@@ -48,22 +45,20 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         IKeyboardMonitor keyboardMonitor,
         IDictationStateMachine stateMachine,
         IAudioRecordingCoordinator recordingCoordinator,
-        ITranscriptionService transcriptionService,
+        IDictationTranscriber transcriber,
         IDictationOutputChannel outputChannel,
         IDictationTranscriptionPersister persister,
         IClaudeCodeCivilityTrimmer civilityTrimmer,
-        IStreamingChunkAssembler streamingAssembler,
         IOptions<DictationOptions> options)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _keyboardMonitor = keyboardMonitor ?? throw new ArgumentNullException(nameof(keyboardMonitor));
         _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
         _recordingCoordinator = recordingCoordinator ?? throw new ArgumentNullException(nameof(recordingCoordinator));
-        _transcriptionService = transcriptionService ?? throw new ArgumentNullException(nameof(transcriptionService));
+        _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
         _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
         _persister = persister ?? throw new ArgumentNullException(nameof(persister));
         _civilityTrimmer = civilityTrimmer ?? throw new ArgumentNullException(nameof(civilityTrimmer));
-        _streamingAssembler = streamingAssembler ?? throw new ArgumentNullException(nameof(streamingAssembler));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
     }
@@ -155,9 +150,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // If user picked slow mode but streaming was pre-transcribing chunks,
             // cancel those background tasks — they'd be discarded anyway, no point
             // burning GPU/serializing the Whisper semaphore for them.
-            if (!quickMode && _streamingAssembler.IsActive)
+            if (!quickMode && _transcriber.IsStreamingActive)
             {
-                _streamingAssembler.CancelAndClear();
+                _transcriber.EndSession();
                 _recordingCoordinator.DisableChunking();
                 _logger.LogInformation("Slow-mode override: canceled pending streaming chunk transcriptions");
             }
@@ -186,7 +181,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // Subscribe to state changes for SignalR broadcasting
             _stateMachine.StateChanged += OnStateChangedBroadcast;
             TranscriptionCompleted += OnTranscriptionCompletedBroadcast;
-            _transcriptionService.RawTranscriptionReady += OnRawTranscriptionReadyBroadcast;
+            _transcriber.RawTranscriptionReady += OnRawTranscriptionReadyBroadcast;
 
             // Subscribe to streaming chunk emissions — transcribes each chunk in background
             _recordingCoordinator.ChunkAvailable += OnChunkAvailable;
@@ -208,7 +203,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _keyboardMonitor.KeyReleased -= OnKeyReleased;
             _stateMachine.StateChanged -= OnStateChangedBroadcast;
             TranscriptionCompleted -= OnTranscriptionCompletedBroadcast;
-            _transcriptionService.RawTranscriptionReady -= OnRawTranscriptionReadyBroadcast;
+            _transcriber.RawTranscriptionReady -= OnRawTranscriptionReadyBroadcast;
             _recordingCoordinator.ChunkAvailable -= OnChunkAvailable;
 
             // Stop recording if active
@@ -317,14 +312,13 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     }
 
     /// <summary>
-    /// Forwards a streaming audio chunk to <see cref="IStreamingChunkAssembler"/>
-    /// which runs the per-chunk Whisper call on a background task and stores
-    /// the result keyed by chunk index. Ignored when streaming is not active
-    /// for the current session.
+    /// Forwards a streaming audio chunk to <see cref="IDictationTranscriber"/>,
+    /// which runs the per-chunk Whisper call on a background task. Ignored when
+    /// streaming is not active for the current session.
     /// </summary>
     private void OnChunkAvailable(object? sender, AudioChunkEventArgs e)
     {
-        _streamingAssembler.SubmitChunk(e.Index, e.PcmBytes);
+        _transcriber.ForwardChunk(e.Index, e.PcmBytes);
     }
 
     private Task BroadcastDictationEventAsync(DictationEventType eventType, string? text) =>
@@ -339,7 +333,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
             // Freeze streaming choice for this session — toggles mid-recording have no effect
             var streamingActive = _streamingTranscriptionEnabled;
-            _streamingAssembler.Reset(streamingActive);
+            _transcriber.BeginSession(streamingActive);
 
             if (streamingActive)
             {
@@ -447,12 +441,12 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
     /// <summary>
     /// Clears streaming chunk state after a dictation session completes (any path).
-    /// Delegates the concurrent-collection cleanup to <see cref="IStreamingChunkAssembler"/>;
+    /// Delegates the concurrent-collection cleanup to <see cref="IDictationTranscriber"/>;
     /// the worker still owns the recording-coordinator's chunking flag.
     /// </summary>
     private void ResetStreamingSessionState()
     {
-        _streamingAssembler.CancelAndClear();
+        _transcriber.EndSession();
         _recordingCoordinator.DisableChunking();
     }
 
@@ -478,36 +472,17 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     }
 
     /// <summary>
-    /// Transcribes audio using raw STT only (no LLM correction) with typing sound effect.
-    /// Used for quick dictation mode. When streaming was active for this session,
-    /// assembles the cached chunk transcriptions instead of running Whisper on the full buffer.
+    /// Raw (no-LLM) transcription with typing sound effect. The streaming-aware
+    /// raw pass lives in <see cref="IDictationTranscriber"/>; this method only
+    /// owns the UX side-effects (sound cue, CTS lifecycle, state-machine
+    /// fallback on failure).
     /// </summary>
     private async Task<TranscriptionResult?> TranscribeRawWithSoundAsync(byte[] audioData)
     {
         _outputChannel.StartTypingFeedback();
         _transcriptionCts = new CancellationTokenSource();
 
-        TranscriptionResult result;
-        if (_streamingAssembler.IsActive)
-        {
-            var combined = await _streamingAssembler.CombineAsync(_transcriptionCts.Token);
-            if (string.IsNullOrWhiteSpace(combined))
-            {
-                _logger.LogWarning("Streaming quick transcription produced empty text; falling back to full-buffer Whisper");
-                result = await _transcriptionService.TranscribeRawAsync(audioData, _transcriptionCts.Token);
-            }
-            else
-            {
-                _logger.LogInformation(
-                    "Streaming quick transcription: combined {Count} chunks into {Length} chars",
-                    _streamingAssembler.CompletedChunkCount, combined.Length);
-                result = await _transcriptionService.FinalizePreTranscribedRawAsync(combined, _transcriptionCts.Token);
-            }
-        }
-        else
-        {
-            result = await _transcriptionService.TranscribeRawAsync(audioData, _transcriptionCts.Token);
-        }
+        var result = await _transcriber.TranscribeRawAsync(audioData, _transcriptionCts.Token);
 
         if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
         {
@@ -522,15 +497,15 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     }
 
     /// <summary>
-    /// Transcribes audio with typing sound effect.
-    /// Returns null if transcription failed, otherwise returns transcription result.
+    /// Full-pipeline transcription (with LLM correction, filters, racing) plus
+    /// typing sound feedback and the state-machine fallback on failure.
     /// </summary>
     private async Task<TranscriptionResult?> TranscribeAudioWithSoundAsync(byte[] audioData)
     {
         _outputChannel.StartTypingFeedback();
         _transcriptionCts = new CancellationTokenSource();
 
-        var result = await _transcriptionService.TranscribeAsync(audioData, _transcriptionCts.Token);
+        var result = await _transcriber.TranscribeFullAsync(audioData, _transcriptionCts.Token);
 
         if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
         {

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationTranscriberTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationTranscriberTests.cs
@@ -92,13 +92,33 @@ public class DictationTranscriberTests
     }
 
     [Fact]
-    public async Task TranscribeRawAsync_StreamingActive_WithEmptyCombine_FallsBackToFullBuffer()
+    public async Task TranscribeRawAsync_StreamingActive_WithWhitespaceCombine_FallsBackToFullBuffer()
     {
-        // Per the xmldoc fallback contract: empty streaming result means
-        // "chunks were faulted or produced no text" — rerun Whisper on the
-        // full buffer so dictation still produces something.
+        // Whitespace-only combine means chunks ran but produced no usable
+        // text — rerun Whisper on the full buffer so dictation still produces
+        // something.
         _assemblerMock.SetupGet(x => x.IsActive).Returns(true);
         _assemblerMock.Setup(x => x.CombineAsync(It.IsAny<CancellationToken>())).ReturnsAsync("   ");
+        _transcriptionMock
+            .Setup(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("rescued", 0.9f));
+
+        var sut = CreateSut();
+        var result = await sut.TranscribeRawAsync(new byte[] { 1 }, CancellationToken.None);
+
+        Assert.Equal("rescued", result.Text);
+        _transcriptionMock.Verify(x => x.FinalizePreTranscribedRawAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TranscribeRawAsync_StreamingActive_WithNullCombine_FallsBackToFullBuffer()
+    {
+        // Null combine means no chunks were produced (normal for very short
+        // recordings) — distinct from whitespace (chunks ran but were empty).
+        // Both paths fall back, but the null case is informational, not a
+        // warning.
+        _assemblerMock.SetupGet(x => x.IsActive).Returns(true);
+        _assemblerMock.Setup(x => x.CombineAsync(It.IsAny<CancellationToken>())).ReturnsAsync((string?)null);
         _transcriptionMock
             .Setup(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TranscriptionResult("rescued", 0.9f));

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationTranscriberTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationTranscriberTests.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Speech;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
+using Olbrasoft.VirtualAssistant.Voice.Services;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the transcription façade lifted out of DictationWorker in #969:
+/// the raw path is streaming-aware (combined chunks when BeginSession(true)
+/// and chunks were forwarded, full-buffer fallback when the combine was
+/// empty), the full path is always full-buffer, and session lifecycle
+/// methods forward cleanly to the underlying IStreamingChunkAssembler.
+/// </summary>
+public class DictationTranscriberTests
+{
+    private readonly Mock<ILogger<DictationTranscriber>> _loggerMock = new();
+    private readonly Mock<ITranscriptionService> _transcriptionMock = new();
+    private readonly Mock<IStreamingChunkAssembler> _assemblerMock = new();
+
+    private DictationTranscriber CreateSut() =>
+        new(_loggerMock.Object, _transcriptionMock.Object, _assemblerMock.Object);
+
+    [Fact]
+    public void BeginSession_ForwardsActiveFlagToAssembler()
+    {
+        var sut = CreateSut();
+        sut.BeginSession(streamingActive: true);
+        _assemblerMock.Verify(x => x.Reset(true), Times.Once);
+    }
+
+    [Fact]
+    public void ForwardChunk_ForwardsToAssembler()
+    {
+        var sut = CreateSut();
+        sut.ForwardChunk(7, new byte[] { 1, 2, 3 });
+        _assemblerMock.Verify(x => x.SubmitChunk(7, It.Is<byte[]>(b => b.Length == 3)), Times.Once);
+    }
+
+    [Fact]
+    public void EndSession_CancelsAssemblerState()
+    {
+        var sut = CreateSut();
+        sut.EndSession();
+        _assemblerMock.Verify(x => x.CancelAndClear(), Times.Once);
+    }
+
+    [Fact]
+    public void IsStreamingActive_MirrorsAssemblerIsActive()
+    {
+        _assemblerMock.SetupGet(x => x.IsActive).Returns(true);
+        var sut = CreateSut();
+
+        Assert.True(sut.IsStreamingActive);
+    }
+
+    [Fact]
+    public async Task TranscribeRawAsync_StreamingInactive_RunsFullBufferRaw()
+    {
+        _assemblerMock.SetupGet(x => x.IsActive).Returns(false);
+        _transcriptionMock
+            .Setup(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("raw output", 0.9f));
+
+        var sut = CreateSut();
+        var result = await sut.TranscribeRawAsync(new byte[] { 1 }, CancellationToken.None);
+
+        Assert.Equal("raw output", result.Text);
+        _transcriptionMock.Verify(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        _assemblerMock.Verify(x => x.CombineAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TranscribeRawAsync_StreamingActive_WithCombinedText_FinalizesPretranscribed()
+    {
+        // The streaming path feeds the combined chunk output back through
+        // FinalizePreTranscribedRawAsync so filters/corrections still apply —
+        // the per-chunk Whisper output is just STT, not the final shape.
+        _assemblerMock.SetupGet(x => x.IsActive).Returns(true);
+        _assemblerMock.Setup(x => x.CombineAsync(It.IsAny<CancellationToken>())).ReturnsAsync("combined text");
+        _transcriptionMock
+            .Setup(x => x.FinalizePreTranscribedRawAsync("combined text", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("combined text", 0.9f));
+
+        var sut = CreateSut();
+        var result = await sut.TranscribeRawAsync(new byte[] { 1 }, CancellationToken.None);
+
+        Assert.Equal("combined text", result.Text);
+        _transcriptionMock.Verify(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TranscribeRawAsync_StreamingActive_WithEmptyCombine_FallsBackToFullBuffer()
+    {
+        // Per the xmldoc fallback contract: empty streaming result means
+        // "chunks were faulted or produced no text" — rerun Whisper on the
+        // full buffer so dictation still produces something.
+        _assemblerMock.SetupGet(x => x.IsActive).Returns(true);
+        _assemblerMock.Setup(x => x.CombineAsync(It.IsAny<CancellationToken>())).ReturnsAsync("   ");
+        _transcriptionMock
+            .Setup(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("rescued", 0.9f));
+
+        var sut = CreateSut();
+        var result = await sut.TranscribeRawAsync(new byte[] { 1 }, CancellationToken.None);
+
+        Assert.Equal("rescued", result.Text);
+        _transcriptionMock.Verify(x => x.FinalizePreTranscribedRawAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TranscribeFullAsync_ForwardsToTranscribeAsync()
+    {
+        _transcriptionMock
+            .Setup(x => x.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("full-pipeline", 0.9f));
+
+        var sut = CreateSut();
+        var result = await sut.TranscribeFullAsync(new byte[] { 1 }, CancellationToken.None);
+
+        Assert.Equal("full-pipeline", result.Text);
+        _transcriptionMock.Verify(x => x.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        _assemblerMock.Verify(x => x.CombineAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void RawTranscriptionReady_ForwardsFromUnderlyingService()
+    {
+        // The underlying ITranscriptionService raises this event mid-pipeline
+        // so the UI can show "your words" before the LLM correction lands.
+        // The transcriber must re-raise it so the worker keeps the same API
+        // after the extraction.
+        string? captured = null;
+        var sut = CreateSut();
+        sut.RawTranscriptionReady += text => captured = text;
+
+        _transcriptionMock.Raise(x => x.RawTranscriptionReady += null, "hello");
+
+        Assert.Equal("hello", captured);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -25,11 +25,10 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IKeyboardMonitor> _keyboardMonitorMock;
     private readonly Mock<IDictationStateMachine> _stateMachineMock;
     private readonly Mock<IAudioRecordingCoordinator> _recordingCoordinatorMock;
-    private readonly Mock<ITranscriptionService> _transcriptionServiceMock;
+    private readonly Mock<IDictationTranscriber> _transcriberMock;
     private readonly Mock<IDictationOutputChannel> _outputChannelMock;
     private readonly Mock<IDictationTranscriptionPersister> _persisterMock;
     private readonly Mock<IClaudeCodeCivilityTrimmer> _civilityTrimmerMock;
-    private readonly Mock<IStreamingChunkAssembler> _streamingAssemblerMock;
     private readonly DictationOptions _options;
     private readonly DictationWorker _sut;
 
@@ -41,11 +40,10 @@ public class DictationWorkerTests : IDisposable
         _keyboardMonitorMock = new Mock<IKeyboardMonitor>();
         _stateMachineMock = new Mock<IDictationStateMachine>();
         _recordingCoordinatorMock = new Mock<IAudioRecordingCoordinator>();
-        _transcriptionServiceMock = new Mock<ITranscriptionService>();
+        _transcriberMock = new Mock<IDictationTranscriber>();
         _outputChannelMock = new Mock<IDictationOutputChannel>();
         _persisterMock = new Mock<IDictationTranscriptionPersister>();
         _civilityTrimmerMock = new Mock<IClaudeCodeCivilityTrimmer>();
-        _streamingAssemblerMock = new Mock<IStreamingChunkAssembler>();
 
         _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
 
@@ -66,11 +64,10 @@ public class DictationWorkerTests : IDisposable
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             Options.Create(_options));
     }
 
@@ -84,11 +81,10 @@ public class DictationWorkerTests : IDisposable
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -100,11 +96,10 @@ public class DictationWorkerTests : IDisposable
             null!,
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -116,11 +111,10 @@ public class DictationWorkerTests : IDisposable
             _keyboardMonitorMock.Object,
             null!,
             _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -132,11 +126,10 @@ public class DictationWorkerTests : IDisposable
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             null!));
     }
 
@@ -148,16 +141,15 @@ public class DictationWorkerTests : IDisposable
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
             null!,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
     [Fact]
-    public void Constructor_NullTranscriptionService_ThrowsArgumentNullException()
+    public void Constructor_NullTranscriber_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object,
@@ -168,7 +160,6 @@ public class DictationWorkerTests : IDisposable
             _outputChannelMock.Object,
             _persisterMock.Object,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -180,11 +171,10 @@ public class DictationWorkerTests : IDisposable
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             null!,
             _persisterMock.Object,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -196,11 +186,10 @@ public class DictationWorkerTests : IDisposable
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             _outputChannelMock.Object,
             null!,
             _civilityTrimmerMock.Object,
-            _streamingAssemblerMock.Object,
             Options.Create(_options)));
     }
 
@@ -212,26 +201,9 @@ public class DictationWorkerTests : IDisposable
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
             _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
+            _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
-            null!,
-            _streamingAssemblerMock.Object,
-            Options.Create(_options)));
-    }
-
-    [Fact]
-    public void Constructor_NullStreamingAssembler_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
-            _transcriptionServiceMock.Object,
-            _outputChannelMock.Object,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
             null!,
             Options.Create(_options)));
     }
@@ -271,7 +243,7 @@ public class DictationWorkerTests : IDisposable
         _ = _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
-        _transcriptionServiceMock.VerifyAdd(x => x.RawTranscriptionReady += It.IsAny<Action<string>>(), Times.Once);
+        _transcriberMock.VerifyAdd(x => x.RawTranscriptionReady += It.IsAny<Action<string>>(), Times.Once);
     }
 
     [Fact]
@@ -283,7 +255,7 @@ public class DictationWorkerTests : IDisposable
 
         await _sut.StopAsync(CancellationToken.None);
 
-        _transcriptionServiceMock.VerifyRemove(x => x.RawTranscriptionReady -= It.IsAny<Action<string>>(), Times.Once);
+        _transcriberMock.VerifyRemove(x => x.RawTranscriptionReady -= It.IsAny<Action<string>>(), Times.Once);
     }
 
     #endregion
@@ -428,7 +400,7 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(audioData);
-        _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -438,7 +410,7 @@ public class DictationWorkerTests : IDisposable
 
         _recordingCoordinatorMock.Verify(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()), Times.Once);
         _outputChannelMock.Verify(x => x.StartTypingFeedback(), Times.Once);
-        _transcriptionServiceMock.Verify(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
+        _transcriberMock.Verify(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -477,7 +449,7 @@ public class DictationWorkerTests : IDisposable
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(200);
 
-        _transcriptionServiceMock.Verify(x => x.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _transcriberMock.Verify(x => x.TranscribeFullAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
     }
 
@@ -494,7 +466,7 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(audioData);
-        _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(failedResult);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
@@ -522,7 +494,7 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(audioData);
-        _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -560,7 +532,7 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(audioData);
-        _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -599,7 +571,7 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(audioData);
-        _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
@@ -679,7 +651,7 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(audioData);
-        _transcriptionServiceMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
+        _transcriberMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -688,8 +660,8 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(400);
 
         // Verify raw transcription used (not full pipeline)
-        _transcriptionServiceMock.Verify(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
-        _transcriptionServiceMock.Verify(x => x.TranscribeAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _transcriberMock.Verify(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
+        _transcriberMock.Verify(x => x.TranscribeFullAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
 
         // Verify FastPaste used (not TypeIntoActiveWindow)
         _outputChannelMock.Verify(x => x.FastPasteAsync("Quick test", It.IsAny<CancellationToken>()), Times.Once);
@@ -712,7 +684,7 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(audioData);
-        _transcriptionServiceMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
+        _transcriberMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
         _outputChannelMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
@@ -760,7 +732,7 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(audioData);
-        _transcriptionServiceMock.Setup(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()))
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
         _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -769,8 +741,8 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(400);
 
         // Verify normal transcription used (not raw)
-        _transcriptionServiceMock.Verify(x => x.TranscribeAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
-        _transcriptionServiceMock.Verify(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _transcriberMock.Verify(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
+        _transcriberMock.Verify(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     #endregion


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Fourth step in the #969 god-class split (parent #967). Continues the extraction work from #1021 / #1025 / #1026. Bundles `ITranscriptionService` + `IStreamingChunkAssembler` behind one `IDictationTranscriber` façade so the worker never talks to either backend directly.

## Summary

New `IDictationTranscriber` + `DictationTranscriber` façade that owns:

- **Session lifecycle**: `BeginSession` / `ForwardChunk` / `EndSession` (all forward to the streaming assembler).
- **Raw transcription** (`TranscribeRawAsync`): streaming-aware. When the session was started with `streamingActive=true` and chunks were forwarded, combines them through `FinalizePreTranscribedRawAsync` so filters still apply; if the combine produces empty text, falls back to full-buffer Whisper so the user always gets some output.
- **Full transcription** (`TranscribeFullAsync`): plain forward to `TranscribeAsync` — the full-pipeline path is never streaming-aware (LLM correction would contaminate per-chunk decisions).
- **`RawTranscriptionReady` event**: re-raised from the underlying `ITranscriptionService` so subscribers bind against the transcriber façade instead of the backend.
- **`IsStreamingActive` property**: lets the worker skip streaming-specific cleanup when slow-mode overrides the start-time choice (`StopDictationAsync(quickMode: false)` branch).

## Impact on DictationWorker

- LOC: **704 → 679**
- ctor deps: **10 → 9** (removes `ITranscriptionService` + `IStreamingChunkAssembler`, adds `IDictationTranscriber`)
- The two transcribe-with-sound methods shrink to: sound start → create CTS → transcriber call → failure guard. The streaming-vs-full decision moves out.

## Tests

- `DictationWorkerTests` — ctor swap drops two mocks, adds one. Null-arg test for `NullTranscriber`; `NullStreamingAssembler` test removed (no longer a direct dep). `Setup`/`Verify` sites switched to `_transcriberMock` with `TranscribeFullAsync` / `TranscribeRawAsync` on the new interface.
- New `DictationTranscriberTests` (9 cases): session lifecycle forwards, `IsStreamingActive` mirrors assembler, raw path inactive=full-buffer, active+non-empty=`FinalizePreTranscribedRawAsync`, active+empty=fallback, full path is never streaming-aware, `RawTranscriptionReady` re-raises.

## Progress for #969

- worker LOC: **679** (target ≤ 400)
- worker ctor deps: **9** (target ≤ 5)
- Remaining worker-internal state (key-event handler, state-machine event wiring, recording lifecycle orchestration) is the next extraction boundary.

## Test plan

- [x] `dotnet build` green
- [x] `dotnet test tests/VirtualAssistant.Service.Tests/` = 369/369 (+9 new transcriber tests; retains 360 from prior phases)
- [ ] CI green
- [ ] Post-deploy dictation smoke: quick + slow path both produce correct text in their respective targets