### PR TITLE
fix(dictation): pass effective settings to FallbackSpeechTranscriber (PR #1032 review)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -225,12 +225,27 @@ public static class WorkerServicesExtensions
             if (!speechSettings.EnableFallback)
                 return primary;
 
+            // Build effective settings with provider-key names that actually
+            // match the wired instances. The raw config may be mistyped (wrong
+            // case, unknown value, extra whitespace) and we normalize above;
+            // FallbackSpeechTranscriber then feeds these into
+            // ISpeechTranscriberFactory.GetProviderId for DB tracking and
+            // log messages, and that call throws on an unknown name.
+            // Using each transcriber's own ProviderKey as the source of truth
+            // avoids the divergence. (Copilot review on PR #1032.)
+            var effectiveSettings = new SpeechProviderSettings
+            {
+                PrimaryProvider = primary.ProviderKey,
+                FallbackProvider = fallback.ProviderKey,
+                EnableFallback = speechSettings.EnableFallback
+            };
+
             return new FallbackSpeechTranscriber(
                 primary,
                 fallback,
                 factory,
                 sp.GetRequiredService<ILogger<FallbackSpeechTranscriber>>(),
-                speechSettings);
+                effectiveSettings);
         });
 
         services.AddKeyedSingleton<ITranscriptionService>(DictationKey, (sp, _) =>


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Addresses Copilot review on the now-merged PR #1032.

## Problem

PR #1032 normalized the DI-local `primaryName` for the (primary, fallback) instance selection but still passed the raw `SpeechProviderSettings` into `FallbackSpeechTranscriber`. Inside, the transcriber calls:

```csharp
_factory.GetProviderId(_settings.PrimaryProvider)   // DB tracking
_factory.GetProviderId(_settings.FallbackProvider)  // DB tracking on fallback
```

`SpeechTranscriberFactory.GetProviderId` throws `ArgumentException` on an unknown name. So if the user typed `PrimaryProvider="WHISPER"` or left something weird there, my selection logic would correctly wire Whisper as primary, but the transcriber would then crash on provider-ID lookup.

## Fix

Build `effectiveSettings` from each chosen transcriber's own `ProviderKey` (`"whisper"` / `"google"`) — a single source of truth that stays in sync with the wired instances. Raw user-provided strings only drive the selection; normalized keys drive the settings.

## Test plan

- [x] `dotnet build` — green.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 390 Service tests pass (unchanged behavior for valid configs).