### PR TITLE
fix(dictation): respect SpeechProvider.PrimaryProvider config (slow quick-dictation)

### DIFF
--- a/src/VirtualAssistant.Core/Configuration/SpeechProviderSettings.cs
+++ b/src/VirtualAssistant.Core/Configuration/SpeechProviderSettings.cs
@@ -11,14 +11,16 @@ public class SpeechProviderSettings
     public const string SectionName = "SpeechProvider";
 
     /// <summary>
-    /// Primary STT provider name ("google" or "whisper").
+    /// Primary STT provider name ("google" or "whisper"). Defaults to local
+    /// Whisper — no remote API round-trip for the default deployment.
     /// </summary>
-    public string PrimaryProvider { get; set; } = "google";
+    public string PrimaryProvider { get; set; } = "whisper";
 
     /// <summary>
-    /// Fallback STT provider name when primary fails.
+    /// Fallback STT provider name when primary fails. Defaults to "google"
+    /// since Whisper is primary by default.
     /// </summary>
-    public string FallbackProvider { get; set; } = "whisper";
+    public string FallbackProvider { get; set; } = "google";
 
     /// <summary>
     /// Enable automatic fallback to secondary provider on failure.

--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -189,14 +189,19 @@ public static class WorkerServicesExtensions
                 Microsoft.Extensions.Options.Options.Create(continuousOptions));
         });
 
-        // Active transcriber for dictation — Google primary + dedicated Whisper fallback
-        // when configured, otherwise the single available provider.
-        // NOTE: GoogleSpeechTranscriber is registered as a concrete singleton in
-        // VoiceServicesExtensions (NOT as a keyed ISpeechTranscriber), so we pull it
-        // by type here. A previous version of this code used
-        // GetKeyedService<ISpeechTranscriber>("google") which always returned null
-        // and silently fell back to Whisper (pre-existing bug) — Copilot caught it
-        // during the #977 review.
+        // Active transcriber for dictation — honors appsettings
+        // SpeechProvider.PrimaryProvider so the config-declared primary really
+        // gets hit first. Previously this was hardcoded to Google-primary +
+        // Whisper-fallback regardless of config, which meant a ~7s Google API
+        // round-trip for every quick dictation even on hosts configured for
+        // local Whisper Turbo.
+        //
+        // NOTE: GoogleSpeechTranscriber is registered as a concrete singleton
+        // in VoiceServicesExtensions (NOT as a keyed ISpeechTranscriber), so we
+        // pull it by type here. A previous version of this code used
+        // GetKeyedService<ISpeechTranscriber>("google") which always returned
+        // null and silently fell back to Whisper — Copilot caught it during
+        // the #977 review.
         services.AddKeyedSingleton<ISpeechTranscriber>(DictationKey, (sp, _) =>
         {
             var speechSettings = sp.GetRequiredService<IOptions<SpeechProviderSettings>>().Value;
@@ -207,12 +212,22 @@ public static class WorkerServicesExtensions
             if (googleTranscriber == null)
                 return whisper;
 
+            // Map config provider names to concrete transcribers. Unknown
+            // names fall back to Whisper so misconfiguration can't degrade
+            // quick dictation into a remote API round-trip.
+            var primaryName = (speechSettings.PrimaryProvider ?? "whisper").Trim().ToLowerInvariant();
+            var (primary, fallback) = primaryName switch
+            {
+                "google" => ((ISpeechTranscriber)googleTranscriber, (ISpeechTranscriber)whisper),
+                _ => ((ISpeechTranscriber)whisper, (ISpeechTranscriber)googleTranscriber),
+            };
+
             if (!speechSettings.EnableFallback)
-                return googleTranscriber;
+                return primary;
 
             return new FallbackSpeechTranscriber(
-                googleTranscriber,
-                whisper,
+                primary,
+                fallback,
                 factory,
                 sp.GetRequiredService<ILogger<FallbackSpeechTranscriber>>(),
                 speechSettings);

--- a/tests/VirtualAssistant.Core.Tests/Configuration/SpeechProviderSettingsTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Configuration/SpeechProviderSettingsTests.cs
@@ -4,9 +4,10 @@ namespace Olbrasoft.VirtualAssistant.Core.Tests.Configuration;
 
 /// <summary>
 /// Pins the defaults on SpeechProviderSettings: the whole fallback chain
-/// depends on Primary=google / Fallback=whisper / Enable=true wiring so
-/// production starts with Google STT and degrades to local Whisper on API
-/// errors. A silent default drift would flip the production behavior.
+/// depends on Primary=whisper / Fallback=google / Enable=true wiring so the
+/// default deployment runs local Whisper Turbo (no remote API round-trip)
+/// and only falls back to Google STT on failure. A silent default drift
+/// would flip quick dictation back into a ~7s Google API round-trip.
 /// </summary>
 public class SpeechProviderSettingsTests
 {
@@ -15,8 +16,8 @@ public class SpeechProviderSettingsTests
     {
         var settings = new SpeechProviderSettings();
 
-        Assert.Equal("google", settings.PrimaryProvider);
-        Assert.Equal("whisper", settings.FallbackProvider);
+        Assert.Equal("whisper", settings.PrimaryProvider);
+        Assert.Equal("google", settings.FallbackProvider);
         Assert.True(settings.EnableFallback);
     }
 


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

## Problem

User reported quick dictation (the remote control's "rychle" button) taking ~8 seconds and suspected LLM correction was silently running. Log inspection ruled LLM out — the actual culprit was a 7.5s Google STT API round-trip:

```
Sending 1404928 bytes to Google Speech API (language: cs-CZ)
Google STT transcription successful: "..." (confidence: 93 %, 7508.5622ms)
```

Production `appsettings.json` has `SpeechProvider.PrimaryProvider = "whisper"` (local GPU Whisper Turbo) but the DI wiring at `WorkerServicesExtensions.AddDictationTranscriberServices` hardcoded `new FallbackSpeechTranscriber(googleTranscriber, whisper, …)` regardless of config. Every quick dictation hit Google first and only fell back to Whisper on API failure.

## Fix

- `WorkerServicesExtensions.AddDictationTranscriberServices` reads `PrimaryProvider`: `"google"` → Google-primary + Whisper-fallback; anything else (default `"whisper"`, unknown names) → Whisper-primary + Google-fallback. Unknown values fall back to Whisper so misconfiguration can't re-introduce the regression.
- Flip `SpeechProviderSettings` defaults: `Primary="whisper"`, `Fallback="google"`. Matches what `appsettings.json` has been saying all along and what the user expects for local GPU deployments. Confirms pin in `SpeechProviderSettingsTests.Defaults_MatchProductionFallbackChain`.

## Expected impact

Quick dictation on a Whisper-primary host now bypasses the Google API round-trip entirely. The 7s Google call is gone; local Whisper GPU inference is sub-second. Full dictation was already hitting the same wiring so it benefits the same way. `TranscribeRawAsync` continues to skip LLM correction + DB corrections (as designed for the latency budget) — that part was never broken.

## Test plan

- [x] `dotnet build` — green.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — all 390 Service tests + 321 Voice tests pass.
- [ ] After deploy, record a quick dictation and check `journalctl --user -u virtual-assistant.service | grep -E "WhisperSpeechTranscriber|GoogleSpeechTranscriber"` — should see Whisper not Google.