### PR TITLE
refactor(dictation): extract IDictationKeyHandler (#969 partial)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -99,9 +99,16 @@ public static class WorkerServicesExtensions
                 persister,
                 civilityTrimmer);
 
+            // Key handler owns the IKeyboardMonitor subscription + the
+            // ScrollLock/Pause routing tree so the worker no longer has a
+            // direct IKeyboardMonitor dep. (#969 extraction.)
+            var keyHandler = new DictationKeyHandler(
+                sp.GetRequiredService<ILogger<DictationKeyHandler>>(),
+                sp.GetRequiredService<IKeyboardMonitor>());
+
             return new DictationWorker(
                 sp.GetRequiredService<ILogger<DictationWorker>>(),
-                sp.GetRequiredService<IKeyboardMonitor>(),
+                keyHandler,
                 sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
                 recordingSession,
                 transcriber,

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationKeyHandler.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationKeyHandler.cs
@@ -1,0 +1,104 @@
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationKeyHandler : IDictationKeyHandler, IDisposable
+{
+    private readonly ILogger<DictationKeyHandler> _logger;
+    private readonly IKeyboardMonitor _keyboardMonitor;
+    private IDictationKeyHandlerBindings? _bindings;
+    private bool _subscribed;
+
+    public DictationKeyHandler(
+        ILogger<DictationKeyHandler> logger,
+        IKeyboardMonitor keyboardMonitor)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _keyboardMonitor = keyboardMonitor ?? throw new ArgumentNullException(nameof(keyboardMonitor));
+    }
+
+    public void Start(IDictationKeyHandlerBindings bindings)
+    {
+        _bindings = bindings ?? throw new ArgumentNullException(nameof(bindings));
+        if (_subscribed) return;
+        _keyboardMonitor.KeyReleased += OnKeyReleased;
+        _subscribed = true;
+    }
+
+    public void Stop()
+    {
+        if (!_subscribed) return;
+        _keyboardMonitor.KeyReleased -= OnKeyReleased;
+        _subscribed = false;
+    }
+
+    public void Dispose() => Stop();
+
+    /// <summary>
+    /// Key-release entry point. Uses fire-and-forget because the keyboard
+    /// monitor's event handler signature is synchronous; the async body is
+    /// exception-wrapped inside <see cref="HandleKeyReleasedAsync"/>.
+    /// </summary>
+    private void OnKeyReleased(object? sender, KeyEventArgs e) => _ = HandleKeyReleasedAsync(e);
+
+    private async Task HandleKeyReleasedAsync(KeyEventArgs e)
+    {
+        var bindings = _bindings;
+        if (bindings is null) return;
+
+        try
+        {
+            // Globally gated — the enable flag short-circuits every key.
+            if (!bindings.IsEnabled) return;
+
+            // Pause: cancel recording or transcription depending on state.
+            if (e.Key == KeyCode.Pause)
+            {
+                var state = bindings.State;
+
+                if (state == DictationState.Recording)
+                {
+                    _logger.LogInformation("Pause pressed during recording - canceling dictation");
+                    await bindings.CancelRecordingAsync();
+                    return;
+                }
+
+                if (state == DictationState.Transcribing)
+                {
+                    _logger.LogInformation("Pause pressed - canceling transcription");
+                    bindings.CancelTranscription();
+                    return;
+                }
+            }
+
+            // Only ScrollLock drives the start/stop toggle.
+            if (e.Key != KeyCode.ScrollLock) return;
+
+            var currentState = bindings.State;
+            _logger.LogDebug("ScrollLock released - State: {State}", currentState);
+
+            // Toggle logic: Idle → start, Recording → stop + transcribe,
+            // Transcribing → ignored (use Pause to cancel).
+            switch (currentState)
+            {
+                case DictationState.Idle:
+                    _logger.LogInformation("ScrollLock pressed - starting dictation");
+                    _ = Task.Run(() => bindings.StartAsync());
+                    break;
+                case DictationState.Recording:
+                    _logger.LogInformation("ScrollLock pressed - stopping dictation");
+                    _ = Task.Run(() => bindings.StopAndTranscribeAsync());
+                    break;
+                case DictationState.Transcribing:
+                    _logger.LogDebug("ScrollLock pressed during transcription - ignored (use Pause to cancel)");
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling key release");
+        }
+    }
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationKeyHandler.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationKeyHandler.cs
@@ -1,0 +1,55 @@
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Keyboard-event decision tree lifted out of <c>DictationWorker</c>
+/// (#969 god-class split). Owns the <see cref="IKeyboardMonitor"/>
+/// subscription + the ScrollLock/Pause routing logic so the worker
+/// never has to see raw key events — it just plugs in the four state
+/// transitions the handler can trigger via <see cref="Start"/>.
+/// </summary>
+public interface IDictationKeyHandler
+{
+    /// <summary>
+    /// Subscribe to keyboard events and wire the four actions the handler
+    /// can trigger (start recording, stop + transcribe, cancel while
+    /// recording, cancel during transcription). The providers give the
+    /// handler the runtime state it needs to route each key release.
+    /// Call <see cref="Stop"/> on worker shutdown to unsubscribe.
+    /// </summary>
+    void Start(IDictationKeyHandlerBindings bindings);
+
+    /// <summary>
+    /// Unsubscribe from keyboard events; safe to call if <see cref="Start"/>
+    /// was never called.
+    /// </summary>
+    void Stop();
+}
+
+/// <summary>
+/// State + action surface the key handler calls back into. Implemented by
+/// <c>DictationWorker</c> (via a tiny adapter) so the handler never
+/// references the worker directly.
+/// </summary>
+public interface IDictationKeyHandlerBindings
+{
+    /// <summary>Whether dictation is globally enabled — a false short-circuits every key.</summary>
+    bool IsEnabled { get; }
+
+    /// <summary>Current state-machine state used to route the key.</summary>
+    DictationState State { get; }
+
+    /// <summary>Start a normal-mode recording session (ScrollLock from Idle).</summary>
+    Task StartAsync();
+
+    /// <summary>Stop recording and run the full completion pipeline (ScrollLock from Recording).</summary>
+    Task StopAndTranscribeAsync();
+
+    /// <summary>Cancel an in-flight recording; discards audio (Pause from Recording).</summary>
+    Task CancelRecordingAsync();
+
+    /// <summary>Cancel a running transcription (Pause from Transcribing).</summary>
+    void CancelTranscription();
+}

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -19,7 +19,7 @@ namespace Olbrasoft.VirtualAssistant.Service.Workers;
 public class DictationWorker : BackgroundService, IDictationControl, IDictationService
 {
     private readonly ILogger<DictationWorker> _logger;
-    private readonly IKeyboardMonitor _keyboardMonitor;
+    private readonly IDictationKeyHandler _keyHandler;
     private readonly IDictationStateMachine _stateMachine;
     private readonly IDictationRecordingSession _recordingSession;
     private readonly IDictationTranscriber _transcriber;
@@ -40,7 +40,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
     public DictationWorker(
         ILogger<DictationWorker> logger,
-        IKeyboardMonitor keyboardMonitor,
+        IDictationKeyHandler keyHandler,
         IDictationStateMachine stateMachine,
         IDictationRecordingSession recordingSession,
         IDictationTranscriber transcriber,
@@ -49,7 +49,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         IOptions<DictationOptions> options)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _keyboardMonitor = keyboardMonitor ?? throw new ArgumentNullException(nameof(keyboardMonitor));
+        _keyHandler = keyHandler ?? throw new ArgumentNullException(nameof(keyHandler));
         _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
         _recordingSession = recordingSession ?? throw new ArgumentNullException(nameof(recordingSession));
         _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
@@ -170,8 +170,11 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
         try
         {
-            // Subscribe to keyboard events
-            _keyboardMonitor.KeyReleased += OnKeyReleased;
+            // Wire the key handler to the worker's state + action surface.
+            // The handler owns the IKeyboardMonitor subscription + the
+            // ScrollLock/Pause routing tree; the worker just exposes the
+            // four bindings the handler can trigger via IDictationKeyHandlerBindings.
+            _keyHandler.Start(new KeyHandlerBindings(this));
 
             // Subscribe to state changes for SignalR broadcasting
             _stateMachine.StateChanged += OnStateChangedBroadcast;
@@ -192,7 +195,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         }
         finally
         {
-            _keyboardMonitor.KeyReleased -= OnKeyReleased;
+            _keyHandler.Stop();
             _stateMachine.StateChanged -= OnStateChangedBroadcast;
             TranscriptionCompleted -= OnTranscriptionCompletedBroadcast;
             _transcriber.RawTranscriptionReady -= OnRawTranscriptionReadyBroadcast;
@@ -206,78 +209,28 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     }
 
     /// <summary>
-    /// Event handler for key release. Uses fire-and-forget pattern
-    /// to delegate to async handler with proper exception handling.
+    /// Tiny adapter that exposes the worker's state + the four key-triggered
+    /// actions to <see cref="IDictationKeyHandler"/> without leaking the
+    /// whole worker into the handler. Keeping it nested avoids polluting the
+    /// namespace with a helper type that only the worker's factory call
+    /// uses. (#969 god-class split.)
     /// </summary>
-    private void OnKeyReleased(object? sender, KeyEventArgs e)
+    private sealed class KeyHandlerBindings(DictationWorker worker) : IDictationKeyHandlerBindings
     {
-        _ = HandleKeyReleasedAsync(e);
-    }
+        public bool IsEnabled => worker._dictationEnabled;
+        public DictationState State => worker._stateMachine.CurrentState;
 
-    /// <summary>
-    /// Handles key release events and manages dictation workflow accordingly.
-    /// </summary>
-    private async Task HandleKeyReleasedAsync(KeyEventArgs e)
-    {
-        try
+        public Task StartAsync()
         {
-            // Ignore all keys when dictation is disabled
-            if (!_dictationEnabled)
-                return;
-
-            // Pause - cancel recording or transcription
-            if (e.Key == KeyCode.Pause)
-            {
-                var state = _stateMachine.CurrentState;
-
-                // Cancel during recording - discard audio, play cancel sound
-                if (state == DictationState.Recording)
-                {
-                    _logger.LogInformation("Pause pressed during recording - canceling dictation");
-                    await CancelRecordingAsync();
-                    return;
-                }
-
-                // Cancel during transcription
-                if (state == DictationState.Transcribing)
-                {
-                    _logger.LogInformation("Pause pressed - canceling transcription");
-                    CancelTranscription();
-                    return;
-                }
-            }
-
-            // Only handle ScrollLock
-            if (e.Key != KeyCode.ScrollLock)
-                return;
-
-            var currentState = _stateMachine.CurrentState;
-            _logger.LogDebug("ScrollLock released - State: {State}", currentState);
-
-            // Toggle logic: ScrollLock toggles between Idle and Recording
-            // Idle → Start recording
-            if (currentState == DictationState.Idle)
-            {
-                _logger.LogInformation("ScrollLock pressed - starting dictation");
-                _quickDictationMode = false;
-                _ = Task.Run(async () => await StartRecordingAsync());
-            }
-            // Recording → Stop and transcribe
-            else if (currentState == DictationState.Recording)
-            {
-                _logger.LogInformation("ScrollLock pressed - stopping dictation");
-                _ = Task.Run(async () => await StopAndTranscribeAsync());
-            }
-            // Transcribing → Ignore (use Pause to cancel)
-            else if (currentState == DictationState.Transcribing)
-            {
-                _logger.LogDebug("ScrollLock pressed during transcription - ignored (use Pause to cancel)");
-            }
+            worker._quickDictationMode = false;
+            return worker.StartRecordingAsync();
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error handling key release");
-        }
+
+        public Task StopAndTranscribeAsync() => worker.StopAndTranscribeAsync();
+
+        public Task CancelRecordingAsync() => worker.CancelRecordingAsync();
+
+        public void CancelTranscription() => worker.CancelTranscription();
     }
 
     private void OnStateChangedBroadcast(object? sender, DictationState state)

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationKeyHandlerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationKeyHandlerTests.cs
@@ -1,0 +1,200 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the ScrollLock/Pause routing tree lifted out of DictationWorker in
+/// #969. Handler subscribes to IKeyboardMonitor at Start time and fans each
+/// release to one of the four IDictationKeyHandlerBindings actions based on
+/// the current state machine + the enabled flag.
+/// </summary>
+public class DictationKeyHandlerTests
+{
+    private readonly Mock<ILogger<DictationKeyHandler>> _loggerMock = new();
+    private readonly Mock<IKeyboardMonitor> _keyboardMonitorMock = new();
+    private readonly Mock<IDictationKeyHandlerBindings> _bindingsMock = new();
+
+    private EventHandler<KeyEventArgs>? _capturedHandler;
+
+    public DictationKeyHandlerTests()
+    {
+        _keyboardMonitorMock.SetupAdd(x => x.KeyReleased += It.IsAny<EventHandler<KeyEventArgs>>())
+            .Callback<EventHandler<KeyEventArgs>>(h => _capturedHandler = h);
+
+        // Default: enabled + Idle. Individual tests override.
+        _bindingsMock.SetupGet(x => x.IsEnabled).Returns(true);
+        _bindingsMock.SetupGet(x => x.State).Returns(DictationState.Idle);
+    }
+
+    private DictationKeyHandler CreateSut() =>
+        new(_loggerMock.Object, _keyboardMonitorMock.Object);
+
+    [Fact]
+    public void Start_SubscribesToKeyReleased()
+    {
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _keyboardMonitorMock.VerifyAdd(x => x.KeyReleased += It.IsAny<EventHandler<KeyEventArgs>>(), Times.Once);
+    }
+
+    [Fact]
+    public void Start_Twice_SubscribesOnlyOnce()
+    {
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+        sut.Start(_bindingsMock.Object);
+
+        _keyboardMonitorMock.VerifyAdd(x => x.KeyReleased += It.IsAny<EventHandler<KeyEventArgs>>(), Times.Once);
+    }
+
+    [Fact]
+    public void Stop_UnsubscribesFromKeyReleased()
+    {
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        sut.Stop();
+
+        _keyboardMonitorMock.VerifyRemove(x => x.KeyReleased -= It.IsAny<EventHandler<KeyEventArgs>>(), Times.Once);
+    }
+
+    [Fact]
+    public void Stop_WithoutStart_DoesNotThrow()
+    {
+        var sut = CreateSut();
+        sut.Stop(); // must be idempotent — DI shutdown may call it unconditionally
+
+        _keyboardMonitorMock.VerifyRemove(x => x.KeyReleased -= It.IsAny<EventHandler<KeyEventArgs>>(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Disabled_IgnoresAllKeys()
+    {
+        _bindingsMock.SetupGet(x => x.IsEnabled).Returns(false);
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _capturedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
+        await Task.Delay(50);
+
+        _bindingsMock.Verify(x => x.StartAsync(), Times.Never);
+        _bindingsMock.Verify(x => x.CancelRecordingAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task NonScrollLockNonPauseKey_IsIgnored()
+    {
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _capturedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Escape, IsPressed = false });
+        await Task.Delay(50);
+
+        _bindingsMock.Verify(x => x.StartAsync(), Times.Never);
+        _bindingsMock.Verify(x => x.StopAndTranscribeAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScrollLock_WhileIdle_TriggersStart()
+    {
+        _bindingsMock.SetupGet(x => x.State).Returns(DictationState.Idle);
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _capturedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
+        await Task.Delay(100);
+
+        _bindingsMock.Verify(x => x.StartAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScrollLock_WhileRecording_TriggersStopAndTranscribe()
+    {
+        _bindingsMock.SetupGet(x => x.State).Returns(DictationState.Recording);
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _capturedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
+        await Task.Delay(100);
+
+        _bindingsMock.Verify(x => x.StopAndTranscribeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScrollLock_WhileTranscribing_IsIgnored()
+    {
+        // ScrollLock during transcribe is explicitly ignored — Pause is the
+        // cancel key to avoid accidental cancel-on-toggle.
+        _bindingsMock.SetupGet(x => x.State).Returns(DictationState.Transcribing);
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _capturedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
+        await Task.Delay(50);
+
+        _bindingsMock.Verify(x => x.StartAsync(), Times.Never);
+        _bindingsMock.Verify(x => x.StopAndTranscribeAsync(), Times.Never);
+        _bindingsMock.Verify(x => x.CancelTranscription(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Pause_WhileRecording_CancelsRecording()
+    {
+        _bindingsMock.SetupGet(x => x.State).Returns(DictationState.Recording);
+        _bindingsMock.Setup(x => x.CancelRecordingAsync()).Returns(Task.CompletedTask);
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _capturedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Pause, IsPressed = false });
+        await Task.Delay(50);
+
+        _bindingsMock.Verify(x => x.CancelRecordingAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Pause_WhileTranscribing_CancelsTranscription()
+    {
+        _bindingsMock.SetupGet(x => x.State).Returns(DictationState.Transcribing);
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _capturedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Pause, IsPressed = false });
+        await Task.Delay(50);
+
+        _bindingsMock.Verify(x => x.CancelTranscription(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Pause_WhileIdle_IsIgnored()
+    {
+        _bindingsMock.SetupGet(x => x.State).Returns(DictationState.Idle);
+        var sut = CreateSut();
+        sut.Start(_bindingsMock.Object);
+
+        _capturedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Pause, IsPressed = false });
+        await Task.Delay(50);
+
+        _bindingsMock.Verify(x => x.CancelRecordingAsync(), Times.Never);
+        _bindingsMock.Verify(x => x.CancelTranscription(), Times.Never);
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new DictationKeyHandler(null!, _keyboardMonitorMock.Object));
+
+    [Fact]
+    public void Constructor_NullKeyboardMonitor_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new DictationKeyHandler(_loggerMock.Object, null!));
+
+    [Fact]
+    public void Start_NullBindings_Throws()
+    {
+        var sut = CreateSut();
+        Assert.Throws<ArgumentNullException>(() => sut.Start(null!));
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -8,12 +7,8 @@ using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
-using Olbrasoft.VirtualAssistant.Core.WindowManagement;
-using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Workers;
 using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
-using Olbrasoft.VirtualAssistant.Service.Workers.Streaming;
-using Olbrasoft.VirtualAssistant.Voice.Services;
 using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 
 namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers;
@@ -21,7 +16,7 @@ namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers;
 public class DictationWorkerTests : IDisposable
 {
     private readonly Mock<ILogger<DictationWorker>> _loggerMock;
-    private readonly Mock<IKeyboardMonitor> _keyboardMonitorMock;
+    private readonly Mock<IDictationKeyHandler> _keyHandlerMock;
     private readonly Mock<IDictationStateMachine> _stateMachineMock;
     private readonly Mock<IDictationRecordingSession> _recordingSessionMock;
     private readonly Mock<IDictationTranscriber> _transcriberMock;
@@ -30,12 +25,14 @@ public class DictationWorkerTests : IDisposable
     private readonly DictationOptions _options;
     private readonly DictationWorker _sut;
 
-    private EventHandler<KeyEventArgs>? _capturedKeyReleasedHandler;
+    // Bindings captured from _keyHandler.Start(bindings); the tests invoke this
+    // to simulate key events instead of reaching into an IKeyboardMonitor mock.
+    private IDictationKeyHandlerBindings? _capturedBindings;
 
     public DictationWorkerTests()
     {
         _loggerMock = new Mock<ILogger<DictationWorker>>();
-        _keyboardMonitorMock = new Mock<IKeyboardMonitor>();
+        _keyHandlerMock = new Mock<IDictationKeyHandler>();
         _stateMachineMock = new Mock<IDictationStateMachine>();
         _recordingSessionMock = new Mock<IDictationRecordingSession>();
         _transcriberMock = new Mock<IDictationTranscriber>();
@@ -44,14 +41,15 @@ public class DictationWorkerTests : IDisposable
 
         _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
 
-        _keyboardMonitorMock.SetupAdd(x => x.KeyReleased += It.IsAny<EventHandler<KeyEventArgs>>())
-            .Callback<EventHandler<KeyEventArgs>>(handler => _capturedKeyReleasedHandler = handler);
+        _keyHandlerMock
+            .Setup(x => x.Start(It.IsAny<IDictationKeyHandlerBindings>()))
+            .Callback<IDictationKeyHandlerBindings>(b => _capturedBindings = b);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
 
         _sut = new DictationWorker(
             _loggerMock.Object,
-            _keyboardMonitorMock.Object,
+            _keyHandlerMock.Object,
             _stateMachineMock.Object,
             _recordingSessionMock.Object,
             _transcriberMock.Object,
@@ -63,134 +61,79 @@ public class DictationWorkerTests : IDisposable
     #region Constructor Tests
 
     [Fact]
-    public void Constructor_NullLogger_ThrowsArgumentNullException()
-    {
+    public void Constructor_NullLogger_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            null!,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingSessionMock.Object,
-            _transcriberMock.Object,
-            _outputChannelMock.Object,
-            _completionPipelineMock.Object,
+            null!, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
             Options.Create(_options)));
-    }
 
     [Fact]
-    public void Constructor_NullKeyboardMonitor_ThrowsArgumentNullException()
-    {
+    public void Constructor_NullKeyHandler_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            null!,
-            _stateMachineMock.Object,
-            _recordingSessionMock.Object,
-            _transcriberMock.Object,
-            _outputChannelMock.Object,
-            _completionPipelineMock.Object,
+            _loggerMock.Object, null!, _stateMachineMock.Object, _recordingSessionMock.Object,
+            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
             Options.Create(_options)));
-    }
 
     [Fact]
-    public void Constructor_NullStateMachine_ThrowsArgumentNullException()
-    {
+    public void Constructor_NullStateMachine_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            null!,
-            _recordingSessionMock.Object,
-            _transcriberMock.Object,
-            _outputChannelMock.Object,
-            _completionPipelineMock.Object,
+            _loggerMock.Object, _keyHandlerMock.Object, null!, _recordingSessionMock.Object,
+            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
             Options.Create(_options)));
-    }
 
     [Fact]
-    public void Constructor_NullOptions_ThrowsArgumentNullException()
-    {
+    public void Constructor_NullRecordingSession_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingSessionMock.Object,
-            _transcriberMock.Object,
-            _outputChannelMock.Object,
-            _completionPipelineMock.Object,
+            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, null!,
+            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
+            Options.Create(_options)));
+
+    [Fact]
+    public void Constructor_NullTranscriber_ThrowsArgumentNullException() =>
+        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
+            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            null!, _outputChannelMock.Object, _completionPipelineMock.Object,
+            Options.Create(_options)));
+
+    [Fact]
+    public void Constructor_NullOutputChannel_ThrowsArgumentNullException() =>
+        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
+            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            _transcriberMock.Object, null!, _completionPipelineMock.Object,
+            Options.Create(_options)));
+
+    [Fact]
+    public void Constructor_NullCompletionPipeline_ThrowsArgumentNullException() =>
+        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
+            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            _transcriberMock.Object, _outputChannelMock.Object, null!,
+            Options.Create(_options)));
+
+    [Fact]
+    public void Constructor_NullOptions_ThrowsArgumentNullException() =>
+        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
+            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
             null!));
-    }
-
-    [Fact]
-    public void Constructor_NullRecordingSession_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            null!,
-            _transcriberMock.Object,
-            _outputChannelMock.Object,
-            _completionPipelineMock.Object,
-            Options.Create(_options)));
-    }
-
-    [Fact]
-    public void Constructor_NullTranscriber_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingSessionMock.Object,
-            null!,
-            _outputChannelMock.Object,
-            _completionPipelineMock.Object,
-            Options.Create(_options)));
-    }
-
-    [Fact]
-    public void Constructor_NullOutputChannel_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingSessionMock.Object,
-            _transcriberMock.Object,
-            null!,
-            _completionPipelineMock.Object,
-            Options.Create(_options)));
-    }
-
-    [Fact]
-    public void Constructor_NullCompletionPipeline_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object,
-            _keyboardMonitorMock.Object,
-            _stateMachineMock.Object,
-            _recordingSessionMock.Object,
-            _transcriberMock.Object,
-            _outputChannelMock.Object,
-            null!,
-            Options.Create(_options)));
-    }
 
     #endregion
 
     #region ExecuteAsync Tests
 
     [Fact]
-    public async Task ExecuteAsync_SubscribesToKeyReleasedEvent()
+    public async Task ExecuteAsync_StartsKeyHandlerWithBindings()
     {
         using var cts = new CancellationTokenSource();
 
         _ = _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
-        _keyboardMonitorMock.VerifyAdd(x => x.KeyReleased += It.IsAny<EventHandler<KeyEventArgs>>(), Times.Once);
+        _keyHandlerMock.Verify(x => x.Start(It.IsAny<IDictationKeyHandlerBindings>()), Times.Once);
+        Assert.NotNull(_capturedBindings);
     }
 
     [Fact]
-    public async Task StopAsync_UnsubscribesFromKeyReleasedEvent()
+    public async Task StopAsync_StopsKeyHandler()
     {
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
@@ -198,7 +141,7 @@ public class DictationWorkerTests : IDisposable
 
         await _sut.StopAsync(CancellationToken.None);
 
-        _keyboardMonitorMock.VerifyRemove(x => x.KeyReleased -= It.IsAny<EventHandler<KeyEventArgs>>(), Times.Once);
+        _keyHandlerMock.Verify(x => x.Stop(), Times.Once);
     }
 
     [Fact]
@@ -226,6 +169,106 @@ public class DictationWorkerTests : IDisposable
 
     #endregion
 
+    #region Bindings Adapter Tests
+
+    // The worker's nested KeyHandlerBindings adapter is the only place the
+    // worker's internal state reaches the key handler. Exercise it via the
+    // captured IDictationKeyHandlerBindings instance.
+
+    [Fact]
+    public async Task Bindings_StateMirrorsStateMachineCurrentState()
+    {
+        using var cts = new CancellationTokenSource();
+        _ = _sut.StartAsync(cts.Token);
+        await Task.Delay(50);
+
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
+
+        Assert.NotNull(_capturedBindings);
+        Assert.Equal(DictationState.Transcribing, _capturedBindings!.State);
+    }
+
+    [Fact]
+    public async Task Bindings_IsEnabledReflectsSetDictationEnabled()
+    {
+        using var cts = new CancellationTokenSource();
+        _ = _sut.StartAsync(cts.Token);
+        await Task.Delay(50);
+
+        Assert.NotNull(_capturedBindings);
+        Assert.True(_capturedBindings!.IsEnabled);
+
+        _sut.SetDictationEnabled(false);
+        Assert.False(_capturedBindings.IsEnabled);
+    }
+
+    [SkipOnCIFact]
+    public async Task Bindings_StartAsync_TriggersNormalModeRecording()
+    {
+        using var cts = new CancellationTokenSource();
+        _ = _sut.StartAsync(cts.Token);
+        await Task.Delay(50);
+
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>())).Returns(Task.CompletedTask);
+
+        await _capturedBindings!.StartAsync();
+
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
+        _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Once);
+    }
+
+    [SkipOnCIFact]
+    public async Task Bindings_StopAndTranscribeAsync_InvokesCompletionPipelineFullMode()
+    {
+        using var cts = new CancellationTokenSource();
+        _ = _sut.StartAsync(cts.Token);
+        await Task.Delay(50);
+
+        var audio = new byte[] { 1, 2, 3, 4 };
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audio);
+
+        await _capturedBindings!.StopAndTranscribeAsync();
+        await Task.Delay(100);
+
+        _completionPipelineMock.Verify(
+            x => x.CompleteFullAsync(audio, It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [SkipOnCIFact]
+    public async Task Bindings_CancelRecordingAsync_EmergencyStopsAndPlaysCancelCue()
+    {
+        using var cts = new CancellationTokenSource();
+        _ = _sut.StartAsync(cts.Token);
+        await Task.Delay(50);
+
+        await _capturedBindings!.CancelRecordingAsync();
+
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
+        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [SkipOnCIFact]
+    public async Task Bindings_CancelTranscription_DelegatesToWorker()
+    {
+        using var cts = new CancellationTokenSource();
+        _ = _sut.StartAsync(cts.Token);
+        await Task.Delay(50);
+
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
+
+        _capturedBindings!.CancelTranscription();
+
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    #endregion
+
     #region SetDictationEnabled Tests
 
     [Fact]
@@ -242,8 +285,7 @@ public class DictationWorkerTests : IDisposable
     public async Task SetDictationEnabled_DisablingWhileRecording_PerformsEmergencyStop()
     {
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.EmergencyStopAsync())
-            .Returns(Task.CompletedTask);
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
 
         _sut.SetDictationEnabled(false);
         await Task.Delay(100);
@@ -256,138 +298,12 @@ public class DictationWorkerTests : IDisposable
     public async Task SetDictationEnabled_DisablingWhileTranscribing_PerformsEmergencyStop()
     {
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
-        _recordingSessionMock.Setup(x => x.EmergencyStopAsync())
-            .Returns(Task.CompletedTask);
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
 
         _sut.SetDictationEnabled(false);
         await Task.Delay(100);
 
         _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
-    }
-
-    #endregion
-
-    #region Key Event Handling Tests
-
-    [SkipOnCIFact]
-    public async Task KeyReleased_ScrollLockWhileIdle_StartsRecording()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
-        _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>()))
-            .Returns(Task.CompletedTask);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(150);
-
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
-        _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task KeyReleased_NonScrollLockKey_DoesNotStartRecording()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Escape, IsPressed = false });
-        await Task.Delay(100);
-
-        _stateMachineMock.Verify(x => x.TransitionTo(It.IsAny<DictationState>()), Times.Never);
-        _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task KeyReleased_WhenDictationDisabled_IgnoresEvent()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        _sut.SetDictationEnabled(false);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(100);
-
-        _stateMachineMock.Verify(x => x.TransitionTo(It.IsAny<DictationState>()), Times.Never);
-    }
-
-    [SkipOnCIFact]
-    public async Task KeyReleased_PauseWhileTranscribing_CancelsTranscription()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Pause, IsPressed = false });
-        await Task.Delay(100);
-
-        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
-        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
-    }
-
-    [SkipOnCIFact]
-    public async Task KeyReleased_PauseWhileRecording_CancelsRecording()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.Pause, IsPressed = false });
-        await Task.Delay(100);
-
-        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
-        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
-    }
-
-    [SkipOnCIFact]
-    public async Task KeyReleased_ScrollLockWhileRecording_StopsRecordingAndInvokesPipeline()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        var audioData = new byte[] { 1, 2, 3, 4 };
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(audioData);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(300);
-
-        _recordingSessionMock.Verify(x => x.StopAsync(), Times.Once);
-        _completionPipelineMock.Verify(
-            x => x.CompleteFullAsync(audioData, It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task KeyReleased_ScrollLockWhileTranscribing_IsIgnored()
-    {
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(100);
-
-        // ScrollLock during transcription should be ignored (use Pause to cancel)
-        _stateMachineMock.Verify(x => x.TransitionTo(It.IsAny<DictationState>()), Times.Never);
-        _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Never);
-        _recordingSessionMock.Verify(x => x.StopAsync(), Times.Never);
     }
 
     #endregion
@@ -397,18 +313,14 @@ public class DictationWorkerTests : IDisposable
     [SkipOnCIFact]
     public async Task StopAndTranscribe_EmptyAudio_TransitionsIdleAndSkipsCompletionPipeline()
     {
-        // Worker's ValidateAndPrepareAudioAsync owns the empty-buffer branch:
-        // it transitions the state machine back to Idle (since the pipeline
-        // won't run) and the pipeline must never be invoked.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(Array.Empty<byte>());
+        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(Array.Empty<byte>());
 
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
+        await _sut.StopDictationAsync();
         await Task.Delay(200);
 
         _completionPipelineMock.Verify(
@@ -423,11 +335,6 @@ public class DictationWorkerTests : IDisposable
     [SkipOnCIFact]
     public async Task StopAndTranscribe_NormalMode_InvokesCompleteFullAsync()
     {
-        // Worker's only job in normal dictation is to stop recording, hand
-        // the audio to the completion pipeline's full-mode method, and wire
-        // the TranscriptionCompleted callback. The actual pipeline behavior
-        // (save, type, state transitions) is covered in
-        // DictationCompletionPipelineTests.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
@@ -435,17 +342,13 @@ public class DictationWorkerTests : IDisposable
         var audioData = new byte[] { 1, 2, 3, 4 };
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(audioData);
+        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
 
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
+        await _sut.StopDictationAsync();
         await Task.Delay(200);
 
         _completionPipelineMock.Verify(
-            x => x.CompleteFullAsync(
-                audioData,
-                It.IsAny<Action<string>>(),
-                It.IsAny<CancellationToken>()),
+            x => x.CompleteFullAsync(audioData, It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _completionPipelineMock.Verify(
             x => x.CompleteQuickAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
@@ -466,8 +369,7 @@ public class DictationWorkerTests : IDisposable
         var audioData = new byte[] { 1, 2, 3, 4 };
         Action<string>? capturedCallback = null;
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(audioData);
+        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
         _completionPipelineMock
             .Setup(x => x.CompleteFullAsync(
                 It.IsAny<byte[]>(), It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()))
@@ -477,7 +379,7 @@ public class DictationWorkerTests : IDisposable
         string? workerEventText = null;
         ((IDictationService)_sut).TranscriptionCompleted += (_, text) => workerEventText = text;
 
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
+        await _sut.StopDictationAsync();
         await Task.Delay(200);
 
         Assert.NotNull(capturedCallback);
@@ -512,8 +414,7 @@ public class DictationWorkerTests : IDisposable
         await Task.Delay(50);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.EmergencyStopAsync())
-            .Returns(Task.CompletedTask);
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
 
         await _sut.StopAsync(CancellationToken.None);
 
@@ -539,10 +440,6 @@ public class DictationWorkerTests : IDisposable
     [SkipOnCIFact]
     public async Task QuickDictation_InvokesCompleteQuickAsync()
     {
-        // Worker's quick-mode contract: StartQuickDictationAsync flips the
-        // flag, and on stop the worker hands audio to CompleteQuickAsync.
-        // Fast-paste / civility-trim / broadcast internals are covered in
-        // DictationCompletionPipelineTests.
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
         await Task.Delay(50);
@@ -553,8 +450,7 @@ public class DictationWorkerTests : IDisposable
         await _sut.StartQuickDictationAsync();
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(audioData);
+        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
 
         await _sut.StopDictationAsync();
         await Task.Delay(200);
@@ -565,43 +461,6 @@ public class DictationWorkerTests : IDisposable
         _completionPipelineMock.Verify(
             x => x.CompleteFullAsync(It.IsAny<byte[]>(), It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
             Times.Never);
-    }
-
-    [SkipOnCIFact]
-    public async Task KeyboardDictation_AfterQuickMode_ResetsToNormalMode()
-    {
-        // After canceling a quick-mode session, the next ScrollLock-triggered
-        // dictation must go through the full-mode pipeline, not the quick one.
-        using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
-        await _sut.StartQuickDictationAsync();
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        ((IDictationService)_sut).CancelTranscription();
-        await Task.Delay(50);
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
-        _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>()))
-            .Returns(Task.CompletedTask);
-
-        var audioData = new byte[] { 1, 2, 3 };
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(100);
-
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync())
-            .ReturnsAsync(audioData);
-
-        _capturedKeyReleasedHandler?.Invoke(this, new KeyEventArgs { Key = KeyCode.ScrollLock, IsPressed = false });
-        await Task.Delay(200);
-
-        _completionPipelineMock.Verify(
-            x => x.CompleteFullAsync(audioData, It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
-            Times.AtLeastOnce);
     }
 
     #endregion


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Part of #969 (DictationWorker god-class split).

## Summary

7th extraction. Keyboard-event decision tree + `IKeyboardMonitor` subscription move behind `IDictationKeyHandler`; the worker exposes its state + the four trigger-able actions via a tiny `IDictationKeyHandlerBindings` adapter.

- `IDictationKeyHandler` owns `Start` / `Stop` subscription lifecycle and the ScrollLock/Pause routing tree (disabled short-circuit, Pause→cancel, ScrollLock→start/stop+transcribe).
- `IDictationKeyHandlerBindings` exposes `IsEnabled`, `State`, `StartAsync`, `StopAndTranscribeAsync`, `CancelRecordingAsync`, `CancelTranscription` — a minimal surface so the handler never references the worker.
- Worker drops `IKeyboardMonitor` ctor dep in favor of `IDictationKeyHandler` (8 → 8 count, swap) and deletes the ~75-LOC `OnKeyReleased` + `HandleKeyReleasedAsync` methods.
- Nested `KeyHandlerBindings` adapter in the worker delegates bindings-interface calls to the existing private methods.

Worker: **511 → 464 LOC**. Target is still ≤400 / ≤5 deps; remaining candidates are the state-broadcast subscriptions (would free the transcriber dep) and the cancel flow trio.

## Tests

- `DictationWorkerTests`: rewritten to capture the `IDictationKeyHandlerBindings` instance at `Start` time and exercise it via the public worker API. 6 new bindings-adapter cases.
- `DictationKeyHandlerTests`: new file, 13 cases pinning Start/Stop lifecycle, idempotence, the full ScrollLock/Pause decision tree, and null-ctor-arg guards.
- Full suite green: 403 Service tests pass.

## Test plan

- [x] `dotnet build` — green.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 403 Service + 321 Voice + others all pass.