### PR TITLE
refactor(dictation): extract IDictationStateBroadcaster + address PR #1034 review

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -106,14 +106,22 @@ public static class WorkerServicesExtensions
                 sp.GetRequiredService<ILogger<DictationKeyHandler>>(),
                 sp.GetRequiredService<IKeyboardMonitor>());
 
+            // State broadcaster owns the SignalR fan-out for state-changed,
+            // raw-transcription-ready, and transcription-completed events so
+            // the worker drops the direct transcriber dep. (#969 extraction.)
+            var stateBroadcaster = new DictationStateBroadcaster(
+                sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
+                transcriber,
+                outputChannel);
+
             return new DictationWorker(
                 sp.GetRequiredService<ILogger<DictationWorker>>(),
                 keyHandler,
                 sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
                 recordingSession,
-                transcriber,
                 outputChannel,
                 completionPipeline,
+                stateBroadcaster,
                 sp.GetRequiredService<IOptions<DictationOptions>>());
         });
 

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationKeyHandler.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationKeyHandler.cs
@@ -29,9 +29,15 @@ public sealed class DictationKeyHandler : IDictationKeyHandler, IDisposable
 
     public void Stop()
     {
-        if (!_subscribed) return;
-        _keyboardMonitor.KeyReleased -= OnKeyReleased;
-        _subscribed = false;
+        if (_subscribed)
+        {
+            _keyboardMonitor.KeyReleased -= OnKeyReleased;
+            _subscribed = false;
+        }
+
+        // Clear bindings so the handler doesn't pin the worker reference
+        // past Stop — Copilot review on PR #1034.
+        _bindings = null;
     }
 
     public void Dispose() => Stop();
@@ -81,15 +87,20 @@ public sealed class DictationKeyHandler : IDictationKeyHandler, IDisposable
 
             // Toggle logic: Idle → start, Recording → stop + transcribe,
             // Transcribing → ignored (use Pause to cancel).
+            //
+            // HandleKeyReleasedAsync is itself fire-and-forget from OnKeyReleased,
+            // so awaiting directly here is safe: it keeps exceptions inside the
+            // outer catch block instead of orphaning them on a detached Task.Run.
+            // (Copilot review on PR #1034.)
             switch (currentState)
             {
                 case DictationState.Idle:
                     _logger.LogInformation("ScrollLock pressed - starting dictation");
-                    _ = Task.Run(() => bindings.StartAsync());
+                    await bindings.StartAsync();
                     break;
                 case DictationState.Recording:
                     _logger.LogInformation("ScrollLock pressed - stopping dictation");
-                    _ = Task.Run(() => bindings.StopAndTranscribeAsync());
+                    await bindings.StopAndTranscribeAsync();
                     break;
                 case DictationState.Transcribing:
                     _logger.LogDebug("ScrollLock pressed during transcription - ignored (use Pause to cancel)");

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationStateBroadcaster.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationStateBroadcaster.cs
@@ -1,0 +1,82 @@
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+using Olbrasoft.VirtualAssistant.Voice.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationStateBroadcaster : IDictationStateBroadcaster, IDisposable
+{
+    private readonly IDictationStateMachine _stateMachine;
+    private readonly IDictationTranscriber _transcriber;
+    private readonly IDictationOutputChannel _outputChannel;
+    private Action<EventHandler<string>>? _unsubscribeCompleted;
+    private EventHandler<string>? _completedHandler;
+    private bool _subscribed;
+
+    public DictationStateBroadcaster(
+        IDictationStateMachine stateMachine,
+        IDictationTranscriber transcriber,
+        IDictationOutputChannel outputChannel)
+    {
+        _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
+        _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
+        _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
+    }
+
+    public void Start(
+        Action<EventHandler<string>> subscribeTranscriptionCompleted,
+        Action<EventHandler<string>> unsubscribeTranscriptionCompleted)
+    {
+        ArgumentNullException.ThrowIfNull(subscribeTranscriptionCompleted);
+        ArgumentNullException.ThrowIfNull(unsubscribeTranscriptionCompleted);
+
+        if (_subscribed) return;
+
+        _stateMachine.StateChanged += OnStateChanged;
+        _transcriber.RawTranscriptionReady += OnRawTranscriptionReady;
+
+        _completedHandler = OnTranscriptionCompleted;
+        subscribeTranscriptionCompleted(_completedHandler);
+        _unsubscribeCompleted = unsubscribeTranscriptionCompleted;
+
+        _subscribed = true;
+    }
+
+    public void Stop()
+    {
+        if (!_subscribed) return;
+
+        _stateMachine.StateChanged -= OnStateChanged;
+        _transcriber.RawTranscriptionReady -= OnRawTranscriptionReady;
+
+        if (_completedHandler is not null)
+        {
+            _unsubscribeCompleted?.Invoke(_completedHandler);
+            _completedHandler = null;
+        }
+        _unsubscribeCompleted = null;
+
+        _subscribed = false;
+    }
+
+    public void Dispose() => Stop();
+
+    private void OnStateChanged(object? sender, DictationState state)
+    {
+        var eventType = state switch
+        {
+            DictationState.Recording => DictationEventType.RecordingStarted,
+            DictationState.Transcribing => DictationEventType.TranscriptionStarted,
+            _ => DictationEventType.RecordingStopped
+        };
+
+        _ = _outputChannel.BroadcastEventAsync(eventType, null);
+    }
+
+    private void OnTranscriptionCompleted(object? sender, string text) =>
+        _ = _outputChannel.BroadcastEventAsync(DictationEventType.TranscriptionCompleted, text);
+
+    private void OnRawTranscriptionReady(string text) =>
+        _ = _outputChannel.BroadcastEventAsync(DictationEventType.RawTranscriptionCompleted, text);
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationStateBroadcaster.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationStateBroadcaster.cs
@@ -1,0 +1,30 @@
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// SignalR broadcast bridge lifted out of <c>DictationWorker</c> (#969
+/// god-class split). Owns the subscriptions to the state machine's
+/// <c>StateChanged</c> event, the transcriber's <c>RawTranscriptionReady</c>
+/// event, and the worker's own <c>TranscriptionCompleted</c> event, and
+/// fans every emission into <see cref="IDictationOutputChannel.BroadcastEventAsync"/>
+/// on the dictation SignalR hub.
+/// </summary>
+public interface IDictationStateBroadcaster
+{
+    /// <summary>
+    /// Wire event subscriptions. <paramref name="transcriptionCompleted"/>
+    /// is the worker-scoped event raise hook (worker owns the event so the
+    /// broadcaster subscribes via add/remove callbacks rather than a direct
+    /// reference to the event itself).
+    /// </summary>
+    void Start(
+        Action<EventHandler<string>> subscribeTranscriptionCompleted,
+        Action<EventHandler<string>> unsubscribeTranscriptionCompleted);
+
+    /// <summary>
+    /// Unsubscribe from all events. Safe to call when <see cref="Start"/>
+    /// was never invoked.
+    /// </summary>
+    void Stop();
+}

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -22,9 +22,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly IDictationKeyHandler _keyHandler;
     private readonly IDictationStateMachine _stateMachine;
     private readonly IDictationRecordingSession _recordingSession;
-    private readonly IDictationTranscriber _transcriber;
     private readonly IDictationOutputChannel _outputChannel;
     private readonly IDictationCompletionPipeline _completionPipeline;
+    private readonly IDictationStateBroadcaster _stateBroadcaster;
     private readonly DictationOptions _options;
 
     private CancellationTokenSource? _transcriptionCts;
@@ -43,18 +43,18 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         IDictationKeyHandler keyHandler,
         IDictationStateMachine stateMachine,
         IDictationRecordingSession recordingSession,
-        IDictationTranscriber transcriber,
         IDictationOutputChannel outputChannel,
         IDictationCompletionPipeline completionPipeline,
+        IDictationStateBroadcaster stateBroadcaster,
         IOptions<DictationOptions> options)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _keyHandler = keyHandler ?? throw new ArgumentNullException(nameof(keyHandler));
         _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
         _recordingSession = recordingSession ?? throw new ArgumentNullException(nameof(recordingSession));
-        _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
         _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
         _completionPipeline = completionPipeline ?? throw new ArgumentNullException(nameof(completionPipeline));
+        _stateBroadcaster = stateBroadcaster ?? throw new ArgumentNullException(nameof(stateBroadcaster));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value;
     }
@@ -176,10 +176,12 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // four bindings the handler can trigger via IDictationKeyHandlerBindings.
             _keyHandler.Start(new KeyHandlerBindings(this));
 
-            // Subscribe to state changes for SignalR broadcasting
-            _stateMachine.StateChanged += OnStateChangedBroadcast;
-            TranscriptionCompleted += OnTranscriptionCompletedBroadcast;
-            _transcriber.RawTranscriptionReady += OnRawTranscriptionReadyBroadcast;
+            // Broadcaster owns the state-machine + transcriber event
+            // subscriptions; TranscriptionCompleted is worker-scoped so the
+            // broadcaster gets add/remove hooks for it.
+            _stateBroadcaster.Start(
+                handler => TranscriptionCompleted += handler,
+                handler => TranscriptionCompleted -= handler);
 
             // Wait for cancellation
             await Task.Delay(Timeout.Infinite, stoppingToken);
@@ -196,9 +198,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         finally
         {
             _keyHandler.Stop();
-            _stateMachine.StateChanged -= OnStateChangedBroadcast;
-            TranscriptionCompleted -= OnTranscriptionCompletedBroadcast;
-            _transcriber.RawTranscriptionReady -= OnRawTranscriptionReadyBroadcast;
+            _stateBroadcaster.Stop();
 
             // Stop recording if active
             if (_stateMachine.CurrentState == DictationState.Recording)
@@ -232,31 +232,6 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
         public void CancelTranscription() => worker.CancelTranscription();
     }
-
-    private void OnStateChangedBroadcast(object? sender, DictationState state)
-    {
-        var eventType = state switch
-        {
-            DictationState.Recording => DictationEventType.RecordingStarted,
-            DictationState.Transcribing => DictationEventType.TranscriptionStarted,
-            _ => DictationEventType.RecordingStopped
-        };
-
-        _ = BroadcastDictationEventAsync(eventType, null);
-    }
-
-    private void OnTranscriptionCompletedBroadcast(object? sender, string text)
-    {
-        _ = BroadcastDictationEventAsync(DictationEventType.TranscriptionCompleted, text);
-    }
-
-    private void OnRawTranscriptionReadyBroadcast(string text)
-    {
-        _ = BroadcastDictationEventAsync(DictationEventType.RawTranscriptionCompleted, text);
-    }
-
-    private Task BroadcastDictationEventAsync(DictationEventType eventType, string? text) =>
-        _outputChannel.BroadcastEventAsync(eventType, text);
 
     private async Task StartRecordingAsync()
     {

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationStateBroadcasterTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationStateBroadcasterTests.cs
@@ -1,0 +1,184 @@
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Service.Hubs;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+using Olbrasoft.VirtualAssistant.Voice.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the SignalR fan-out lifted out of DictationWorker in #969. The
+/// broadcaster subscribes to the state machine's StateChanged, the
+/// transcriber's RawTranscriptionReady, and the worker's
+/// TranscriptionCompleted (via subscribe/unsubscribe hooks), and maps each
+/// emission to the matching DictationEventType broadcast.
+/// </summary>
+public class DictationStateBroadcasterTests
+{
+    private readonly Mock<IDictationStateMachine> _stateMachineMock = new();
+    private readonly Mock<IDictationTranscriber> _transcriberMock = new();
+    private readonly Mock<IDictationOutputChannel> _outputChannelMock = new();
+
+    // Proxy for the worker's TranscriptionCompleted event — tests register
+    // add/remove hooks and then raise the event to exercise the broadcaster.
+    private event EventHandler<string>? TranscriptionCompleted;
+
+    private DictationStateBroadcaster CreateSut() =>
+        new(_stateMachineMock.Object, _transcriberMock.Object, _outputChannelMock.Object);
+
+    private void StartWith(DictationStateBroadcaster sut) =>
+        sut.Start(h => TranscriptionCompleted += h, h => TranscriptionCompleted -= h);
+
+    [Fact]
+    public void Start_SubscribesToAllEvents()
+    {
+        var sut = CreateSut();
+        StartWith(sut);
+
+        _stateMachineMock.VerifyAdd(x => x.StateChanged += It.IsAny<EventHandler<DictationState>>(), Times.Once);
+        _transcriberMock.VerifyAdd(x => x.RawTranscriptionReady += It.IsAny<Action<string>>(), Times.Once);
+    }
+
+    [Fact]
+    public void Start_Twice_SubscribesOnlyOnce()
+    {
+        var sut = CreateSut();
+        StartWith(sut);
+        StartWith(sut);
+
+        _stateMachineMock.VerifyAdd(x => x.StateChanged += It.IsAny<EventHandler<DictationState>>(), Times.Once);
+    }
+
+    [Fact]
+    public void Stop_UnsubscribesFromAllEvents()
+    {
+        var sut = CreateSut();
+        StartWith(sut);
+
+        sut.Stop();
+
+        _stateMachineMock.VerifyRemove(x => x.StateChanged -= It.IsAny<EventHandler<DictationState>>(), Times.Once);
+        _transcriberMock.VerifyRemove(x => x.RawTranscriptionReady -= It.IsAny<Action<string>>(), Times.Once);
+    }
+
+    [Fact]
+    public void Stop_WithoutStart_DoesNotThrow()
+    {
+        var sut = CreateSut();
+        sut.Stop(); // must be idempotent for DI shutdown
+
+        _stateMachineMock.VerifyRemove(x => x.StateChanged -= It.IsAny<EventHandler<DictationState>>(), Times.Never);
+    }
+
+    [Fact]
+    public void StateChanged_Recording_BroadcastsRecordingStarted()
+    {
+        var sut = CreateSut();
+        StartWith(sut);
+
+        _stateMachineMock.Raise(x => x.StateChanged += null, this, DictationState.Recording);
+
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(DictationEventType.RecordingStarted, null, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void StateChanged_Transcribing_BroadcastsTranscriptionStarted()
+    {
+        var sut = CreateSut();
+        StartWith(sut);
+
+        _stateMachineMock.Raise(x => x.StateChanged += null, this, DictationState.Transcribing);
+
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(DictationEventType.TranscriptionStarted, null, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void StateChanged_Idle_BroadcastsRecordingStopped()
+    {
+        // Idle is the catch-all — any non-Recording, non-Transcribing state
+        // transition maps to RecordingStopped so the UI clears its pending flag.
+        var sut = CreateSut();
+        StartWith(sut);
+
+        _stateMachineMock.Raise(x => x.StateChanged += null, this, DictationState.Idle);
+
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(DictationEventType.RecordingStopped, null, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void RawTranscriptionReady_BroadcastsRawTranscriptionCompleted()
+    {
+        var sut = CreateSut();
+        StartWith(sut);
+
+        _transcriberMock.Raise(x => x.RawTranscriptionReady += null, "raw text");
+
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(DictationEventType.RawTranscriptionCompleted, "raw text", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void TranscriptionCompleted_BroadcastsTranscriptionCompleted()
+    {
+        var sut = CreateSut();
+        StartWith(sut);
+
+        TranscriptionCompleted?.Invoke(this, "final text");
+
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(DictationEventType.TranscriptionCompleted, "final text", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Stop_UnsubscribesTranscriptionCompletedToo()
+    {
+        // After Stop, raising TranscriptionCompleted must not broadcast —
+        // the worker may still exist but the broadcaster is done.
+        var sut = CreateSut();
+        StartWith(sut);
+        sut.Stop();
+
+        TranscriptionCompleted?.Invoke(this, "after stop");
+
+        _outputChannelMock.Verify(
+            x => x.BroadcastEventAsync(It.IsAny<DictationEventType>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void Constructor_NullStateMachine_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationStateBroadcaster(null!, _transcriberMock.Object, _outputChannelMock.Object));
+
+    [Fact]
+    public void Constructor_NullTranscriber_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationStateBroadcaster(_stateMachineMock.Object, null!, _outputChannelMock.Object));
+
+    [Fact]
+    public void Constructor_NullOutputChannel_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationStateBroadcaster(_stateMachineMock.Object, _transcriberMock.Object, null!));
+
+    [Fact]
+    public void Start_NullSubscribeHook_Throws()
+    {
+        var sut = CreateSut();
+        Assert.Throws<ArgumentNullException>(() => sut.Start(null!, _ => { }));
+    }
+
+    [Fact]
+    public void Start_NullUnsubscribeHook_Throws()
+    {
+        var sut = CreateSut();
+        Assert.Throws<ArgumentNullException>(() => sut.Start(_ => { }, null!));
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -19,15 +19,18 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IDictationKeyHandler> _keyHandlerMock;
     private readonly Mock<IDictationStateMachine> _stateMachineMock;
     private readonly Mock<IDictationRecordingSession> _recordingSessionMock;
-    private readonly Mock<IDictationTranscriber> _transcriberMock;
     private readonly Mock<IDictationOutputChannel> _outputChannelMock;
     private readonly Mock<IDictationCompletionPipeline> _completionPipelineMock;
+    private readonly Mock<IDictationStateBroadcaster> _stateBroadcasterMock;
     private readonly DictationOptions _options;
     private readonly DictationWorker _sut;
 
     // Bindings captured from _keyHandler.Start(bindings); the tests invoke this
     // to simulate key events instead of reaching into an IKeyboardMonitor mock.
+    // TaskCompletionSource replaces Task.Delay-based waits so tests don't race
+    // with the worker's ExecuteAsync scheduling. (Copilot review on PR #1034.)
     private IDictationKeyHandlerBindings? _capturedBindings;
+    private readonly TaskCompletionSource<IDictationKeyHandlerBindings> _bindingsReady = new();
 
     public DictationWorkerTests()
     {
@@ -35,15 +38,19 @@ public class DictationWorkerTests : IDisposable
         _keyHandlerMock = new Mock<IDictationKeyHandler>();
         _stateMachineMock = new Mock<IDictationStateMachine>();
         _recordingSessionMock = new Mock<IDictationRecordingSession>();
-        _transcriberMock = new Mock<IDictationTranscriber>();
         _outputChannelMock = new Mock<IDictationOutputChannel>();
         _completionPipelineMock = new Mock<IDictationCompletionPipeline>();
+        _stateBroadcasterMock = new Mock<IDictationStateBroadcaster>();
 
         _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
 
         _keyHandlerMock
             .Setup(x => x.Start(It.IsAny<IDictationKeyHandlerBindings>()))
-            .Callback<IDictationKeyHandlerBindings>(b => _capturedBindings = b);
+            .Callback<IDictationKeyHandlerBindings>(b =>
+            {
+                _capturedBindings = b;
+                _bindingsReady.TrySetResult(b);
+            });
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
 
@@ -52,9 +59,9 @@ public class DictationWorkerTests : IDisposable
             _keyHandlerMock.Object,
             _stateMachineMock.Object,
             _recordingSessionMock.Object,
-            _transcriberMock.Object,
             _outputChannelMock.Object,
             _completionPipelineMock.Object,
+            _stateBroadcasterMock.Object,
             Options.Create(_options));
     }
 
@@ -64,59 +71,71 @@ public class DictationWorkerTests : IDisposable
     public void Constructor_NullLogger_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             null!, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
+            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
             Options.Create(_options)));
 
     [Fact]
     public void Constructor_NullKeyHandler_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, null!, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
+            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
             Options.Create(_options)));
 
     [Fact]
     public void Constructor_NullStateMachine_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, null!, _recordingSessionMock.Object,
-            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
+            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
             Options.Create(_options)));
 
     [Fact]
     public void Constructor_NullRecordingSession_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, null!,
-            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
-            Options.Create(_options)));
-
-    [Fact]
-    public void Constructor_NullTranscriber_ThrowsArgumentNullException() =>
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            null!, _outputChannelMock.Object, _completionPipelineMock.Object,
+            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
             Options.Create(_options)));
 
     [Fact]
     public void Constructor_NullOutputChannel_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _transcriberMock.Object, null!, _completionPipelineMock.Object,
+            null!, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
             Options.Create(_options)));
 
     [Fact]
     public void Constructor_NullCompletionPipeline_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _transcriberMock.Object, _outputChannelMock.Object, null!,
+            _outputChannelMock.Object, null!, _stateBroadcasterMock.Object,
+            Options.Create(_options)));
+
+    [Fact]
+    public void Constructor_NullStateBroadcaster_ThrowsArgumentNullException() =>
+        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
+            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            _outputChannelMock.Object, _completionPipelineMock.Object, null!,
             Options.Create(_options)));
 
     [Fact]
     public void Constructor_NullOptions_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _transcriberMock.Object, _outputChannelMock.Object, _completionPipelineMock.Object,
+            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
             null!));
 
     #endregion
+
+    /// <summary>
+    /// Starts the worker and blocks until the key-handler's Start(bindings)
+    /// callback fires via the TaskCompletionSource rigged in the ctor. Keeps
+    /// tests deterministic instead of racing against Task.Delay(50).
+    /// (Copilot review on PR #1034.)
+    /// </summary>
+    private async Task<IDictationKeyHandlerBindings> StartAndAwaitBindingsAsync(CancellationToken stoppingToken = default)
+    {
+        _ = _sut.StartAsync(stoppingToken);
+        return await _bindingsReady.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
 
     #region ExecuteAsync Tests
 
@@ -125,11 +144,10 @@ public class DictationWorkerTests : IDisposable
     {
         using var cts = new CancellationTokenSource();
 
-        _ = _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
         _keyHandlerMock.Verify(x => x.Start(It.IsAny<IDictationKeyHandlerBindings>()), Times.Once);
-        Assert.NotNull(_capturedBindings);
+        Assert.NotNull(bindings);
     }
 
     [Fact]
@@ -145,18 +163,23 @@ public class DictationWorkerTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_SubscribesToRawTranscriptionReadyEvent()
+    public async Task ExecuteAsync_StartsStateBroadcaster()
     {
+        // Broadcaster owns the state-machine + transcriber event subscriptions;
+        // worker only wires its own TranscriptionCompleted event into the
+        // broadcaster via the Start callback pair.
         using var cts = new CancellationTokenSource();
 
         _ = _sut.StartAsync(cts.Token);
         await Task.Delay(50);
 
-        _transcriberMock.VerifyAdd(x => x.RawTranscriptionReady += It.IsAny<Action<string>>(), Times.Once);
+        _stateBroadcasterMock.Verify(
+            x => x.Start(It.IsAny<Action<EventHandler<string>>>(), It.IsAny<Action<EventHandler<string>>>()),
+            Times.Once);
     }
 
     [Fact]
-    public async Task StopAsync_UnsubscribesFromRawTranscriptionReadyEvent()
+    public async Task StopAsync_StopsStateBroadcaster()
     {
         using var cts = new CancellationTokenSource();
         await _sut.StartAsync(cts.Token);
@@ -164,7 +187,7 @@ public class DictationWorkerTests : IDisposable
 
         await _sut.StopAsync(CancellationToken.None);
 
-        _transcriberMock.VerifyRemove(x => x.RawTranscriptionReady -= It.IsAny<Action<string>>(), Times.Once);
+        _stateBroadcasterMock.Verify(x => x.Stop(), Times.Once);
     }
 
     #endregion
@@ -460,6 +483,44 @@ public class DictationWorkerTests : IDisposable
             Times.Once);
         _completionPipelineMock.Verify(
             x => x.CompleteFullAsync(It.IsAny<byte[]>(), It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [SkipOnCIFact]
+    public async Task KeyboardDictation_AfterQuickMode_ResetsToNormalMode()
+    {
+        // After a quick-mode session is canceled, the next keyboard-triggered
+        // dictation (routed through bindings.StartAsync) must reset the mode
+        // flag and run CompleteFullAsync, not CompleteQuickAsync. Regression
+        // coverage for the pre-extraction behavior lost in PR #1034.
+        // (Copilot review on PR #1034.)
+        using var cts = new CancellationTokenSource();
+        var bindings = await StartAndAwaitBindingsAsync(cts.Token);
+
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        await _sut.StartQuickDictationAsync();
+
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        ((IDictationService)_sut).CancelTranscription();
+
+        // Simulate keyboard ScrollLock from Idle: handler invokes bindings.StartAsync
+        // which must reset quick mode back to false.
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>())).Returns(Task.CompletedTask);
+        await bindings.StartAsync();
+
+        // Now stop + transcribe — should use full mode since quick flag is cleared.
+        var audioData = new byte[] { 1, 2, 3 };
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
+        await bindings.StopAndTranscribeAsync();
+        await Task.Delay(200);
+
+        _completionPipelineMock.Verify(
+            x => x.CompleteFullAsync(audioData, It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+        _completionPipelineMock.Verify(
+            x => x.CompleteQuickAsync(audioData, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Part of #969 (DictationWorker god-class split). Also addresses Copilot review on the merged PR #1034.

## Summary

8th extraction. The SignalR fan-out for state-machine + transcriber events moves behind `IDictationStateBroadcaster`:

- `StateChanged`, `RawTranscriptionReady`, and `TranscriptionCompleted` subscriptions all go to the broadcaster.
- Each emission maps to the matching `DictationEventType` broadcast via `IDictationOutputChannel`.
- Worker's `ExecuteAsync` drops ~25 LOC of event-to-broadcast glue; calls `_stateBroadcaster.Start / Stop`.
- `TranscriptionCompleted` is worker-scoped, so the broadcaster takes `add`/`remove` `Action` hooks rather than a direct reference to the event.

## PR #1034 review fixes (bundled)

- `DictationKeyHandler.Stop()` clears `_bindings` so the handler doesn't pin the worker after Stop.
- `DictationKeyHandler` awaits `bindings.StartAsync()` / `StopAndTranscribeAsync()` directly instead of `Task.Run`, keeping exceptions inside the outer try/catch.
- `DictationWorkerTests` use `TaskCompletionSource` for bindings capture (new `StartAndAwaitBindingsAsync` helper) instead of `Task.Delay(50)`.
- Restore `KeyboardDictation_AfterQuickMode_ResetsToNormalMode` coverage via captured `bindings.StartAsync` / `StopAndTranscribeAsync` path.

## Tests

- New `DictationStateBroadcasterTests` (14 cases): subscription lifecycle idempotence, state→event mapping, `TranscriptionCompleted` subscribe/unsubscribe hooks, null-ctor-arg guards.
- `DictationWorkerTests` updated: broadcaster mock replaces transcriber mock; new `Start/Stop` assertions for the broadcaster; new quick→cancel→full mode regression.
- Full suite green: **419 Service tests pass** (up from 403 on main).

Worker: **464 → 439 LOC**. Ctor dep count stays at 8 (swap `IDictationTranscriber` → `IDictationStateBroadcaster`) but the ExecuteAsync event-wiring block collapses. Target is still ≤400 / ≤5 — remaining candidate is the cancel-flow trio.

## Test plan

- [x] `dotnet build` — green.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — all 419 Service + 321 Voice + others pass.