### PR TITLE
refactor(dictation): extract IDictationCompletionPipeline (#969 partial)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -87,6 +87,18 @@ public static class WorkerServicesExtensions
                 sp.GetRequiredService<ILogger<ClaudeCodeCivilityTrimmer>>(),
                 sp.GetRequiredService<ICliAppDetector>());
 
+            // Bundle the post-recording transcribe → save → trim → paste/type
+            // pipeline behind one IDictationCompletionPipeline so the worker
+            // drops the persister + civility-trimmer deps and ~170 LOC of
+            // inline orchestration. (#969 extraction.)
+            var completionPipeline = new DictationCompletionPipeline(
+                sp.GetRequiredService<ILogger<DictationCompletionPipeline>>(),
+                sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
+                transcriber,
+                outputChannel,
+                persister,
+                civilityTrimmer);
+
             return new DictationWorker(
                 sp.GetRequiredService<ILogger<DictationWorker>>(),
                 sp.GetRequiredService<IKeyboardMonitor>(),
@@ -94,8 +106,7 @@ public static class WorkerServicesExtensions
                 recordingSession,
                 transcriber,
                 outputChannel,
-                persister,
-                civilityTrimmer,
+                completionPipeline,
                 sp.GetRequiredService<IOptions<DictationOptions>>());
         });
 

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationCompletionPipeline.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationCompletionPipeline.cs
@@ -1,0 +1,126 @@
+using Olbrasoft.VirtualAssistant.Core.Models;
+using Olbrasoft.VirtualAssistant.Core.Speech;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+using Olbrasoft.VirtualAssistant.Voice.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationCompletionPipeline : IDictationCompletionPipeline
+{
+    private readonly ILogger<DictationCompletionPipeline> _logger;
+    private readonly IDictationStateMachine _stateMachine;
+    private readonly IDictationTranscriber _transcriber;
+    private readonly IDictationOutputChannel _outputChannel;
+    private readonly IDictationTranscriptionPersister _persister;
+    private readonly IClaudeCodeCivilityTrimmer _civilityTrimmer;
+
+    public DictationCompletionPipeline(
+        ILogger<DictationCompletionPipeline> logger,
+        IDictationStateMachine stateMachine,
+        IDictationTranscriber transcriber,
+        IDictationOutputChannel outputChannel,
+        IDictationTranscriptionPersister persister,
+        IClaudeCodeCivilityTrimmer civilityTrimmer)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
+        _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
+        _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
+        _persister = persister ?? throw new ArgumentNullException(nameof(persister));
+        _civilityTrimmer = civilityTrimmer ?? throw new ArgumentNullException(nameof(civilityTrimmer));
+    }
+
+    public async Task CompleteQuickAsync(byte[] audio, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(audio);
+
+        _outputChannel.StartTypingFeedback();
+
+        var result = await _transcriber.TranscribeRawAsync(audio, cancellationToken);
+
+        if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
+        {
+            _logger.LogWarning("Quick transcription failed or empty");
+            _outputChannel.StopTypingFeedback();
+            _stateMachine.TransitionTo(DictationState.Idle);
+            return;
+        }
+
+        _logger.LogInformation("Quick transcription: '{Text}'", result.Text);
+
+        await _persister.SaveAsync(audio, result, cancellationToken);
+
+        // Strip trailing civility ("… Děkuji.", "… Ahoj.", Whisper hallucinated
+        // sign-offs) when pasting into a CLI agent that reads the text as a
+        // prompt. Scoped to Claude Code only — in chat apps "Děkuji." is a
+        // legitimate message and must stay.
+        var textToPaste = await _civilityTrimmer.TrimIfClaudeCodeAsync(result.Text, cancellationToken);
+        if (string.IsNullOrWhiteSpace(textToPaste))
+        {
+            _logger.LogInformation("Quick dictation: transcription reduced to empty after civility trim — skipping paste");
+            _outputChannel.StopTypingFeedback();
+            _stateMachine.TransitionTo(DictationState.Idle);
+            return;
+        }
+
+        // Quick mode: fast paste without clipboard save/restore.
+        var pasteSucceeded = await _outputChannel.FastPasteAsync(textToPaste, cancellationToken);
+        _outputChannel.StopTypingFeedback();
+
+        if (!pasteSucceeded)
+        {
+            _logger.LogWarning("Quick dictation: fast paste failed");
+            _stateMachine.TransitionTo(DictationState.Idle);
+            return;
+        }
+
+        // Broadcast QuickTranscriptionCompleted BEFORE idle transition so the
+        // client sets the pending flag first.
+        await _outputChannel.BroadcastEventAsync(DictationEventType.QuickTranscriptionCompleted, textToPaste);
+        _stateMachine.TransitionTo(DictationState.Idle);
+        _logger.LogInformation("Quick dictation: text pasted, QuickTranscriptionCompleted sent");
+    }
+
+    public async Task CompleteFullAsync(
+        byte[] audio,
+        Action<string> onTranscriptionReady,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(audio);
+        ArgumentNullException.ThrowIfNull(onTranscriptionReady);
+
+        _outputChannel.StartTypingFeedback();
+
+        var result = await _transcriber.TranscribeFullAsync(audio, cancellationToken);
+
+        if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
+        {
+            _logger.LogWarning("Transcription failed or empty");
+            _outputChannel.StopTypingFeedback();
+            _stateMachine.TransitionTo(DictationState.Idle);
+            return;
+        }
+
+        _logger.LogInformation("Transcription result: '{Text}'", result.Text);
+
+        await _persister.SaveAsync(audio, result, cancellationToken);
+
+        // Raise TranscriptionCompleted before typing so remote UI gets the text immediately.
+        onTranscriptionReady(result.Text);
+
+        var typed = await _outputChannel.TypeIntoActiveWindowAsync(result.Text, cancellationToken);
+        _outputChannel.StopTypingFeedback();
+
+        if (!typed)
+        {
+            _logger.LogWarning("Failed to type text into active window");
+            _stateMachine.TransitionTo(DictationState.Idle);
+            return;
+        }
+
+        _logger.LogInformation("Text typed successfully into active window");
+        _stateMachine.TransitionTo(DictationState.Idle);
+    }
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationCompletionPipeline.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationCompletionPipeline.cs
@@ -37,50 +37,50 @@ public sealed class DictationCompletionPipeline : IDictationCompletionPipeline
         ArgumentNullException.ThrowIfNull(audio);
 
         _outputChannel.StartTypingFeedback();
-
-        var result = await _transcriber.TranscribeRawAsync(audio, cancellationToken);
-
-        if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
+        try
         {
-            _logger.LogWarning("Quick transcription failed or empty");
+            var result = await _transcriber.TranscribeRawAsync(audio, cancellationToken);
+
+            if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
+            {
+                _logger.LogWarning("Quick transcription failed or empty");
+                return;
+            }
+
+            _logger.LogInformation("Quick transcription: '{Text}'", result.Text);
+
+            await _persister.SaveAsync(audio, result, cancellationToken);
+
+            // Strip trailing civility ("… Děkuji.", "… Ahoj.", Whisper hallucinated
+            // sign-offs) when pasting into a CLI agent that reads the text as a
+            // prompt. Scoped to Claude Code only — in chat apps "Děkuji." is a
+            // legitimate message and must stay.
+            var textToPaste = await _civilityTrimmer.TrimIfClaudeCodeAsync(result.Text, cancellationToken);
+            if (string.IsNullOrWhiteSpace(textToPaste))
+            {
+                _logger.LogInformation("Quick dictation: transcription reduced to empty after civility trim — skipping paste");
+                return;
+            }
+
+            // Quick mode: fast paste without clipboard save/restore.
+            var pasteSucceeded = await _outputChannel.FastPasteAsync(textToPaste, cancellationToken);
+
+            if (!pasteSucceeded)
+            {
+                _logger.LogWarning("Quick dictation: fast paste failed");
+                return;
+            }
+
+            // Broadcast QuickTranscriptionCompleted BEFORE idle transition so the
+            // client sets the pending flag first.
+            await _outputChannel.BroadcastEventAsync(DictationEventType.QuickTranscriptionCompleted, textToPaste);
+            _logger.LogInformation("Quick dictation: text pasted, QuickTranscriptionCompleted sent");
+        }
+        finally
+        {
             _outputChannel.StopTypingFeedback();
             _stateMachine.TransitionTo(DictationState.Idle);
-            return;
         }
-
-        _logger.LogInformation("Quick transcription: '{Text}'", result.Text);
-
-        await _persister.SaveAsync(audio, result, cancellationToken);
-
-        // Strip trailing civility ("… Děkuji.", "… Ahoj.", Whisper hallucinated
-        // sign-offs) when pasting into a CLI agent that reads the text as a
-        // prompt. Scoped to Claude Code only — in chat apps "Děkuji." is a
-        // legitimate message and must stay.
-        var textToPaste = await _civilityTrimmer.TrimIfClaudeCodeAsync(result.Text, cancellationToken);
-        if (string.IsNullOrWhiteSpace(textToPaste))
-        {
-            _logger.LogInformation("Quick dictation: transcription reduced to empty after civility trim — skipping paste");
-            _outputChannel.StopTypingFeedback();
-            _stateMachine.TransitionTo(DictationState.Idle);
-            return;
-        }
-
-        // Quick mode: fast paste without clipboard save/restore.
-        var pasteSucceeded = await _outputChannel.FastPasteAsync(textToPaste, cancellationToken);
-        _outputChannel.StopTypingFeedback();
-
-        if (!pasteSucceeded)
-        {
-            _logger.LogWarning("Quick dictation: fast paste failed");
-            _stateMachine.TransitionTo(DictationState.Idle);
-            return;
-        }
-
-        // Broadcast QuickTranscriptionCompleted BEFORE idle transition so the
-        // client sets the pending flag first.
-        await _outputChannel.BroadcastEventAsync(DictationEventType.QuickTranscriptionCompleted, textToPaste);
-        _stateMachine.TransitionTo(DictationState.Idle);
-        _logger.LogInformation("Quick dictation: text pasted, QuickTranscriptionCompleted sent");
     }
 
     public async Task CompleteFullAsync(
@@ -92,35 +92,37 @@ public sealed class DictationCompletionPipeline : IDictationCompletionPipeline
         ArgumentNullException.ThrowIfNull(onTranscriptionReady);
 
         _outputChannel.StartTypingFeedback();
-
-        var result = await _transcriber.TranscribeFullAsync(audio, cancellationToken);
-
-        if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
+        try
         {
-            _logger.LogWarning("Transcription failed or empty");
+            var result = await _transcriber.TranscribeFullAsync(audio, cancellationToken);
+
+            if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
+            {
+                _logger.LogWarning("Transcription failed or empty");
+                return;
+            }
+
+            _logger.LogInformation("Transcription result: '{Text}'", result.Text);
+
+            await _persister.SaveAsync(audio, result, cancellationToken);
+
+            // Raise TranscriptionCompleted before typing so remote UI gets the text immediately.
+            onTranscriptionReady(result.Text);
+
+            var typed = await _outputChannel.TypeIntoActiveWindowAsync(result.Text, cancellationToken);
+
+            if (!typed)
+            {
+                _logger.LogWarning("Failed to type text into active window");
+                return;
+            }
+
+            _logger.LogInformation("Text typed successfully into active window");
+        }
+        finally
+        {
             _outputChannel.StopTypingFeedback();
             _stateMachine.TransitionTo(DictationState.Idle);
-            return;
         }
-
-        _logger.LogInformation("Transcription result: '{Text}'", result.Text);
-
-        await _persister.SaveAsync(audio, result, cancellationToken);
-
-        // Raise TranscriptionCompleted before typing so remote UI gets the text immediately.
-        onTranscriptionReady(result.Text);
-
-        var typed = await _outputChannel.TypeIntoActiveWindowAsync(result.Text, cancellationToken);
-        _outputChannel.StopTypingFeedback();
-
-        if (!typed)
-        {
-            _logger.LogWarning("Failed to type text into active window");
-            _stateMachine.TransitionTo(DictationState.Idle);
-            return;
-        }
-
-        _logger.LogInformation("Text typed successfully into active window");
-        _stateMachine.TransitionTo(DictationState.Idle);
     }
 }

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationCompletionPipeline.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationCompletionPipeline.cs
@@ -1,0 +1,42 @@
+using Olbrasoft.VirtualAssistant.Core.Speech;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Post-recording "audio → spoken-into-active-window" pipeline lifted out of
+/// <c>DictationWorker</c> (#969 god-class split). Bundles the transcriber
+/// call, the typing-sound feedback, the persister save, the Claude-Code
+/// civility trim, and the FastPaste / TypeIntoActiveWindow + state-machine
+/// transitions that used to live inline in the worker's
+/// <c>StopAndTranscribeAsync</c> body. The worker keeps just the recording
+/// lifecycle, the CTS lifecycle, and the top-level exception handling.
+/// </summary>
+public interface IDictationCompletionPipeline
+{
+    /// <summary>
+    /// Quick-mode completion: raw (no-LLM) transcription, civility trim for
+    /// Claude Code, fast paste without clipboard save/restore, and the
+    /// <c>QuickTranscriptionCompleted</c> broadcast. Owns the typing sound
+    /// feedback and the Idle transition on every exit path.
+    /// </summary>
+    Task CompleteQuickAsync(byte[] audio, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Full-mode completion: full-pipeline transcription (LLM correction,
+    /// filters, racing), persister save, <paramref name="onTranscriptionReady"/>
+    /// invoked before typing so remote UI updates immediately, then
+    /// TypeIntoActiveWindow + Idle transition.
+    /// </summary>
+    /// <param name="audio">PCM buffer from the recording session.</param>
+    /// <param name="onTranscriptionReady">
+    /// Callback raised with the final text between transcription completing
+    /// and typing starting. Worker uses this to re-raise its public
+    /// <c>TranscriptionCompleted</c> event so the SignalR broadcast lands
+    /// before the keystrokes do.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation from the worker's CTS.</param>
+    Task CompleteFullAsync(
+        byte[] audio,
+        Action<string> onTranscriptionReady,
+        CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -24,8 +24,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly IDictationRecordingSession _recordingSession;
     private readonly IDictationTranscriber _transcriber;
     private readonly IDictationOutputChannel _outputChannel;
-    private readonly IDictationTranscriptionPersister _persister;
-    private readonly IClaudeCodeCivilityTrimmer _civilityTrimmer;
+    private readonly IDictationCompletionPipeline _completionPipeline;
     private readonly DictationOptions _options;
 
     private CancellationTokenSource? _transcriptionCts;
@@ -46,8 +45,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         IDictationRecordingSession recordingSession,
         IDictationTranscriber transcriber,
         IDictationOutputChannel outputChannel,
-        IDictationTranscriptionPersister persister,
-        IClaudeCodeCivilityTrimmer civilityTrimmer,
+        IDictationCompletionPipeline completionPipeline,
         IOptions<DictationOptions> options)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -56,8 +54,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _recordingSession = recordingSession ?? throw new ArgumentNullException(nameof(recordingSession));
         _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
         _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
-        _persister = persister ?? throw new ArgumentNullException(nameof(persister));
-        _civilityTrimmer = civilityTrimmer ?? throw new ArgumentNullException(nameof(civilityTrimmer));
+        _completionPipeline = completionPipeline ?? throw new ArgumentNullException(nameof(completionPipeline));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
     }
@@ -337,57 +334,18 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             var audioData = await ValidateAndPrepareAudioAsync();
             if (audioData == null) return;
 
-            TranscriptionResult? transcriptionResult;
+            _transcriptionCts = new CancellationTokenSource();
 
             if (_quickDictationMode)
             {
-                transcriptionResult = await TranscribeRawWithSoundAsync(audioData);
+                await _completionPipeline.CompleteQuickAsync(audioData, _transcriptionCts.Token);
             }
             else
             {
-                transcriptionResult = await TranscribeAudioWithSoundAsync(audioData);
-            }
-
-            if (transcriptionResult == null) return;
-
-            await SaveTranscriptionToDatabaseAsync(audioData, transcriptionResult);
-
-            if (_quickDictationMode)
-            {
-                // Strip trailing civility ("… Děkuji.", "… Ahoj.", Whisper
-                // hallucinated sign-offs) when pasting into a CLI agent that
-                // reads the text as a prompt. Scoped to Claude Code only — in
-                // chat apps "Děkuji." is a legitimate message and must stay.
-                var textToPaste = await StripCivilityForClaudeCodeAsync(transcriptionResult.Text, _transcriptionCts!.Token);
-                if (string.IsNullOrWhiteSpace(textToPaste))
-                {
-                    _logger.LogInformation("Quick dictation: transcription reduced to empty after civility trim — skipping paste");
-                    _outputChannel.StopTypingFeedback();
-                    _stateMachine.TransitionTo(DictationState.Idle);
-                    return;
-                }
-
-                // Quick mode: fast paste without clipboard save/restore
-                var pasteSucceeded = await _outputChannel.FastPasteAsync(textToPaste, _transcriptionCts!.Token);
-                _outputChannel.StopTypingFeedback();
-
-                if (!pasteSucceeded)
-                {
-                    _logger.LogWarning("Quick dictation: fast paste failed");
-                    _stateMachine.TransitionTo(DictationState.Idle);
-                    return;
-                }
-
-                // Broadcast QuickTranscriptionCompleted BEFORE idle transition so client sets pending flag first
-                await BroadcastDictationEventAsync(DictationEventType.QuickTranscriptionCompleted, textToPaste);
-                _stateMachine.TransitionTo(DictationState.Idle);
-                _logger.LogInformation("Quick dictation: text pasted, QuickTranscriptionCompleted sent");
-            }
-            else
-            {
-                // Raise TranscriptionCompleted before typing so remote UI gets the text immediately
-                TranscriptionCompleted?.Invoke(this, transcriptionResult.Text);
-                await TypeTextAndFinishAsync(transcriptionResult.Text);
+                await _completionPipeline.CompleteFullAsync(
+                    audioData,
+                    text => TranscriptionCompleted?.Invoke(this, text),
+                    _transcriptionCts.Token);
             }
         }
         catch (OperationCanceledException)
@@ -429,90 +387,6 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _stateMachine.TransitionTo(DictationState.Transcribing);
 
         return audioData;
-    }
-
-    /// <summary>
-    /// Raw (no-LLM) transcription with typing sound effect. The streaming-aware
-    /// raw pass lives in <see cref="IDictationTranscriber"/>; this method only
-    /// owns the UX side-effects (sound cue, CTS lifecycle, state-machine
-    /// fallback on failure).
-    /// </summary>
-    private async Task<TranscriptionResult?> TranscribeRawWithSoundAsync(byte[] audioData)
-    {
-        _outputChannel.StartTypingFeedback();
-        _transcriptionCts = new CancellationTokenSource();
-
-        var result = await _transcriber.TranscribeRawAsync(audioData, _transcriptionCts.Token);
-
-        if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
-        {
-            _logger.LogWarning("Quick transcription failed or empty");
-            _outputChannel.StopTypingFeedback();
-            _stateMachine.TransitionTo(DictationState.Idle);
-            return null;
-        }
-
-        _logger.LogInformation("Quick transcription: '{Text}'", result.Text);
-        return result;
-    }
-
-    /// <summary>
-    /// Full-pipeline transcription (with LLM correction, filters, racing) plus
-    /// typing sound feedback and the state-machine fallback on failure.
-    /// </summary>
-    private async Task<TranscriptionResult?> TranscribeAudioWithSoundAsync(byte[] audioData)
-    {
-        _outputChannel.StartTypingFeedback();
-        _transcriptionCts = new CancellationTokenSource();
-
-        var result = await _transcriber.TranscribeFullAsync(audioData, _transcriptionCts.Token);
-
-        if (!result.Success || string.IsNullOrWhiteSpace(result.Text))
-        {
-            _logger.LogWarning("Transcription failed or empty");
-            _outputChannel.StopTypingFeedback();
-            _stateMachine.TransitionTo(DictationState.Idle);
-            return null;
-        }
-
-        _logger.LogInformation("Transcription result: '{Text}'", result.Text);
-        return result;
-    }
-
-    /// <summary>
-    /// Saves transcription to database via <see cref="IDictationTranscriptionPersister"/>,
-    /// which owns the scoped <c>IDictationPersistenceService</c> resolution and
-    /// the racing/non-racing save dispatch. (#969 extraction.)
-    /// </summary>
-    private Task SaveTranscriptionToDatabaseAsync(byte[] audioData, TranscriptionResult result) =>
-        _persister.SaveAsync(audioData, result, _transcriptionCts!.Token);
-
-    /// <summary>
-    /// Thin wrapper around <see cref="IClaudeCodeCivilityTrimmer.TrimIfClaudeCodeAsync"/>
-    /// that the quick-dictation path calls before pasting. (#969 extraction
-    /// moved the detection + trimming into a dedicated helper.)
-    /// </summary>
-    private Task<string> StripCivilityForClaudeCodeAsync(string text, CancellationToken cancellationToken) =>
-        _civilityTrimmer.TrimIfClaudeCodeAsync(text, cancellationToken);
-
-    /// <summary>
-    /// Types text into active window and transitions to Idle state.
-    /// </summary>
-    private async Task TypeTextAndFinishAsync(string text)
-    {
-        var typed = await _outputChannel.TypeIntoActiveWindowAsync(text, _transcriptionCts!.Token);
-
-        _outputChannel.StopTypingFeedback();
-
-        if (!typed)
-        {
-            _logger.LogWarning("Failed to type text into active window");
-            _stateMachine.TransitionTo(DictationState.Idle);
-            return;
-        }
-
-        _logger.LogInformation("Text typed successfully into active window");
-        _stateMachine.TransitionTo(DictationState.Idle);
     }
 
     private async Task CancelRecordingAsync()

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -350,15 +350,13 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         }
         catch (OperationCanceledException)
         {
+            // Pipeline's finally already ran StopTypingFeedback + Idle transition
+            // (on both successful and faulted exit); worker only logs here.
             _logger.LogInformation("Transcription canceled by user");
-            _outputChannel.StopTypingFeedback();
-            _stateMachine.TransitionTo(DictationState.Idle);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error during transcription");
-            _outputChannel.StopTypingFeedback();
-            _stateMachine.TransitionTo(DictationState.Idle);
         }
         finally
         {

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationCompletionPipelineTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationCompletionPipelineTests.cs
@@ -1,0 +1,220 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Models;
+using Olbrasoft.VirtualAssistant.Core.Speech;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+using Olbrasoft.VirtualAssistant.Voice.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the post-recording pipeline lifted out of DictationWorker in #969.
+/// Covers the transcribe → save → (quick: trim + paste + broadcast) /
+/// (full: raise + type) → state-transition flow that used to live inline
+/// in the worker's StopAndTranscribeAsync body.
+/// </summary>
+public class DictationCompletionPipelineTests
+{
+    private readonly Mock<ILogger<DictationCompletionPipeline>> _loggerMock = new();
+    private readonly Mock<IDictationStateMachine> _stateMachineMock = new();
+    private readonly Mock<IDictationTranscriber> _transcriberMock = new();
+    private readonly Mock<IDictationOutputChannel> _outputChannelMock = new();
+    private readonly Mock<IDictationTranscriptionPersister> _persisterMock = new();
+    private readonly Mock<IClaudeCodeCivilityTrimmer> _civilityTrimmerMock = new();
+
+    public DictationCompletionPipelineTests()
+    {
+        // Default civility trimmer: passthrough (non-Claude-Code path).
+        // Individual tests override when they need the Claude-Code trim.
+        _civilityTrimmerMock
+            .Setup(x => x.TrimIfClaudeCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((text, _) => Task.FromResult(text));
+    }
+
+    private DictationCompletionPipeline CreateSut() =>
+        new(_loggerMock.Object, _stateMachineMock.Object, _transcriberMock.Object,
+            _outputChannelMock.Object, _persisterMock.Object, _civilityTrimmerMock.Object);
+
+    [Fact]
+    public async Task CompleteQuickAsync_Success_PastesAndBroadcasts()
+    {
+        var audio = new byte[] { 1, 2, 3 };
+        _transcriberMock.Setup(x => x.TranscribeRawAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("quick text", 0.9f));
+        _outputChannelMock.Setup(x => x.FastPasteAsync("quick text", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await CreateSut().CompleteQuickAsync(audio, CancellationToken.None);
+
+        _outputChannelMock.Verify(x => x.StartTypingFeedback(), Times.Once);
+        _persisterMock.Verify(
+            x => x.SaveAsync(audio, It.Is<TranscriptionResult>(r => r.Text == "quick text"), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _outputChannelMock.Verify(x => x.FastPasteAsync("quick text", It.IsAny<CancellationToken>()), Times.Once);
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(DictationEventType.QuickTranscriptionCompleted, "quick text", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteQuickAsync_TranscriptionEmpty_SkipsPaste()
+    {
+        var audio = new byte[] { 1 };
+        _transcriberMock.Setup(x => x.TranscribeRawAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("") { OriginalText = null });
+
+        await CreateSut().CompleteQuickAsync(audio, CancellationToken.None);
+
+        _outputChannelMock.Verify(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _persisterMock.Verify(
+            x => x.SaveAsync(It.IsAny<byte[]>(), It.IsAny<TranscriptionResult>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteQuickAsync_CivilityTrimmedToEmpty_SkipsPaste()
+    {
+        // Claude-Code civility trim strips "Děkuji." hallucination; if it
+        // reduces the whole text to empty the pipeline must skip paste,
+        // not send an empty keystroke burst.
+        var audio = new byte[] { 1 };
+        _transcriberMock.Setup(x => x.TranscribeRawAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("Děkuji.", 0.9f));
+        _civilityTrimmerMock
+            .Setup(x => x.TrimIfClaudeCodeAsync("Děkuji.", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("   ");
+
+        await CreateSut().CompleteQuickAsync(audio, CancellationToken.None);
+
+        _outputChannelMock.Verify(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(It.IsAny<DictationEventType>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteQuickAsync_FastPasteFails_DoesNotBroadcast()
+    {
+        // Regression for PR #1025 review: if the keystroke burst didn't land,
+        // the remote UI must NOT see QuickTranscriptionCompleted (otherwise it
+        // would light up as if the text went through).
+        var audio = new byte[] { 1 };
+        _transcriberMock.Setup(x => x.TranscribeRawAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("quick text", 0.9f));
+        _outputChannelMock.Setup(x => x.FastPasteAsync("quick text", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        await CreateSut().CompleteQuickAsync(audio, CancellationToken.None);
+
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(DictationEventType.QuickTranscriptionCompleted, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteFullAsync_Success_SavesAndTypes()
+    {
+        var audio = new byte[] { 1, 2 };
+        var transcription = new TranscriptionResult("hello world", 0.95f)
+        {
+            OriginalText = "hello world",
+            SttProviderId = 14,
+            PromptId = 42
+        };
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcription);
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync("hello world", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var callbackText = (string?)null;
+        await CreateSut().CompleteFullAsync(audio, text => callbackText = text, CancellationToken.None);
+
+        // Forwards the raw TranscriptionResult (incl. LLM metadata) to the
+        // persister; LlmCorrectionResult details live in the persister.
+        _persisterMock.Verify(
+            x => x.SaveAsync(
+                audio,
+                It.Is<TranscriptionResult>(r => r.Text == "hello world" && r.SttProviderId == 14 && r.PromptId == 42),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.Equal("hello world", callbackText);
+        _outputChannelMock.Verify(x => x.TypeIntoActiveWindowAsync("hello world", It.IsAny<CancellationToken>()), Times.Once);
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteFullAsync_TranscriptionEmpty_SkipsSaveAndType()
+    {
+        var audio = new byte[] { 1 };
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("") { OriginalText = null });
+
+        var callbackFired = false;
+        await CreateSut().CompleteFullAsync(audio, _ => callbackFired = true, CancellationToken.None);
+
+        _persisterMock.Verify(
+            x => x.SaveAsync(It.IsAny<byte[]>(), It.IsAny<TranscriptionResult>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        Assert.False(callbackFired);
+        _outputChannelMock.Verify(
+            x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteFullAsync_TypingFails_StillTransitionsIdle()
+    {
+        var audio = new byte[] { 1 };
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("text", 0.9f));
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        await CreateSut().CompleteFullAsync(audio, _ => { }, CancellationToken.None);
+
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteFullAsync_CallbackFiresBeforeTyping()
+    {
+        // The callback is the worker's TranscriptionCompleted event raise;
+        // it must fire BEFORE typing so the remote-UI SignalR broadcast
+        // lands ahead of the keystrokes.
+        var audio = new byte[] { 1 };
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("text", 0.9f));
+
+        var order = new List<string>();
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("type"))
+            .ReturnsAsync(true);
+
+        await CreateSut().CompleteFullAsync(audio, _ => order.Add("callback"), CancellationToken.None);
+
+        Assert.Equal(new[] { "callback", "type" }, order);
+    }
+
+    [Fact]
+    public async Task CompleteQuickAsync_NullAudio_Throws() =>
+        await Assert.ThrowsAsync<ArgumentNullException>(() => CreateSut().CompleteQuickAsync(null!, CancellationToken.None));
+
+    [Fact]
+    public async Task CompleteFullAsync_NullAudio_Throws() =>
+        await Assert.ThrowsAsync<ArgumentNullException>(() => CreateSut().CompleteFullAsync(null!, _ => { }, CancellationToken.None));
+
+    [Fact]
+    public async Task CompleteFullAsync_NullCallback_Throws() =>
+        await Assert.ThrowsAsync<ArgumentNullException>(() => CreateSut().CompleteFullAsync(new byte[] { 1 }, null!, CancellationToken.None));
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationCompletionPipelineTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationCompletionPipelineTests.cs
@@ -207,6 +207,37 @@ public class DictationCompletionPipelineTests
     }
 
     [Fact]
+    public async Task CompleteQuickAsync_TranscriberThrows_StillStopsFeedbackAndIdles()
+    {
+        // Copilot review on PR #1031: the pipeline's contract says it owns
+        // StopTypingFeedback + Idle transition on every exit path, so if an
+        // awaited dep throws (incl. cancellation), the finally block must
+        // still run. Otherwise the typing sound loops forever and the state
+        // machine stays stuck on Transcribing.
+        _transcriberMock.Setup(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            CreateSut().CompleteQuickAsync(new byte[] { 1 }, CancellationToken.None));
+
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteFullAsync_TranscriberThrows_StillStopsFeedbackAndIdles()
+    {
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            CreateSut().CompleteFullAsync(new byte[] { 1 }, _ => { }, CancellationToken.None));
+
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
     public async Task CompleteQuickAsync_NullAudio_Throws() =>
         await Assert.ThrowsAsync<ArgumentNullException>(() => CreateSut().CompleteQuickAsync(null!, CancellationToken.None));
 

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -26,8 +26,7 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IDictationRecordingSession> _recordingSessionMock;
     private readonly Mock<IDictationTranscriber> _transcriberMock;
     private readonly Mock<IDictationOutputChannel> _outputChannelMock;
-    private readonly Mock<IDictationTranscriptionPersister> _persisterMock;
-    private readonly Mock<IClaudeCodeCivilityTrimmer> _civilityTrimmerMock;
+    private readonly Mock<IDictationCompletionPipeline> _completionPipelineMock;
     private readonly DictationOptions _options;
     private readonly DictationWorker _sut;
 
@@ -41,17 +40,9 @@ public class DictationWorkerTests : IDisposable
         _recordingSessionMock = new Mock<IDictationRecordingSession>();
         _transcriberMock = new Mock<IDictationTranscriber>();
         _outputChannelMock = new Mock<IDictationOutputChannel>();
-        _persisterMock = new Mock<IDictationTranscriptionPersister>();
-        _civilityTrimmerMock = new Mock<IClaudeCodeCivilityTrimmer>();
+        _completionPipelineMock = new Mock<IDictationCompletionPipeline>();
 
         _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
-
-        // The civility trimmer is always on the quick-dictation path; without
-        // an explicit passthrough setup, the Mock default returns null/empty
-        // which trips the "reduced to empty" short-circuit and skips paste.
-        _civilityTrimmerMock
-            .Setup(x => x.TrimIfClaudeCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns<string, CancellationToken>((text, _) => Task.FromResult(text));
 
         _keyboardMonitorMock.SetupAdd(x => x.KeyReleased += It.IsAny<EventHandler<KeyEventArgs>>())
             .Callback<EventHandler<KeyEventArgs>>(handler => _capturedKeyReleasedHandler = handler);
@@ -65,8 +56,7 @@ public class DictationWorkerTests : IDisposable
             _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
+            _completionPipelineMock.Object,
             Options.Create(_options));
     }
 
@@ -82,8 +72,7 @@ public class DictationWorkerTests : IDisposable
             _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
+            _completionPipelineMock.Object,
             Options.Create(_options)));
     }
 
@@ -97,8 +86,7 @@ public class DictationWorkerTests : IDisposable
             _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
+            _completionPipelineMock.Object,
             Options.Create(_options)));
     }
 
@@ -112,8 +100,7 @@ public class DictationWorkerTests : IDisposable
             _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
+            _completionPipelineMock.Object,
             Options.Create(_options)));
     }
 
@@ -127,8 +114,7 @@ public class DictationWorkerTests : IDisposable
             _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
+            _completionPipelineMock.Object,
             null!));
     }
 
@@ -142,8 +128,7 @@ public class DictationWorkerTests : IDisposable
             null!,
             _transcriberMock.Object,
             _outputChannelMock.Object,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
+            _completionPipelineMock.Object,
             Options.Create(_options)));
     }
 
@@ -157,8 +142,7 @@ public class DictationWorkerTests : IDisposable
             _recordingSessionMock.Object,
             null!,
             _outputChannelMock.Object,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
+            _completionPipelineMock.Object,
             Options.Create(_options)));
     }
 
@@ -172,13 +156,12 @@ public class DictationWorkerTests : IDisposable
             _recordingSessionMock.Object,
             _transcriberMock.Object,
             null!,
-            _persisterMock.Object,
-            _civilityTrimmerMock.Object,
+            _completionPipelineMock.Object,
             Options.Create(_options)));
     }
 
     [Fact]
-    public void Constructor_NullPersister_ThrowsArgumentNullException()
+    public void Constructor_NullCompletionPipeline_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object,
@@ -187,22 +170,6 @@ public class DictationWorkerTests : IDisposable
             _recordingSessionMock.Object,
             _transcriberMock.Object,
             _outputChannelMock.Object,
-            null!,
-            _civilityTrimmerMock.Object,
-            Options.Create(_options)));
-    }
-
-    [Fact]
-    public void Constructor_NullCivilityTrimmer_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingSessionMock.Object,
-            _transcriberMock.Object,
-            _outputChannelMock.Object,
-            _persisterMock.Object,
             null!,
             Options.Create(_options)));
     }
@@ -384,32 +351,25 @@ public class DictationWorkerTests : IDisposable
     }
 
     [SkipOnCIFact]
-    public async Task KeyReleased_ScrollLockWhileRecording_StopsAndTranscribes()
+    public async Task KeyReleased_ScrollLockWhileRecording_StopsRecordingAndInvokesPipeline()
     {
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
         var audioData = new byte[] { 1, 2, 3, 4 };
-        var transcriptionResult = new TranscriptionResult("Test transcription", 0.95f)
-        {
-            OriginalText = "Test transcription"
-        };
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
-        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(transcriptionResult);
-        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(300);
 
         _recordingSessionMock.Verify(x => x.StopAsync(), Times.Once);
-        _outputChannelMock.Verify(x => x.StartTypingFeedback(), Times.Once);
-        _transcriberMock.Verify(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
+        _completionPipelineMock.Verify(
+            x => x.CompleteFullAsync(audioData, It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -435,8 +395,12 @@ public class DictationWorkerTests : IDisposable
     #region Transcription Workflow Tests
 
     [SkipOnCIFact]
-    public async Task StopAndTranscribe_EmptyAudio_TransitionsToIdleWithoutTranscription()
+    public async Task StopAndTranscribe_EmptyAudio_SkipsCompletionPipeline()
     {
+        // ValidateAndPrepareAudioAsync returns null on empty buffer; the
+        // pipeline must never be invoked. Transcription workflow internals
+        // (save + type + state transitions) are covered in
+        // DictationCompletionPipelineTests.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
@@ -448,138 +412,78 @@ public class DictationWorkerTests : IDisposable
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(200);
 
-        _transcriberMock.Verify(x => x.TranscribeFullAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
+        _completionPipelineMock.Verify(
+            x => x.CompleteFullAsync(It.IsAny<byte[]>(), It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _completionPipelineMock.Verify(
+            x => x.CompleteQuickAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [SkipOnCIFact]
-    public async Task StopAndTranscribe_TranscriptionFails_TransitionsToIdle()
+    public async Task StopAndTranscribe_NormalMode_InvokesCompleteFullAsync()
     {
+        // Worker's only job in normal dictation is to stop recording, hand
+        // the audio to the completion pipeline's full-mode method, and wire
+        // the TranscriptionCompleted callback. The actual pipeline behavior
+        // (save, type, state transitions) is covered in
+        // DictationCompletionPipelineTests.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
         var audioData = new byte[] { 1, 2, 3, 4 };
-        var failedResult = new TranscriptionResult("Error") { OriginalText = null };
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
-        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(failedResult);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(300);
+        await Task.Delay(200);
 
-        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.AtLeastOnce);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
-    }
-
-    [SkipOnCIFact]
-    public async Task StopAndTranscribe_SuccessfulTranscription_TypesTextAndSaves()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        var audioData = new byte[] { 1, 2, 3, 4 };
-        const int expectedProviderId = 14; // Google STT
-        var transcriptionResult = new TranscriptionResult("Hello world", 0.95f)
-        {
-            OriginalText = "Hello world",
-            SttProviderId = expectedProviderId
-        };
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(audioData);
-        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(transcriptionResult);
-        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(400);
-
-        _outputChannelMock.Verify(x => x.TypeIntoActiveWindowAsync("Hello world", It.IsAny<CancellationToken>()), Times.Once);
-        // The LlmCorrectionResult building + STT-provider fallback live in the
-        // persister now; the worker's contract is just "forward the raw
-        // TranscriptionResult". DictationTranscriptionPersisterTests cover the
-        // details.
-        _persisterMock.Verify(x => x.SaveAsync(
-            audioData, It.Is<TranscriptionResult>(r => r.Text == "Hello world" && r.SttProviderId == expectedProviderId), It.IsAny<CancellationToken>()),
+        _completionPipelineMock.Verify(
+            x => x.CompleteFullAsync(
+                audioData,
+                It.IsAny<Action<string>>(),
+                It.IsAny<CancellationToken>()),
             Times.Once);
-        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.AtLeastOnce);
+        _completionPipelineMock.Verify(
+            x => x.CompleteQuickAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [SkipOnCIFact]
-    public async Task StopAndTranscribe_WithLlmCorrection_SavesCorrectedTextWithMetadata()
+    public async Task StopAndTranscribe_NormalMode_TranscriptionCompletedCallbackRaisesWorkerEvent()
     {
+        // The worker's public TranscriptionCompleted event must fire for any
+        // text the pipeline hands back via the callback — this is how the
+        // SignalR broadcast + remote UI see the text before the keystrokes
+        // land.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
         var audioData = new byte[] { 1, 2, 3, 4 };
-        var transcriptionResult = new TranscriptionResult("Hello world corrected", 0.95f)
-        {
-            OriginalText = "hello world",
-            LlmDurationMs = 150,
-            PromptId = 42,
-            ModelId = 1
-        };
-
+        Action<string>? capturedCallback = null;
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
-        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(transcriptionResult);
-        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+        _completionPipelineMock
+            .Setup(x => x.CompleteFullAsync(
+                It.IsAny<byte[]>(), It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<byte[], Action<string>, CancellationToken>((_, cb, _) => capturedCallback = cb)
+            .Returns(Task.CompletedTask);
+
+        string? workerEventText = null;
+        ((IDictationService)_sut).TranscriptionCompleted += (_, text) => workerEventText = text;
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(400);
+        await Task.Delay(200);
 
-        // Worker just forwards the TranscriptionResult (incl. LLM-correction
-        // metadata) to the persister; the LlmCorrectionResult construction is
-        // pinned in DictationTranscriptionPersisterTests.
-        _persisterMock.Verify(x => x.SaveAsync(
-            audioData,
-            It.Is<TranscriptionResult>(r =>
-                r.Text == "Hello world corrected" &&
-                r.OriginalText == "hello world" &&
-                r.PromptId == 42 &&
-                r.ModelId == 1 &&
-                r.LlmDurationMs == 150),
-            It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
+        Assert.NotNull(capturedCallback);
+        capturedCallback!("final text");
 
-    [SkipOnCIFact]
-    public async Task StopAndTranscribe_KeyboardSimulationFails_TransitionsToIdle()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        var audioData = new byte[] { 1, 2, 3, 4 };
-        var transcriptionResult = new TranscriptionResult("Test text", 0.95f)
-        {
-            OriginalText = "Test text"
-        };
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(audioData);
-        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(transcriptionResult);
-        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(400);
-
-        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.AtLeastOnce);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
+        Assert.Equal("final text", workerEventText);
     }
 
     #endregion
@@ -633,49 +537,17 @@ public class DictationWorkerTests : IDisposable
     }
 
     [SkipOnCIFact]
-    public async Task QuickDictation_UsesTranscribeRawAndFastPaste()
+    public async Task QuickDictation_InvokesCompleteQuickAsync()
     {
+        // Worker's quick-mode contract: StartQuickDictationAsync flips the
+        // flag, and on stop the worker hands audio to CompleteQuickAsync.
+        // Fast-paste / civility-trim / broadcast internals are covered in
+        // DictationCompletionPipelineTests.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
         var audioData = new byte[] { 1, 2, 3, 4 };
-        var transcriptionResult = new TranscriptionResult("Quick test", 0.95f);
-
-        // Start quick dictation
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
-        await _sut.StartQuickDictationAsync();
-
-        // Stop and transcribe
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(audioData);
-        _transcriberMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(transcriptionResult);
-        _outputChannelMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        await _sut.StopDictationAsync();
-        await Task.Delay(400);
-
-        // Verify raw transcription used (not full pipeline)
-        _transcriberMock.Verify(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
-        _transcriberMock.Verify(x => x.TranscribeFullAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
-
-        // Verify FastPaste used (not TypeIntoActiveWindow)
-        _outputChannelMock.Verify(x => x.FastPasteAsync("Quick test", It.IsAny<CancellationToken>()), Times.Once);
-        _outputChannelMock.Verify(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [SkipOnCIFact]
-    public async Task QuickDictation_WhenFastPasteFails_DoesNotBroadcastQuickTranscriptionCompleted()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        var audioData = new byte[] { 1, 2, 3, 4 };
-        var transcriptionResult = new TranscriptionResult("Quick test", 0.95f);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         await _sut.StartQuickDictationAsync();
@@ -683,47 +555,39 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
-        _transcriberMock.Setup(x => x.TranscribeRawAsync(audioData, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(transcriptionResult);
-        _outputChannelMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
 
         await _sut.StopDictationAsync();
-        await Task.Delay(400);
+        await Task.Delay(200);
 
-        // Should still transition to Idle on failure — AND must not emit the
-        // QuickTranscriptionCompleted broadcast, since the paste didn't land
-        // (remote UI would otherwise light up as if the text went through).
-        // (Copilot review on PR #1025.)
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
-        _outputChannelMock.Verify(
-            x => x.BroadcastEventAsync(DictationEventType.QuickTranscriptionCompleted, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+        _completionPipelineMock.Verify(
+            x => x.CompleteQuickAsync(audioData, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _completionPipelineMock.Verify(
+            x => x.CompleteFullAsync(It.IsAny<byte[]>(), It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
     [SkipOnCIFact]
     public async Task KeyboardDictation_AfterQuickMode_ResetsToNormalMode()
     {
+        // After canceling a quick-mode session, the next ScrollLock-triggered
+        // dictation must go through the full-mode pipeline, not the quick one.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
-        // First: start quick dictation via hub
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         await _sut.StartQuickDictationAsync();
 
-        // Cancel it
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         ((IDictationService)_sut).CancelTranscription();
         await Task.Delay(50);
 
-        // Then: keyboard dictation via ScrollLock should use normal mode
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>()))
             .Returns(Task.CompletedTask);
 
         var audioData = new byte[] { 1, 2, 3 };
-        var result = new TranscriptionResult("Normal test", 0.9f);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
         await Task.Delay(100);
@@ -731,17 +595,13 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync())
             .ReturnsAsync(audioData);
-        _transcriberMock.Setup(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(result);
-        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
 
         _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(400);
+        await Task.Delay(200);
 
-        // Verify normal transcription used (not raw)
-        _transcriberMock.Verify(x => x.TranscribeFullAsync(audioData, It.IsAny<CancellationToken>()), Times.Once);
-        _transcriberMock.Verify(x => x.TranscribeRawAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _completionPipelineMock.Verify(
+            x => x.CompleteFullAsync(audioData, It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
     }
 
     #endregion

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -395,12 +395,11 @@ public class DictationWorkerTests : IDisposable
     #region Transcription Workflow Tests
 
     [SkipOnCIFact]
-    public async Task StopAndTranscribe_EmptyAudio_SkipsCompletionPipeline()
+    public async Task StopAndTranscribe_EmptyAudio_TransitionsIdleAndSkipsCompletionPipeline()
     {
-        // ValidateAndPrepareAudioAsync returns null on empty buffer; the
-        // pipeline must never be invoked. Transcription workflow internals
-        // (save + type + state transitions) are covered in
-        // DictationCompletionPipelineTests.
+        // Worker's ValidateAndPrepareAudioAsync owns the empty-buffer branch:
+        // it transitions the state machine back to Idle (since the pipeline
+        // won't run) and the pipeline must never be invoked.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
@@ -418,6 +417,7 @@ public class DictationWorkerTests : IDisposable
         _completionPipelineMock.Verify(
             x => x.CompleteQuickAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
     }
 
     [SkipOnCIFact]


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Part of #969 (DictationWorker god-class split).

## Summary

6th extraction. Bundles the post-recording `transcribe → save → (quick: trim + paste + broadcast) / (full: raise + type) → idle` flow behind one `IDictationCompletionPipeline` so the worker drops two deps (persister + civility trimmer) and ~170 LOC of inline orchestration.

- New `IDictationCompletionPipeline` + `DictationCompletionPipeline` (owns typing sound feedback, transcriber call, persister save, Claude-Code civility trim, FastPaste/TypeIntoActiveWindow, `QuickTranscriptionCompleted` broadcast, idle transition).
- Full-mode takes an `Action<string> onTranscriptionReady` callback fired between transcription and typing so the worker's public `TranscriptionCompleted` event still lands before keystrokes.
- Worker's `StopAndTranscribeAsync` shrinks to validate → new CTS → pipeline → top-level try/catch + finally. Deleted `TranscribeRawWithSoundAsync`, `TranscribeAudioWithSoundAsync`, `SaveTranscriptionToDatabaseAsync`, `StripCivilityForClaudeCodeAsync`, `TypeTextAndFinishAsync`.
- Deep pipeline assertions (LLM-metadata forwarding, paste-broadcast ordering, civility-trim skip) moved out of `DictationWorkerTests` into new `DictationCompletionPipelineTests` (11 cases). Worker tests now just verify pipeline invocation.

Worker: **639 → 513 LOC**, **ctor deps 9 → 8**. Target still ≤400 / ≤5; remaining extraction candidates are the key-event handler and state-broadcast subscriptions.

## Test plan

- [x] `dotnet build` — green.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 388 Service tests (up from 381), 918 tests total across projects pass.