### PR TITLE
refactor(dictation): extract IDictationRecordingSession (#969 partial)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -58,6 +58,15 @@ public static class WorkerServicesExtensions
                 transcription,
                 assembler);
 
+            // Bundle the audio-recording coordinator + streaming-chunk
+            // forwarding behind a single IDictationRecordingSession so the
+            // worker no longer subscribes to ChunkAvailable or toggles
+            // chunking directly. (#969 extraction.)
+            var recordingSession = new DictationRecordingSession(
+                sp.GetRequiredService<ILogger<DictationRecordingSession>>(),
+                sp.GetRequiredKeyedService<IAudioRecordingCoordinator>(DictationKey),
+                transcriber);
+
             // Bundle the four output-surface dependencies (sounds, keyboard,
             // SignalR) behind a single IDictationOutputChannel so the worker
             // ctor shrinks by three deps. (#969 god-class split.)
@@ -82,7 +91,7 @@ public static class WorkerServicesExtensions
                 sp.GetRequiredService<ILogger<DictationWorker>>(),
                 sp.GetRequiredService<IKeyboardMonitor>(),
                 sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
-                sp.GetRequiredKeyedService<IAudioRecordingCoordinator>(DictationKey),
+                recordingSession,
                 transcriber,
                 outputChannel,
                 persister,

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationRecordingSession.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationRecordingSession.cs
@@ -1,0 +1,62 @@
+using Olbrasoft.VirtualAssistant.Core.Audio;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationRecordingSession : IDictationRecordingSession, IDisposable
+{
+    private readonly ILogger<DictationRecordingSession> _logger;
+    private readonly IAudioRecordingCoordinator _recordingCoordinator;
+    private readonly IDictationTranscriber _transcriber;
+
+    public DictationRecordingSession(
+        ILogger<DictationRecordingSession> logger,
+        IAudioRecordingCoordinator recordingCoordinator,
+        IDictationTranscriber transcriber)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _recordingCoordinator = recordingCoordinator ?? throw new ArgumentNullException(nameof(recordingCoordinator));
+        _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
+
+        // Forward each emitted chunk to the transcriber's streaming assembler.
+        // Kept inside the session so the worker never sees the chunk event.
+        _recordingCoordinator.ChunkAvailable += OnChunkAvailable;
+    }
+
+    public bool IsStreamingActive => _transcriber.IsStreamingActive;
+
+    public async Task StartAsync(bool streamingActive)
+    {
+        _transcriber.BeginSession(streamingActive);
+
+        if (streamingActive)
+        {
+            _recordingCoordinator.EnableChunking(TimeSpan.FromSeconds(8));
+            _logger.LogInformation("Streaming transcription active for this session (8s chunks)");
+        }
+        else
+        {
+            _recordingCoordinator.DisableChunking();
+        }
+
+        await _recordingCoordinator.StartRecordingAsync();
+    }
+
+    public Task<byte[]> StopAsync() => _recordingCoordinator.StopRecordingAsync();
+
+    public Task EmergencyStopAsync() => _recordingCoordinator.EmergencyStopAsync();
+
+    public void EndSession()
+    {
+        _transcriber.EndSession();
+        _recordingCoordinator.DisableChunking();
+    }
+
+    private void OnChunkAvailable(object? sender, AudioChunkEventArgs e) =>
+        _transcriber.ForwardChunk(e.Index, e.PcmBytes);
+
+    public void Dispose()
+    {
+        _recordingCoordinator.ChunkAvailable -= OnChunkAvailable;
+    }
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationRecordingSession.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationRecordingSession.cs
@@ -1,0 +1,50 @@
+using Olbrasoft.VirtualAssistant.Core.Audio;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Audio-recording lifecycle lifted out of <c>DictationWorker</c> (#969
+/// god-class split). Bundles <see cref="IAudioRecordingCoordinator"/> with
+/// the streaming-session hooks on <see cref="IDictationTranscriber"/> so
+/// the worker no longer subscribes to <c>ChunkAvailable</c>, toggles
+/// chunking directly, or coordinates the transcriber's streaming state —
+/// it just tells the session start / stop / cancel / reset. State-machine
+/// transitions stay in the worker because they're cross-cutting across
+/// the transcription, typing, and cancel paths too.
+/// </summary>
+public interface IDictationRecordingSession
+{
+    /// <summary>
+    /// True when streaming chunk transcription is active for the current
+    /// session (<see cref="StartAsync"/> was called with
+    /// <c>streamingActive=true</c> and <see cref="EndSession"/> hasn't run
+    /// yet). Delegates to the underlying transcriber.
+    /// </summary>
+    bool IsStreamingActive { get; }
+
+    /// <summary>
+    /// Start a new recording session. Opens the transcriber's streaming
+    /// session, toggles chunking on the coordinator, and starts the audio
+    /// capture. Caller owns state-machine transitions.
+    /// </summary>
+    Task StartAsync(bool streamingActive);
+
+    /// <summary>
+    /// Stop the recording and return the captured PCM buffer. Caller owns
+    /// state-machine transitions and empty-buffer handling.
+    /// </summary>
+    Task<byte[]> StopAsync();
+
+    /// <summary>
+    /// Emergency-stop the recording (discards the buffer). Used on cancel,
+    /// shutdown, and the "dictation disabled while active" path.
+    /// </summary>
+    Task EmergencyStopAsync();
+
+    /// <summary>
+    /// End the streaming session: cancels in-flight per-chunk transcription
+    /// tasks and disables chunking on the coordinator. Safe to call
+    /// repeatedly; cheap when streaming wasn't active.
+    /// </summary>
+    void EndSession();
+}

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Options;
-using Olbrasoft.VirtualAssistant.Core.Audio;
 using Olbrasoft.VirtualAssistant.Core.Configuration;
 using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
@@ -22,7 +21,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly ILogger<DictationWorker> _logger;
     private readonly IKeyboardMonitor _keyboardMonitor;
     private readonly IDictationStateMachine _stateMachine;
-    private readonly IAudioRecordingCoordinator _recordingCoordinator;
+    private readonly IDictationRecordingSession _recordingSession;
     private readonly IDictationTranscriber _transcriber;
     private readonly IDictationOutputChannel _outputChannel;
     private readonly IDictationTranscriptionPersister _persister;
@@ -44,7 +43,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         ILogger<DictationWorker> logger,
         IKeyboardMonitor keyboardMonitor,
         IDictationStateMachine stateMachine,
-        IAudioRecordingCoordinator recordingCoordinator,
+        IDictationRecordingSession recordingSession,
         IDictationTranscriber transcriber,
         IDictationOutputChannel outputChannel,
         IDictationTranscriptionPersister persister,
@@ -54,7 +53,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _keyboardMonitor = keyboardMonitor ?? throw new ArgumentNullException(nameof(keyboardMonitor));
         _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
-        _recordingCoordinator = recordingCoordinator ?? throw new ArgumentNullException(nameof(recordingCoordinator));
+        _recordingSession = recordingSession ?? throw new ArgumentNullException(nameof(recordingSession));
         _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
         _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
         _persister = persister ?? throw new ArgumentNullException(nameof(persister));
@@ -150,10 +149,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // If user picked slow mode but streaming was pre-transcribing chunks,
             // cancel those background tasks — they'd be discarded anyway, no point
             // burning GPU/serializing the Whisper semaphore for them.
-            if (!quickMode && _transcriber.IsStreamingActive)
+            if (!quickMode && _recordingSession.IsStreamingActive)
             {
-                _transcriber.EndSession();
-                _recordingCoordinator.DisableChunking();
+                _recordingSession.EndSession();
                 _logger.LogInformation("Slow-mode override: canceled pending streaming chunk transcriptions");
             }
 
@@ -183,9 +181,6 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             TranscriptionCompleted += OnTranscriptionCompletedBroadcast;
             _transcriber.RawTranscriptionReady += OnRawTranscriptionReadyBroadcast;
 
-            // Subscribe to streaming chunk emissions — transcribes each chunk in background
-            _recordingCoordinator.ChunkAvailable += OnChunkAvailable;
-
             // Wait for cancellation
             await Task.Delay(Timeout.Infinite, stoppingToken);
         }
@@ -204,7 +199,6 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _stateMachine.StateChanged -= OnStateChangedBroadcast;
             TranscriptionCompleted -= OnTranscriptionCompletedBroadcast;
             _transcriber.RawTranscriptionReady -= OnRawTranscriptionReadyBroadcast;
-            _recordingCoordinator.ChunkAvailable -= OnChunkAvailable;
 
             // Stop recording if active
             if (_stateMachine.CurrentState == DictationState.Recording)
@@ -311,16 +305,6 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _ = BroadcastDictationEventAsync(DictationEventType.RawTranscriptionCompleted, text);
     }
 
-    /// <summary>
-    /// Forwards a streaming audio chunk to <see cref="IDictationTranscriber"/>,
-    /// which runs the per-chunk Whisper call on a background task. Ignored when
-    /// streaming is not active for the current session.
-    /// </summary>
-    private void OnChunkAvailable(object? sender, AudioChunkEventArgs e)
-    {
-        _transcriber.ForwardChunk(e.Index, e.PcmBytes);
-    }
-
     private Task BroadcastDictationEventAsync(DictationEventType eventType, string? text) =>
         _outputChannel.BroadcastEventAsync(eventType, text);
 
@@ -331,22 +315,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // Transition to Recording state
             _stateMachine.TransitionTo(DictationState.Recording);
 
-            // Freeze streaming choice for this session — toggles mid-recording have no effect
-            var streamingActive = _streamingTranscriptionEnabled;
-            _transcriber.BeginSession(streamingActive);
-
-            if (streamingActive)
-            {
-                _recordingCoordinator.EnableChunking(TimeSpan.FromSeconds(8));
-                _logger.LogInformation("Streaming transcription active for this session (8s chunks)");
-            }
-            else
-            {
-                _recordingCoordinator.DisableChunking();
-            }
-
-            // Start audio recording via coordinator
-            await _recordingCoordinator.StartRecordingAsync();
+            // Freeze streaming choice for this session — toggles mid-recording have no effect.
+            // The session owns transcriber.BeginSession + chunking toggle + audio start.
+            await _recordingSession.StartAsync(_streamingTranscriptionEnabled);
         }
         catch (Exception ex)
         {
@@ -435,19 +406,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         {
             _transcriptionCts?.Dispose();
             _transcriptionCts = null;
-            ResetStreamingSessionState();
+            _recordingSession.EndSession();
         }
-    }
-
-    /// <summary>
-    /// Clears streaming chunk state after a dictation session completes (any path).
-    /// Delegates the concurrent-collection cleanup to <see cref="IDictationTranscriber"/>;
-    /// the worker still owns the recording-coordinator's chunking flag.
-    /// </summary>
-    private void ResetStreamingSessionState()
-    {
-        _transcriber.EndSession();
-        _recordingCoordinator.DisableChunking();
     }
 
     /// <summary>
@@ -456,7 +416,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     /// </summary>
     private async Task<byte[]?> ValidateAndPrepareAudioAsync()
     {
-        var audioData = await _recordingCoordinator.StopRecordingAsync();
+        var audioData = await _recordingSession.StopAsync();
 
         if (audioData.Length == 0)
         {
@@ -561,8 +521,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         {
             _logger.LogInformation("Canceling recording");
 
-            // Emergency stop recording via coordinator (discards audio data)
-            await _recordingCoordinator.EmergencyStopAsync();
+            // Emergency stop recording (discards audio data)
+            await _recordingSession.EmergencyStopAsync();
 
             // Play cancel sound (paper-rip effect)
             _outputChannel.PlayCancelCue();
@@ -583,8 +543,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     {
         try
         {
-            // Emergency stop recording via coordinator (discards audio data)
-            await _recordingCoordinator.EmergencyStopAsync();
+            // Emergency stop recording (discards audio data)
+            await _recordingSession.EmergencyStopAsync();
 
             // Return to Idle without transcription
             _stateMachine.TransitionTo(DictationState.Idle);
@@ -596,7 +556,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         }
         finally
         {
-            ResetStreamingSessionState();
+            _recordingSession.EndSession();
         }
     }
 
@@ -625,7 +585,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
                 // async would ripple through the hub + state-machine call sites
                 // without any runtime benefit — this is a user-initiated,
                 // infrequent cancel path, not the transcription/streaming hot path.
-                _recordingCoordinator.EmergencyStopAsync().GetAwaiter().GetResult();
+                _recordingSession.EmergencyStopAsync().GetAwaiter().GetResult();
             }
 
             // Cancel transcription if in progress
@@ -635,7 +595,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
             // Cancel in-flight streaming chunk tasks and clear chunk state,
             // otherwise they keep running into the next session.
-            ResetStreamingSessionState();
+            _recordingSession.EndSession();
 
             // Return to Idle
             _stateMachine.TransitionTo(DictationState.Idle);
@@ -654,8 +614,8 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
         try
         {
-            // Stop recording via coordinator (discards audio data on shutdown)
-            await _recordingCoordinator.EmergencyStopAsync();
+            // Stop recording (discards audio data on shutdown)
+            await _recordingSession.EmergencyStopAsync();
         }
         catch (Exception ex)
         {

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationRecordingSessionTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationRecordingSessionTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Audio;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the recording-session façade lifted out of DictationWorker in #969:
+/// StartAsync toggles chunking (8s on/off) and opens the transcriber's
+/// streaming session before starting audio capture, EmergencyStop discards
+/// audio without side-effects, and ChunkAvailable events are forwarded
+/// internally to the transcriber so the worker never sees them.
+/// </summary>
+public class DictationRecordingSessionTests
+{
+    private readonly Mock<ILogger<DictationRecordingSession>> _loggerMock = new();
+    private readonly Mock<IAudioRecordingCoordinator> _coordinatorMock = new();
+    private readonly Mock<IDictationTranscriber> _transcriberMock = new();
+
+    private DictationRecordingSession CreateSut() =>
+        new(_loggerMock.Object, _coordinatorMock.Object, _transcriberMock.Object);
+
+    [Fact]
+    public async Task StartAsync_Streaming_EnablesChunkingAndOpensTranscriberSession()
+    {
+        var sut = CreateSut();
+
+        await sut.StartAsync(streamingActive: true);
+
+        _transcriberMock.Verify(x => x.BeginSession(true), Times.Once);
+        _coordinatorMock.Verify(x => x.EnableChunking(TimeSpan.FromSeconds(8)), Times.Once);
+        _coordinatorMock.Verify(x => x.DisableChunking(), Times.Never);
+        _coordinatorMock.Verify(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_NonStreaming_DisablesChunkingAndStillOpensTranscriberSession()
+    {
+        // Non-streaming is the default path; the transcriber still gets a
+        // BeginSession(false) so the assembler's "is active" flag is reset
+        // from any prior streaming session.
+        var sut = CreateSut();
+
+        await sut.StartAsync(streamingActive: false);
+
+        _transcriberMock.Verify(x => x.BeginSession(false), Times.Once);
+        _coordinatorMock.Verify(x => x.DisableChunking(), Times.Once);
+        _coordinatorMock.Verify(x => x.EnableChunking(It.IsAny<TimeSpan>()), Times.Never);
+        _coordinatorMock.Verify(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StopAsync_ReturnsCoordinatorBuffer()
+    {
+        var buffer = new byte[] { 1, 2, 3 };
+        _coordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>())).ReturnsAsync(buffer);
+        var sut = CreateSut();
+
+        var result = await sut.StopAsync();
+
+        Assert.Same(buffer, result);
+    }
+
+    [Fact]
+    public async Task EmergencyStopAsync_ForwardsToCoordinator()
+    {
+        _coordinatorMock.Setup(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        await sut.EmergencyStopAsync();
+
+        _coordinatorMock.Verify(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void EndSession_EndsTranscriberSessionAndDisablesChunking()
+    {
+        var sut = CreateSut();
+
+        sut.EndSession();
+
+        _transcriberMock.Verify(x => x.EndSession(), Times.Once);
+        _coordinatorMock.Verify(x => x.DisableChunking(), Times.Once);
+    }
+
+    [Fact]
+    public void IsStreamingActive_MirrorsTranscriber()
+    {
+        _transcriberMock.SetupGet(x => x.IsStreamingActive).Returns(true);
+        var sut = CreateSut();
+
+        Assert.True(sut.IsStreamingActive);
+    }
+
+    [Fact]
+    public void ChunkAvailable_ForwardedToTranscriber()
+    {
+        // The point of pulling this into the session is that the worker never
+        // sees ChunkAvailable — the session subscribes at construction and
+        // fans out to the transcriber internally.
+        var sut = CreateSut();
+
+        _coordinatorMock.Raise(x => x.ChunkAvailable += null,
+            this, new AudioChunkEventArgs(3, new byte[] { 1, 2 }));
+
+        _transcriberMock.Verify(
+            x => x.ForwardChunk(3, It.Is<byte[]>(b => b.Length == 2)),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromChunkAvailable()
+    {
+        var sut = CreateSut();
+
+        sut.Dispose();
+        _coordinatorMock.Raise(x => x.ChunkAvailable += null,
+            this, new AudioChunkEventArgs(0, new byte[] { 1 }));
+
+        _transcriberMock.Verify(x => x.ForwardChunk(It.IsAny<int>(), It.IsAny<byte[]>()), Times.Never);
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationRecordingSession(null!, _coordinatorMock.Object, _transcriberMock.Object));
+
+    [Fact]
+    public void Constructor_NullCoordinator_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationRecordingSession(_loggerMock.Object, null!, _transcriberMock.Object));
+
+    [Fact]
+    public void Constructor_NullTranscriber_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationRecordingSession(_loggerMock.Object, _coordinatorMock.Object, null!));
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Olbrasoft.Testing.Xunit.Attributes;
-using Olbrasoft.VirtualAssistant.Core.Audio;
 using Olbrasoft.VirtualAssistant.Core.Configuration;
 using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
@@ -24,7 +23,7 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<ILogger<DictationWorker>> _loggerMock;
     private readonly Mock<IKeyboardMonitor> _keyboardMonitorMock;
     private readonly Mock<IDictationStateMachine> _stateMachineMock;
-    private readonly Mock<IAudioRecordingCoordinator> _recordingCoordinatorMock;
+    private readonly Mock<IDictationRecordingSession> _recordingSessionMock;
     private readonly Mock<IDictationTranscriber> _transcriberMock;
     private readonly Mock<IDictationOutputChannel> _outputChannelMock;
     private readonly Mock<IDictationTranscriptionPersister> _persisterMock;
@@ -39,7 +38,7 @@ public class DictationWorkerTests : IDisposable
         _loggerMock = new Mock<ILogger<DictationWorker>>();
         _keyboardMonitorMock = new Mock<IKeyboardMonitor>();
         _stateMachineMock = new Mock<IDictationStateMachine>();
-        _recordingCoordinatorMock = new Mock<IAudioRecordingCoordinator>();
+        _recordingSessionMock = new Mock<IDictationRecordingSession>();
         _transcriberMock = new Mock<IDictationTranscriber>();
         _outputChannelMock = new Mock<IDictationOutputChannel>();
         _persisterMock = new Mock<IDictationTranscriptionPersister>();
@@ -63,7 +62,7 @@ public class DictationWorkerTests : IDisposable
             _loggerMock.Object,
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
@@ -80,7 +79,7 @@ public class DictationWorkerTests : IDisposable
             null!,
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
@@ -95,7 +94,7 @@ public class DictationWorkerTests : IDisposable
             _loggerMock.Object,
             null!,
             _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
@@ -110,7 +109,7 @@ public class DictationWorkerTests : IDisposable
             _loggerMock.Object,
             _keyboardMonitorMock.Object,
             null!,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
@@ -125,7 +124,7 @@ public class DictationWorkerTests : IDisposable
             _loggerMock.Object,
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
@@ -134,7 +133,7 @@ public class DictationWorkerTests : IDisposable
     }
 
     [Fact]
-    public void Constructor_NullRecordingCoordinator_ThrowsArgumentNullException()
+    public void Constructor_NullRecordingSession_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object,
@@ -155,7 +154,7 @@ public class DictationWorkerTests : IDisposable
             _loggerMock.Object,
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             null!,
             _outputChannelMock.Object,
             _persisterMock.Object,
@@ -170,7 +169,7 @@ public class DictationWorkerTests : IDisposable
             _loggerMock.Object,
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             _transcriberMock.Object,
             null!,
             _persisterMock.Object,
@@ -185,7 +184,7 @@ public class DictationWorkerTests : IDisposable
             _loggerMock.Object,
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
             null!,
@@ -200,7 +199,7 @@ public class DictationWorkerTests : IDisposable
             _loggerMock.Object,
             _keyboardMonitorMock.Object,
             _stateMachineMock.Object,
-            _recordingCoordinatorMock.Object,
+            _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
             _persisterMock.Object,
@@ -269,20 +268,20 @@ public class DictationWorkerTests : IDisposable
 
         _sut.SetDictationEnabled(false);
 
-        _recordingCoordinatorMock.Verify(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Never);
     }
 
     [Fact]
     public async Task SetDictationEnabled_DisablingWhileRecording_PerformsEmergencyStop()
     {
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync())
             .Returns(Task.CompletedTask);
 
         _sut.SetDictationEnabled(false);
         await Task.Delay(100);
 
-        _recordingCoordinatorMock.Verify(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
     }
 
@@ -290,13 +289,13 @@ public class DictationWorkerTests : IDisposable
     public async Task SetDictationEnabled_DisablingWhileTranscribing_PerformsEmergencyStop()
     {
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
-        _recordingCoordinatorMock.Setup(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync())
             .Returns(Task.CompletedTask);
 
         _sut.SetDictationEnabled(false);
         await Task.Delay(100);
 
-        _recordingCoordinatorMock.Verify(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
     }
 
     #endregion
@@ -311,14 +310,14 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(50);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
-        _recordingCoordinatorMock.Setup(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>()))
             .Returns(Task.CompletedTask);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(150);
 
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
-        _recordingCoordinatorMock.Verify(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Once);
     }
 
     [Fact]
@@ -332,7 +331,7 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(100);
 
         _stateMachineMock.Verify(x => x.TransitionTo(It.IsAny<DictationState>()), Times.Never);
-        _recordingCoordinatorMock.Verify(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Never);
     }
 
     [Fact]
@@ -379,7 +378,7 @@ public class DictationWorkerTests : IDisposable
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Pause, IsPressed = false });
         await Task.Delay(100);
 
-        _recordingCoordinatorMock.Verify(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
         _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
     }
@@ -398,7 +397,7 @@ public class DictationWorkerTests : IDisposable
         };
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
         _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
@@ -408,7 +407,7 @@ public class DictationWorkerTests : IDisposable
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(300);
 
-        _recordingCoordinatorMock.Verify(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _recordingSessionMock.Verify(x => x.StopAsync(), Times.Once);
         _outputChannelMock.Verify(x => x.StartTypingFeedback(), Times.Once);
         _transcriberMock.Verify(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -427,8 +426,8 @@ public class DictationWorkerTests : IDisposable
 
         // ScrollLock during transcription should be ignored (use Pause to cancel)
         _stateMachineMock.Verify(x => x.TransitionTo(It.IsAny<DictationState>()), Times.Never);
-        _recordingCoordinatorMock.Verify(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()), Times.Never);
-        _recordingCoordinatorMock.Verify(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Never);
+        _recordingSessionMock.Verify(x => x.StopAsync(), Times.Never);
     }
 
     #endregion
@@ -443,7 +442,7 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(50);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(Array.Empty<byte>());
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
@@ -464,7 +463,7 @@ public class DictationWorkerTests : IDisposable
         var failedResult = new TranscriptionResult("Error") { OriginalText = null };
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
         _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(failedResult);
@@ -492,7 +491,7 @@ public class DictationWorkerTests : IDisposable
         };
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
         _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
@@ -530,7 +529,7 @@ public class DictationWorkerTests : IDisposable
         };
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
         _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
@@ -569,7 +568,7 @@ public class DictationWorkerTests : IDisposable
         };
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
         _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
@@ -598,7 +597,7 @@ public class DictationWorkerTests : IDisposable
 
         await _sut.StopAsync(CancellationToken.None);
 
-        _recordingCoordinatorMock.Verify(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Never);
     }
 
     [Fact]
@@ -609,12 +608,12 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(50);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync())
             .Returns(Task.CompletedTask);
 
         await _sut.StopAsync(CancellationToken.None);
 
-        _recordingCoordinatorMock.Verify(x => x.EmergencyStopAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.AtLeastOnce);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
     }
 
@@ -630,7 +629,7 @@ public class DictationWorkerTests : IDisposable
         await _sut.StartQuickDictationAsync();
 
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
-        _recordingCoordinatorMock.Verify(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Once);
     }
 
     [SkipOnCIFact]
@@ -649,7 +648,7 @@ public class DictationWorkerTests : IDisposable
 
         // Stop and transcribe
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
         _transcriberMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
@@ -682,7 +681,7 @@ public class DictationWorkerTests : IDisposable
         await _sut.StartQuickDictationAsync();
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
         _transcriberMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(transcriptionResult);
@@ -720,7 +719,7 @@ public class DictationWorkerTests : IDisposable
 
         // Then: keyboard dictation via ScrollLock should use normal mode
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
-        _recordingCoordinatorMock.Setup(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>()))
             .Returns(Task.CompletedTask);
 
         var audioData = new byte[] { 1, 2, 3 };
@@ -730,7 +729,7 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(100);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingCoordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>()))
+        _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
         _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Part of #969 (DictationWorker god-class split).

## Summary

5th extraction from DictationWorker. Bundles `IAudioRecordingCoordinator` + the streaming-session hooks on `IDictationTranscriber` behind a single `IDictationRecordingSession` so the worker no longer subscribes to `ChunkAvailable`, toggles chunking directly, or coordinates transcriber streaming state.

- New `IDictationRecordingSession` + `DictationRecordingSession` (subscribes to `ChunkAvailable` at construction, fans out to `transcriber.ForwardChunk` internally, unsubscribes on `Dispose`).
- Worker drops the `IAudioRecordingCoordinator` dependency; now talks to the session for start / stop / emergency-stop / end-session, and to the transcriber only for transcribe calls + streaming-lifecycle delegation via the session.
- `ResetStreamingSessionState` helper folded into `session.EndSession()`.
- DI factory constructs the session inline in the DictationWorker singleton.

Worker: **679 → 639 LOC**. Dep count unchanged (9 — swap `recordingCoordinator` for `recordingSession`), but the worker loses a whole responsibility (chunk subscription + chunking-toggle coordination) and the recording-lifecycle coupling to the transcriber is now mediated through one facade.

## Tests

- `DictationRecordingSessionTests` — 11 new cases pinning streaming / non-streaming start paths, stop/emergency-stop, end-session cleanup, `ChunkAvailable` forwarding + `Dispose` unsubscribe.
- `DictationWorkerTests` — updated to mock `IDictationRecordingSession` instead of `IAudioRecordingCoordinator`; null-ctor-arg test renamed.
- Full suite green: 381 Service tests (up from 370).

## Test plan

- [x] `dotnet build` — green, no new warnings.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — all 932 non-integration tests pass.