### PR TITLE
refactor(dictation): extract IDictationCancellationCoordinator — LOC target hit (#969)

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -114,15 +114,24 @@ public static class WorkerServicesExtensions
                 transcriber,
                 outputChannel);
 
+            // Cancellation coordinator owns all teardown flows (cancel
+            // recording / cancel transcription / emergency stop / shutdown)
+            // + the transcription CTS lifecycle, so the worker no longer
+            // needs a direct IDictationOutputChannel dep. (#969 extraction.)
+            var cancellationCoordinator = new DictationCancellationCoordinator(
+                sp.GetRequiredService<ILogger<DictationCancellationCoordinator>>(),
+                sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
+                recordingSession,
+                outputChannel);
+
             return new DictationWorker(
                 sp.GetRequiredService<ILogger<DictationWorker>>(),
                 keyHandler,
                 sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
                 recordingSession,
-                outputChannel,
                 completionPipeline,
                 stateBroadcaster,
-                sp.GetRequiredService<IOptions<DictationOptions>>());
+                cancellationCoordinator);
         });
 
         // Register the same instance as IDictationControl interface (issue #466)

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationCancellationCoordinator.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationCancellationCoordinator.cs
@@ -1,0 +1,138 @@
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Voice.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationCancellationCoordinator : IDictationCancellationCoordinator, IDisposable
+{
+    private readonly ILogger<DictationCancellationCoordinator> _logger;
+    private readonly IDictationStateMachine _stateMachine;
+    private readonly IDictationRecordingSession _recordingSession;
+    private readonly IDictationOutputChannel _outputChannel;
+    private CancellationTokenSource? _transcriptionCts;
+
+    public DictationCancellationCoordinator(
+        ILogger<DictationCancellationCoordinator> logger,
+        IDictationStateMachine stateMachine,
+        IDictationRecordingSession recordingSession,
+        IDictationOutputChannel outputChannel)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
+        _recordingSession = recordingSession ?? throw new ArgumentNullException(nameof(recordingSession));
+        _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
+    }
+
+    public CancellationToken BeginTranscription()
+    {
+        _transcriptionCts?.Dispose();
+        _transcriptionCts = new CancellationTokenSource();
+        return _transcriptionCts.Token;
+    }
+
+    public void EndTranscription()
+    {
+        _transcriptionCts?.Dispose();
+        _transcriptionCts = null;
+    }
+
+    public async Task CancelRecordingAsync()
+    {
+        try
+        {
+            _logger.LogInformation("Canceling recording");
+            await _recordingSession.EmergencyStopAsync();
+            _outputChannel.PlayCancelCue();
+            _stateMachine.TransitionTo(DictationState.Idle);
+            _logger.LogInformation("Recording canceled");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error canceling recording");
+            _stateMachine.TransitionTo(DictationState.Idle);
+        }
+    }
+
+    public async Task EmergencyStopAsync()
+    {
+        try
+        {
+            await _recordingSession.EmergencyStopAsync();
+            _stateMachine.TransitionTo(DictationState.Idle);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during emergency stop");
+            _stateMachine.TransitionTo(DictationState.Idle);
+        }
+        finally
+        {
+            _recordingSession.EndSession();
+        }
+    }
+
+    public void CancelTranscription()
+    {
+        try
+        {
+            var currentState = _stateMachine.CurrentState;
+            _logger.LogInformation("CancelTranscription called in state {State}", currentState);
+
+            _outputChannel.StopTypingFeedback();
+            _outputChannel.PlayCancelCue();
+
+            // If still recording, stop audio capture and discard buffer.
+            // Must complete before resetting streaming state so no more
+            // chunk events arrive after the reset.
+            if (currentState == DictationState.Recording)
+            {
+                _logger.LogInformation("Canceling active recording (emergency stop)");
+                // Documented sync-over-async exception (#976): CancelTranscription
+                // implements IDictationService.CancelTranscription() which is a
+                // void interface method (synchronous cancel semantics). Making it
+                // async would ripple through the hub + state-machine call sites
+                // without any runtime benefit — this is a user-initiated,
+                // infrequent cancel path, not the transcription/streaming hot
+                // path.
+                _recordingSession.EmergencyStopAsync().GetAwaiter().GetResult();
+            }
+
+            _transcriptionCts?.Cancel();
+            _transcriptionCts?.Dispose();
+            _transcriptionCts = null;
+
+            // Cancel in-flight streaming chunk tasks and clear chunk state,
+            // otherwise they keep running into the next session.
+            _recordingSession.EndSession();
+
+            _stateMachine.TransitionTo(DictationState.Idle);
+            _logger.LogInformation("Dictation canceled from state {State}", currentState);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error canceling transcription");
+        }
+    }
+
+    public async Task ShutdownAsync()
+    {
+        _logger.LogInformation("Stopping recording on worker shutdown");
+        try
+        {
+            await _recordingSession.EmergencyStopAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Error stopping recording on shutdown");
+        }
+
+        _stateMachine.TransitionTo(DictationState.Idle);
+    }
+
+    public void Dispose()
+    {
+        _transcriptionCts?.Dispose();
+        _transcriptionCts = null;
+    }
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationCancellationCoordinator.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationCancellationCoordinator.cs
@@ -1,0 +1,56 @@
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Cancel / emergency-stop orchestration lifted out of <c>DictationWorker</c>
+/// (#969 god-class split). Centralises the four teardown paths that all
+/// combine "stop recording + transition to Idle" with small variations
+/// (whether to play the cancel cue, stop typing feedback, or cancel the
+/// in-flight transcription CTS).
+/// </summary>
+public interface IDictationCancellationCoordinator
+{
+    /// <summary>
+    /// Begin a new transcription session: creates the cancellation token
+    /// source and returns its token. The token is what the worker feeds to
+    /// <c>IDictationCompletionPipeline</c> so user-cancel (via
+    /// <see cref="CancelTranscription"/>) bubbles into the pipeline.
+    /// </summary>
+    CancellationToken BeginTranscription();
+
+    /// <summary>
+    /// Dispose the current transcription CTS. Safe to call when no
+    /// transcription is in flight — used from the worker's
+    /// <c>StopAndTranscribeAsync</c> finally.
+    /// </summary>
+    void EndTranscription();
+
+    /// <summary>
+    /// Pause-while-recording path: emergency-stops the recording session
+    /// (discards audio), plays the paper-rip cancel cue, and transitions
+    /// the state machine to Idle.
+    /// </summary>
+    Task CancelRecordingAsync();
+
+    /// <summary>
+    /// Dictation-disabled-while-active path: emergency-stops the recording
+    /// session and transitions to Idle; resets streaming state in finally.
+    /// No cancel cue (this is a programmatic disable, not a user cancel).
+    /// </summary>
+    Task EmergencyStopAsync();
+
+    /// <summary>
+    /// User-initiated cancel (Pause during Transcribing, remote Cancel):
+    /// stops typing feedback, plays the cancel cue, emergency-stops the
+    /// recording if it's still running, cancels + disposes the transcription
+    /// CTS, resets streaming state, and transitions to Idle.
+    /// </summary>
+    void CancelTranscription();
+
+    /// <summary>
+    /// Worker-shutdown path: emergency-stops the recording and transitions
+    /// to Idle. No sound, no session reset — the process is about to exit.
+    /// </summary>
+    Task ShutdownAsync();
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationStateBroadcaster.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationStateBroadcaster.cs
@@ -13,8 +13,9 @@ namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 public interface IDictationStateBroadcaster
 {
     /// <summary>
-    /// Wire event subscriptions. <paramref name="transcriptionCompleted"/>
-    /// is the worker-scoped event raise hook (worker owns the event so the
+    /// Wire event subscriptions. <paramref name="subscribeTranscriptionCompleted"/>
+    /// and <paramref name="unsubscribeTranscriptionCompleted"/> are the
+    /// worker-scoped event subscription hooks (worker owns the event so the
     /// broadcaster subscribes via add/remove callbacks rather than a direct
     /// reference to the event itself).
     /// </summary>

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Options;
-using Olbrasoft.VirtualAssistant.Core.Configuration;
 using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
@@ -22,12 +20,10 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private readonly IDictationKeyHandler _keyHandler;
     private readonly IDictationStateMachine _stateMachine;
     private readonly IDictationRecordingSession _recordingSession;
-    private readonly IDictationOutputChannel _outputChannel;
     private readonly IDictationCompletionPipeline _completionPipeline;
     private readonly IDictationStateBroadcaster _stateBroadcaster;
-    private readonly DictationOptions _options;
+    private readonly IDictationCancellationCoordinator _cancellationCoordinator;
 
-    private CancellationTokenSource? _transcriptionCts;
     private bool _dictationEnabled = true;
     private bool _quickDictationMode;
     private volatile bool _streamingTranscriptionEnabled;
@@ -43,20 +39,17 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         IDictationKeyHandler keyHandler,
         IDictationStateMachine stateMachine,
         IDictationRecordingSession recordingSession,
-        IDictationOutputChannel outputChannel,
         IDictationCompletionPipeline completionPipeline,
         IDictationStateBroadcaster stateBroadcaster,
-        IOptions<DictationOptions> options)
+        IDictationCancellationCoordinator cancellationCoordinator)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _keyHandler = keyHandler ?? throw new ArgumentNullException(nameof(keyHandler));
         _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
         _recordingSession = recordingSession ?? throw new ArgumentNullException(nameof(recordingSession));
-        _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
         _completionPipeline = completionPipeline ?? throw new ArgumentNullException(nameof(completionPipeline));
         _stateBroadcaster = stateBroadcaster ?? throw new ArgumentNullException(nameof(stateBroadcaster));
-        ArgumentNullException.ThrowIfNull(options);
-        _options = options.Value;
+        _cancellationCoordinator = cancellationCoordinator ?? throw new ArgumentNullException(nameof(cancellationCoordinator));
     }
 
     /// <summary>
@@ -73,7 +66,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         if (!enabled && _stateMachine.CurrentState != DictationState.Idle)
         {
             _logger.LogInformation("Dictation disabled while active - performing emergency stop");
-            Task.Run(async () => await EmergencyStopAsync());
+            Task.Run(async () => await _cancellationCoordinator.EmergencyStopAsync());
         }
     }
 
@@ -159,10 +152,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     }
 
     /// <inheritdoc/>
-    void IDictationService.CancelTranscription()
-    {
-        CancelTranscription();
-    }
+    void IDictationService.CancelTranscription() => _cancellationCoordinator.CancelTranscription();
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -203,7 +193,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             // Stop recording if active
             if (_stateMachine.CurrentState == DictationState.Recording)
             {
-                await StopRecordingAsync();
+                await _cancellationCoordinator.ShutdownAsync();
             }
         }
     }
@@ -228,9 +218,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 
         public Task StopAndTranscribeAsync() => worker.StopAndTranscribeAsync();
 
-        public Task CancelRecordingAsync() => worker.CancelRecordingAsync();
+        public Task CancelRecordingAsync() => worker._cancellationCoordinator.CancelRecordingAsync();
 
-        public void CancelTranscription() => worker.CancelTranscription();
+        public void CancelTranscription() => worker._cancellationCoordinator.CancelTranscription();
     }
 
     private async Task StartRecordingAsync()
@@ -262,18 +252,18 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             var audioData = await ValidateAndPrepareAudioAsync();
             if (audioData == null) return;
 
-            _transcriptionCts = new CancellationTokenSource();
+            var token = _cancellationCoordinator.BeginTranscription();
 
             if (_quickDictationMode)
             {
-                await _completionPipeline.CompleteQuickAsync(audioData, _transcriptionCts.Token);
+                await _completionPipeline.CompleteQuickAsync(audioData, token);
             }
             else
             {
                 await _completionPipeline.CompleteFullAsync(
                     audioData,
                     text => TranscriptionCompleted?.Invoke(this, text),
-                    _transcriptionCts.Token);
+                    token);
             }
         }
         catch (OperationCanceledException)
@@ -288,8 +278,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         }
         finally
         {
-            _transcriptionCts?.Dispose();
-            _transcriptionCts = null;
+            _cancellationCoordinator.EndTranscription();
             _recordingSession.EndSession();
         }
     }
@@ -315,123 +304,13 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         return audioData;
     }
 
-    private async Task CancelRecordingAsync()
-    {
-        try
-        {
-            _logger.LogInformation("Canceling recording");
-
-            // Emergency stop recording (discards audio data)
-            await _recordingSession.EmergencyStopAsync();
-
-            // Play cancel sound (paper-rip effect)
-            _outputChannel.PlayCancelCue();
-
-            // Return to Idle without transcription
-            _stateMachine.TransitionTo(DictationState.Idle);
-
-            _logger.LogInformation("Recording canceled");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error canceling recording");
-            _stateMachine.TransitionTo(DictationState.Idle);
-        }
-    }
-
-    private async Task EmergencyStopAsync()
-    {
-        try
-        {
-            // Emergency stop recording (discards audio data)
-            await _recordingSession.EmergencyStopAsync();
-
-            // Return to Idle without transcription
-            _stateMachine.TransitionTo(DictationState.Idle);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error during emergency stop");
-            _stateMachine.TransitionTo(DictationState.Idle);
-        }
-        finally
-        {
-            _recordingSession.EndSession();
-        }
-    }
-
-    private void CancelTranscription()
-    {
-        try
-        {
-            var currentState = _stateMachine.CurrentState;
-            _logger.LogInformation("CancelTranscription called in state {State}", currentState);
-
-            // Stop typing sound immediately
-            _outputChannel.StopTypingFeedback();
-
-            // Play cancel sound (paper-rip effect)
-            _outputChannel.PlayCancelCue();
-
-            // If still recording, stop audio capture and discard buffer.
-            // Must complete before resetting streaming state so no more
-            // chunk events arrive after the reset.
-            if (currentState == DictationState.Recording)
-            {
-                _logger.LogInformation("Canceling active recording (emergency stop)");
-                // Documented sync-over-async exception (#976): CancelTranscription
-                // implements IDictationService.CancelTranscription() which is a
-                // void interface method (synchronous cancel semantics). Making it
-                // async would ripple through the hub + state-machine call sites
-                // without any runtime benefit — this is a user-initiated,
-                // infrequent cancel path, not the transcription/streaming hot path.
-                _recordingSession.EmergencyStopAsync().GetAwaiter().GetResult();
-            }
-
-            // Cancel transcription if in progress
-            _transcriptionCts?.Cancel();
-            _transcriptionCts?.Dispose();
-            _transcriptionCts = null;
-
-            // Cancel in-flight streaming chunk tasks and clear chunk state,
-            // otherwise they keep running into the next session.
-            _recordingSession.EndSession();
-
-            // Return to Idle
-            _stateMachine.TransitionTo(DictationState.Idle);
-
-            _logger.LogInformation("Dictation canceled from state {State}", currentState);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error canceling transcription");
-        }
-    }
-
-    private async Task StopRecordingAsync()
-    {
-        _logger.LogInformation("Stopping recording on worker shutdown");
-
-        try
-        {
-            // Stop recording (discards audio data on shutdown)
-            await _recordingSession.EmergencyStopAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Error stopping recording on shutdown");
-        }
-
-        _stateMachine.TransitionTo(DictationState.Idle);
-    }
-
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Dictation worker stopping...");
 
         if (_stateMachine.CurrentState == DictationState.Recording)
         {
-            await StopRecordingAsync();
+            await _cancellationCoordinator.ShutdownAsync();
         }
 
         await base.StopAsync(cancellationToken);

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationCancellationCoordinatorTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationCancellationCoordinatorTests.cs
@@ -1,0 +1,208 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+using Olbrasoft.VirtualAssistant.Voice.StateMachine;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the cancel/emergency-stop orchestration lifted out of DictationWorker
+/// in #969. Covers the four teardown paths (Pause-while-recording, dictation-
+/// disabled-while-active, user CancelTranscription, worker shutdown) plus the
+/// transcription CTS lifecycle.
+/// </summary>
+public class DictationCancellationCoordinatorTests
+{
+    private readonly Mock<ILogger<DictationCancellationCoordinator>> _loggerMock = new();
+    private readonly Mock<IDictationStateMachine> _stateMachineMock = new();
+    private readonly Mock<IDictationRecordingSession> _recordingSessionMock = new();
+    private readonly Mock<IDictationOutputChannel> _outputChannelMock = new();
+
+    private DictationCancellationCoordinator CreateSut() =>
+        new(_loggerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object, _outputChannelMock.Object);
+
+    [Fact]
+    public void BeginTranscription_ReturnsCancellableToken()
+    {
+        var sut = CreateSut();
+        var token = sut.BeginTranscription();
+
+        Assert.False(token.IsCancellationRequested);
+
+        sut.CancelTranscription();
+        Assert.True(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void BeginTranscription_Twice_ReplacesPreviousCts()
+    {
+        // Two back-to-back sessions: the first token should stay cancellable
+        // only until the second Begin replaces it (dispose of prior CTS is
+        // implicit in the coordinator).
+        var sut = CreateSut();
+        var first = sut.BeginTranscription();
+        var second = sut.BeginTranscription();
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void EndTranscription_DisposesCurrentCts()
+    {
+        var sut = CreateSut();
+        _ = sut.BeginTranscription();
+
+        sut.EndTranscription();
+        // No-op EndTranscription is safe — a second call must not throw.
+        sut.EndTranscription();
+    }
+
+    [Fact]
+    public async Task CancelRecordingAsync_EmergencyStopsPlaysCueAndIdles()
+    {
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        await sut.CancelRecordingAsync();
+
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
+        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CancelRecordingAsync_EmergencyStopThrows_StillTransitionsIdle()
+    {
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).ThrowsAsync(new InvalidOperationException());
+        var sut = CreateSut();
+
+        await sut.CancelRecordingAsync();
+
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task EmergencyStopAsync_EmergencyStopsIdlesAndEndsSession()
+    {
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        await sut.EmergencyStopAsync();
+
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+        _recordingSessionMock.Verify(x => x.EndSession(), Times.Once);
+    }
+
+    [Fact]
+    public async Task EmergencyStopAsync_NoCancelCue()
+    {
+        // Programmatic disable path — no user-facing sound.
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        await sut.EmergencyStopAsync();
+
+        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Never);
+    }
+
+    [Fact]
+    public void CancelTranscription_WhileTranscribing_StopsFeedbackPlaysCueAndIdles()
+    {
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
+        var sut = CreateSut();
+        _ = sut.BeginTranscription();
+
+        sut.CancelTranscription();
+
+        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
+        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
+        _recordingSessionMock.Verify(x => x.EndSession(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public void CancelTranscription_WhileRecording_AlsoEmergencyStopsRecording()
+    {
+        // Pause-while-recording → hub CancelTranscription path: must also tear
+        // down the active recording before the state machine goes Idle.
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        sut.CancelTranscription();
+
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public void CancelTranscription_CancelsAndDisposesTheCts()
+    {
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
+        var sut = CreateSut();
+        var token = sut.BeginTranscription();
+
+        sut.CancelTranscription();
+
+        Assert.True(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_EmergencyStopsAndIdles()
+    {
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        await sut.ShutdownAsync();
+
+        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_NoSoundOrEndSession()
+    {
+        // Process-exit path — no cancel cue, no EndSession reset (nothing left
+        // to reset since we're about to die).
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        await sut.ShutdownAsync();
+
+        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Never);
+        _recordingSessionMock.Verify(x => x.EndSession(), Times.Never);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_EmergencyStopThrows_StillTransitionsIdle()
+    {
+        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).ThrowsAsync(new IOException());
+        var sut = CreateSut();
+
+        await sut.ShutdownAsync();
+
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationCancellationCoordinator(null!, _stateMachineMock.Object, _recordingSessionMock.Object, _outputChannelMock.Object));
+
+    [Fact]
+    public void Constructor_NullStateMachine_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationCancellationCoordinator(_loggerMock.Object, null!, _recordingSessionMock.Object, _outputChannelMock.Object));
+
+    [Fact]
+    public void Constructor_NullRecordingSession_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationCancellationCoordinator(_loggerMock.Object, _stateMachineMock.Object, null!, _outputChannelMock.Object));
+
+    [Fact]
+    public void Constructor_NullOutputChannel_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationCancellationCoordinator(_loggerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object, null!));
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -1,8 +1,6 @@
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 using Olbrasoft.Testing.Xunit.Attributes;
-using Olbrasoft.VirtualAssistant.Core.Configuration;
 using Olbrasoft.VirtualAssistant.Core.Models;
 using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
@@ -19,18 +17,18 @@ public class DictationWorkerTests : IDisposable
     private readonly Mock<IDictationKeyHandler> _keyHandlerMock;
     private readonly Mock<IDictationStateMachine> _stateMachineMock;
     private readonly Mock<IDictationRecordingSession> _recordingSessionMock;
-    private readonly Mock<IDictationOutputChannel> _outputChannelMock;
     private readonly Mock<IDictationCompletionPipeline> _completionPipelineMock;
     private readonly Mock<IDictationStateBroadcaster> _stateBroadcasterMock;
-    private readonly DictationOptions _options;
+    private readonly Mock<IDictationCancellationCoordinator> _cancellationCoordinatorMock;
     private readonly DictationWorker _sut;
 
-    // Bindings captured from _keyHandler.Start(bindings); the tests invoke this
-    // to simulate key events instead of reaching into an IKeyboardMonitor mock.
-    // TaskCompletionSource replaces Task.Delay-based waits so tests don't race
-    // with the worker's ExecuteAsync scheduling. (Copilot review on PR #1034.)
+    // Bindings captured from _keyHandler.Start(bindings); tests await
+    // _bindingsReady.Task to block until ExecuteAsync wired everything up.
+    // RunContinuationsAsynchronously so continuations don't run inline on the
+    // worker's ExecuteAsync thread. (Copilot review on PR #1035.)
     private IDictationKeyHandlerBindings? _capturedBindings;
-    private readonly TaskCompletionSource<IDictationKeyHandlerBindings> _bindingsReady = new();
+    private readonly TaskCompletionSource<IDictationKeyHandlerBindings> _bindingsReady =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public DictationWorkerTests()
     {
@@ -38,11 +36,9 @@ public class DictationWorkerTests : IDisposable
         _keyHandlerMock = new Mock<IDictationKeyHandler>();
         _stateMachineMock = new Mock<IDictationStateMachine>();
         _recordingSessionMock = new Mock<IDictationRecordingSession>();
-        _outputChannelMock = new Mock<IDictationOutputChannel>();
         _completionPipelineMock = new Mock<IDictationCompletionPipeline>();
         _stateBroadcasterMock = new Mock<IDictationStateBroadcaster>();
-
-        _options = new DictationOptions { KeyboardLedSettleTimeMs = 10 };
+        _cancellationCoordinatorMock = new Mock<IDictationCancellationCoordinator>();
 
         _keyHandlerMock
             .Setup(x => x.Start(It.IsAny<IDictationKeyHandlerBindings>()))
@@ -59,10 +55,20 @@ public class DictationWorkerTests : IDisposable
             _keyHandlerMock.Object,
             _stateMachineMock.Object,
             _recordingSessionMock.Object,
-            _outputChannelMock.Object,
             _completionPipelineMock.Object,
             _stateBroadcasterMock.Object,
-            Options.Create(_options));
+            _cancellationCoordinatorMock.Object);
+    }
+
+    /// <summary>
+    /// Starts the worker and blocks deterministically until the key handler's
+    /// Start(bindings) callback fires via the TaskCompletionSource. Replaces
+    /// flaky Task.Delay(50) waits. (Copilot reviews on PR #1034 + #1035.)
+    /// </summary>
+    private async Task<IDictationKeyHandlerBindings> StartAndAwaitBindingsAsync(CancellationToken stoppingToken = default)
+    {
+        _ = _sut.StartAsync(stoppingToken);
+        return await _bindingsReady.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     #region Constructor Tests
@@ -71,71 +77,45 @@ public class DictationWorkerTests : IDisposable
     public void Constructor_NullLogger_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             null!, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
-            Options.Create(_options)));
+            _completionPipelineMock.Object, _stateBroadcasterMock.Object, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullKeyHandler_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, null!, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
-            Options.Create(_options)));
+            _completionPipelineMock.Object, _stateBroadcasterMock.Object, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullStateMachine_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, null!, _recordingSessionMock.Object,
-            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
-            Options.Create(_options)));
+            _completionPipelineMock.Object, _stateBroadcasterMock.Object, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullRecordingSession_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, null!,
-            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
-            Options.Create(_options)));
-
-    [Fact]
-    public void Constructor_NullOutputChannel_ThrowsArgumentNullException() =>
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            null!, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
-            Options.Create(_options)));
+            _completionPipelineMock.Object, _stateBroadcasterMock.Object, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullCompletionPipeline_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _outputChannelMock.Object, null!, _stateBroadcasterMock.Object,
-            Options.Create(_options)));
+            null!, _stateBroadcasterMock.Object, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullStateBroadcaster_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _outputChannelMock.Object, _completionPipelineMock.Object, null!,
-            Options.Create(_options)));
+            _completionPipelineMock.Object, null!, _cancellationCoordinatorMock.Object));
 
     [Fact]
-    public void Constructor_NullOptions_ThrowsArgumentNullException() =>
+    public void Constructor_NullCancellationCoordinator_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
             _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _outputChannelMock.Object, _completionPipelineMock.Object, _stateBroadcasterMock.Object,
-            null!));
+            _completionPipelineMock.Object, _stateBroadcasterMock.Object, null!));
 
     #endregion
-
-    /// <summary>
-    /// Starts the worker and blocks until the key-handler's Start(bindings)
-    /// callback fires via the TaskCompletionSource rigged in the ctor. Keeps
-    /// tests deterministic instead of racing against Task.Delay(50).
-    /// (Copilot review on PR #1034.)
-    /// </summary>
-    private async Task<IDictationKeyHandlerBindings> StartAndAwaitBindingsAsync(CancellationToken stoppingToken = default)
-    {
-        _ = _sut.StartAsync(stoppingToken);
-        return await _bindingsReady.Task.WaitAsync(TimeSpan.FromSeconds(5));
-    }
 
     #region ExecuteAsync Tests
 
@@ -154,8 +134,7 @@ public class DictationWorkerTests : IDisposable
     public async Task StopAsync_StopsKeyHandler()
     {
         using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         await _sut.StopAsync(CancellationToken.None);
 
@@ -165,13 +144,9 @@ public class DictationWorkerTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_StartsStateBroadcaster()
     {
-        // Broadcaster owns the state-machine + transcriber event subscriptions;
-        // worker only wires its own TranscriptionCompleted event into the
-        // broadcaster via the Start callback pair.
         using var cts = new CancellationTokenSource();
 
-        _ = _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         _stateBroadcasterMock.Verify(
             x => x.Start(It.IsAny<Action<EventHandler<string>>>(), It.IsAny<Action<EventHandler<string>>>()),
@@ -182,8 +157,7 @@ public class DictationWorkerTests : IDisposable
     public async Task StopAsync_StopsStateBroadcaster()
     {
         using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         await _sut.StopAsync(CancellationToken.None);
 
@@ -194,48 +168,39 @@ public class DictationWorkerTests : IDisposable
 
     #region Bindings Adapter Tests
 
-    // The worker's nested KeyHandlerBindings adapter is the only place the
-    // worker's internal state reaches the key handler. Exercise it via the
-    // captured IDictationKeyHandlerBindings instance.
-
     [Fact]
     public async Task Bindings_StateMirrorsStateMachineCurrentState()
     {
         using var cts = new CancellationTokenSource();
-        _ = _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
 
-        Assert.NotNull(_capturedBindings);
-        Assert.Equal(DictationState.Transcribing, _capturedBindings!.State);
+        Assert.Equal(DictationState.Transcribing, bindings.State);
     }
 
     [Fact]
     public async Task Bindings_IsEnabledReflectsSetDictationEnabled()
     {
         using var cts = new CancellationTokenSource();
-        _ = _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
-        Assert.NotNull(_capturedBindings);
-        Assert.True(_capturedBindings!.IsEnabled);
+        Assert.True(bindings.IsEnabled);
 
         _sut.SetDictationEnabled(false);
-        Assert.False(_capturedBindings.IsEnabled);
+        Assert.False(bindings.IsEnabled);
     }
 
     [SkipOnCIFact]
     public async Task Bindings_StartAsync_TriggersNormalModeRecording()
     {
         using var cts = new CancellationTokenSource();
-        _ = _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>())).Returns(Task.CompletedTask);
 
-        await _capturedBindings!.StartAsync();
+        await bindings.StartAsync();
 
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
         _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Once);
@@ -245,14 +210,13 @@ public class DictationWorkerTests : IDisposable
     public async Task Bindings_StopAndTranscribeAsync_InvokesCompletionPipelineFullMode()
     {
         using var cts = new CancellationTokenSource();
-        _ = _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
         var audio = new byte[] { 1, 2, 3, 4 };
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audio);
 
-        await _capturedBindings!.StopAndTranscribeAsync();
+        await bindings.StopAndTranscribeAsync();
         await Task.Delay(100);
 
         _completionPipelineMock.Verify(
@@ -260,34 +224,26 @@ public class DictationWorkerTests : IDisposable
             Times.Once);
     }
 
-    [SkipOnCIFact]
-    public async Task Bindings_CancelRecordingAsync_EmergencyStopsAndPlaysCancelCue()
+    [Fact]
+    public async Task Bindings_CancelRecordingAsync_DelegatesToCoordinator()
     {
         using var cts = new CancellationTokenSource();
-        _ = _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
-        await _capturedBindings!.CancelRecordingAsync();
+        await bindings.CancelRecordingAsync();
 
-        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
-        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+        _cancellationCoordinatorMock.Verify(x => x.CancelRecordingAsync(), Times.Once);
     }
 
-    [SkipOnCIFact]
-    public async Task Bindings_CancelTranscription_DelegatesToWorker()
+    [Fact]
+    public async Task Bindings_CancelTranscription_DelegatesToCoordinator()
     {
         using var cts = new CancellationTokenSource();
-        _ = _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
+        bindings.CancelTranscription();
 
-        _capturedBindings!.CancelTranscription();
-
-        _outputChannelMock.Verify(x => x.StopTypingFeedback(), Times.Once);
-        _outputChannelMock.Verify(x => x.PlayCancelCue(), Times.Once);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+        _cancellationCoordinatorMock.Verify(x => x.CancelTranscription(), Times.Once);
     }
 
     #endregion
@@ -295,38 +251,37 @@ public class DictationWorkerTests : IDisposable
     #region SetDictationEnabled Tests
 
     [Fact]
-    public void SetDictationEnabled_DisablingWhileIdle_DoesNotPerformEmergencyStop()
+    public void SetDictationEnabled_DisablingWhileIdle_DoesNotCallCoordinator()
     {
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
 
         _sut.SetDictationEnabled(false);
 
-        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Never);
+        _cancellationCoordinatorMock.Verify(x => x.EmergencyStopAsync(), Times.Never);
     }
 
     [Fact]
-    public async Task SetDictationEnabled_DisablingWhileRecording_PerformsEmergencyStop()
+    public async Task SetDictationEnabled_DisablingWhileRecording_TriggersCoordinatorEmergencyStop()
     {
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        _cancellationCoordinatorMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
 
         _sut.SetDictationEnabled(false);
         await Task.Delay(100);
 
-        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+        _cancellationCoordinatorMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
     }
 
     [Fact]
-    public async Task SetDictationEnabled_DisablingWhileTranscribing_PerformsEmergencyStop()
+    public async Task SetDictationEnabled_DisablingWhileTranscribing_TriggersCoordinatorEmergencyStop()
     {
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
-        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        _cancellationCoordinatorMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
 
         _sut.SetDictationEnabled(false);
         await Task.Delay(100);
 
-        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
+        _cancellationCoordinatorMock.Verify(x => x.EmergencyStopAsync(), Times.Once);
     }
 
     #endregion
@@ -337,8 +292,7 @@ public class DictationWorkerTests : IDisposable
     public async Task StopAndTranscribe_EmptyAudio_TransitionsIdleAndSkipsCompletionPipeline()
     {
         using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(Array.Empty<byte>());
@@ -356,13 +310,14 @@ public class DictationWorkerTests : IDisposable
     }
 
     [SkipOnCIFact]
-    public async Task StopAndTranscribe_NormalMode_InvokesCompleteFullAsync()
+    public async Task StopAndTranscribe_NormalMode_BeginsTranscriptionAndInvokesCompleteFullAsync()
     {
         using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         var audioData = new byte[] { 1, 2, 3, 4 };
+        var token = new CancellationToken();
+        _cancellationCoordinatorMock.Setup(x => x.BeginTranscription()).Returns(token);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
@@ -370,24 +325,18 @@ public class DictationWorkerTests : IDisposable
         await _sut.StopDictationAsync();
         await Task.Delay(200);
 
+        _cancellationCoordinatorMock.Verify(x => x.BeginTranscription(), Times.Once);
         _completionPipelineMock.Verify(
             x => x.CompleteFullAsync(audioData, It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()),
             Times.Once);
-        _completionPipelineMock.Verify(
-            x => x.CompleteQuickAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _cancellationCoordinatorMock.Verify(x => x.EndTranscription(), Times.Once);
     }
 
     [SkipOnCIFact]
     public async Task StopAndTranscribe_NormalMode_TranscriptionCompletedCallbackRaisesWorkerEvent()
     {
-        // The worker's public TranscriptionCompleted event must fire for any
-        // text the pipeline hands back via the callback — this is how the
-        // SignalR broadcast + remote UI see the text before the keystrokes
-        // land.
         using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         var audioData = new byte[] { 1, 2, 3, 4 };
         Action<string>? capturedCallback = null;
@@ -416,33 +365,30 @@ public class DictationWorkerTests : IDisposable
     #region StopAsync Tests
 
     [Fact]
-    public async Task StopAsync_WhileIdle_DoesNotPerformEmergencyStop()
+    public async Task StopAsync_WhileIdle_DoesNotTriggerCoordinatorShutdown()
     {
         using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
 
         await _sut.StopAsync(CancellationToken.None);
 
-        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.Never);
+        _cancellationCoordinatorMock.Verify(x => x.ShutdownAsync(), Times.Never);
     }
 
     [Fact]
-    public async Task StopAsync_WhileRecording_StopsRecording()
+    public async Task StopAsync_WhileRecording_TriggersCoordinatorShutdown()
     {
         using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.EmergencyStopAsync()).Returns(Task.CompletedTask);
+        _cancellationCoordinatorMock.Setup(x => x.ShutdownAsync()).Returns(Task.CompletedTask);
 
         await _sut.StopAsync(CancellationToken.None);
 
-        _recordingSessionMock.Verify(x => x.EmergencyStopAsync(), Times.AtLeastOnce);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
+        _cancellationCoordinatorMock.Verify(x => x.ShutdownAsync(), Times.AtLeastOnce);
     }
 
     #endregion
@@ -464,8 +410,7 @@ public class DictationWorkerTests : IDisposable
     public async Task QuickDictation_InvokesCompleteQuickAsync()
     {
         using var cts = new CancellationTokenSource();
-        await _sut.StartAsync(cts.Token);
-        await Task.Delay(50);
+        await StartAndAwaitBindingsAsync(cts.Token);
 
         var audioData = new byte[] { 1, 2, 3, 4 };
 
@@ -491,9 +436,7 @@ public class DictationWorkerTests : IDisposable
     {
         // After a quick-mode session is canceled, the next keyboard-triggered
         // dictation (routed through bindings.StartAsync) must reset the mode
-        // flag and run CompleteFullAsync, not CompleteQuickAsync. Regression
-        // coverage for the pre-extraction behavior lost in PR #1034.
-        // (Copilot review on PR #1034.)
+        // flag and run CompleteFullAsync, not CompleteQuickAsync.
         using var cts = new CancellationTokenSource();
         var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
@@ -503,13 +446,10 @@ public class DictationWorkerTests : IDisposable
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         ((IDictationService)_sut).CancelTranscription();
 
-        // Simulate keyboard ScrollLock from Idle: handler invokes bindings.StartAsync
-        // which must reset quick mode back to false.
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>())).Returns(Task.CompletedTask);
         await bindings.StartAsync();
 
-        // Now stop + transcribe — should use full mode since quick flag is cleared.
         var audioData = new byte[] { 1, 2, 3 };
         _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Part of #969 (DictationWorker god-class split). **LOC target hit: worker now 318 LOC (≤400 target).** Ctor deps 8 → 7 (target ≤5).

## Summary

9th extraction. All teardown paths + the transcription CTS lifecycle move behind `IDictationCancellationCoordinator`. Worker drops `IDictationOutputChannel` (no longer used directly) and the dead `IOptions<DictationOptions>` injection.

### Coordinator surface

- `BeginTranscription` / `EndTranscription` — CTS lifecycle owned by the coordinator.
- `CancelRecordingAsync` — Pause-while-recording: emergency-stop + cancel cue + idle.
- `EmergencyStopAsync` — dictation-disabled path: emergency-stop + idle, **no cue**.
- `CancelTranscription` — user cancel: stop feedback + cue + CTS cancel + optional emergency-stop (if still recording) + end session + idle. Retains the documented sync-over-async exception from the original worker.
- `ShutdownAsync` — worker stop: emergency-stop + idle, no cue / no session reset.

### Worker delta

- 439 → 318 LOC.
- Deps 8 → 7 (dropped `IDictationOutputChannel` + dead `IOptions<DictationOptions>`; gained `IDictationCancellationCoordinator`).
- Deleted `CancelRecordingAsync`, `EmergencyStopAsync`, `CancelTranscription`, `StopRecordingAsync`, `_transcriptionCts` field.
- `ExecuteAsync` finally + `StopAsync` + `IDictationService.CancelTranscription` + `KeyHandlerBindings.CancelRecordingAsync` / `CancelTranscription` all delegate to the coordinator.

## PR #1035 review fixes (bundled)

- `DictationWorkerTests` `TaskCompletionSource` now uses `TaskCreationOptions.RunContinuationsAsynchronously` so the bindings-ready continuations don't run inline on the worker's `ExecuteAsync` thread.
- Lingering `Task.Delay(50)` patterns replaced with `StartAndAwaitBindingsAsync` everywhere the test awaits the key-handler start callback.
- `IDictationStateBroadcaster` xmldoc paramref fixed (`transcriptionCompleted` → `subscribeTranscriptionCompleted` / `unsubscribeTranscriptionCompleted`).

## Tests

- New `DictationCancellationCoordinatorTests` (16 cases): all four teardown paths, CTS lifecycle (single + double begin), exception resilience, null-ctor-arg guards.
- `DictationWorkerTests` rewritten to assert coordinator delegation instead of inlined flows; drops the `outputChannelMock` + options injection.
- Full suite: **435 Service tests pass** (up from 419).

## #969 status after this PR

| Target | Before | After |
|---|---|---|
| LOC ≤400 | 439 ❌ | **318 ✅** |
| Ctor deps ≤5 | 8 | 7 ❌ |

LOC target hit. Ctor dep target still 2 over — remaining candidates are consolidating the StateMachine reads (9 usages scattered across Start/Stop/ExecuteAsync paths) with recordingSession into a "recording lifecycle façade", or folding stateBroadcaster into a hosted service so worker doesn't inject it at all.

## Test plan

- [x] `dotnet build` — green.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 435 Service + 321 Voice + others all pass.