### PR TITLE
refactor(dictation): recording session owns state — #969 dep target hit

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -59,7 +59,8 @@ public static class WorkerServicesExtensions
             new DictationRecordingSession(
                 sp.GetRequiredService<ILogger<DictationRecordingSession>>(),
                 sp.GetRequiredKeyedService<IAudioRecordingCoordinator>(DictationKey),
-                sp.GetRequiredService<IDictationTranscriber>()));
+                sp.GetRequiredService<IDictationTranscriber>(),
+                sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>()));
 
         services.AddSingleton<IDictationOutputChannel>(sp =>
             new DictationOutputChannel(
@@ -86,7 +87,6 @@ public static class WorkerServicesExtensions
         services.AddSingleton(sp => new DictationWorker(
             sp.GetRequiredService<ILogger<DictationWorker>>(),
             sp.GetRequiredService<IDictationKeyHandler>(),
-            sp.GetRequiredService<Voice.StateMachine.IDictationStateMachine>(),
             sp.GetRequiredService<IDictationRecordingSession>(),
             sp.GetRequiredService<IDictationCompletionPipeline>(),
             sp.GetRequiredService<IDictationCancellationCoordinator>()));

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationRecordingSession.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationRecordingSession.cs
@@ -1,4 +1,6 @@
 using Olbrasoft.VirtualAssistant.Core.Audio;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
+using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 
 namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 
@@ -8,41 +10,70 @@ public sealed class DictationRecordingSession : IDictationRecordingSession, IDis
     private readonly ILogger<DictationRecordingSession> _logger;
     private readonly IAudioRecordingCoordinator _recordingCoordinator;
     private readonly IDictationTranscriber _transcriber;
+    private readonly IDictationStateMachine _stateMachine;
 
     public DictationRecordingSession(
         ILogger<DictationRecordingSession> logger,
         IAudioRecordingCoordinator recordingCoordinator,
-        IDictationTranscriber transcriber)
+        IDictationTranscriber transcriber,
+        IDictationStateMachine stateMachine)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _recordingCoordinator = recordingCoordinator ?? throw new ArgumentNullException(nameof(recordingCoordinator));
         _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
+        _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
 
         // Forward each emitted chunk to the transcriber's streaming assembler.
         // Kept inside the session so the worker never sees the chunk event.
         _recordingCoordinator.ChunkAvailable += OnChunkAvailable;
     }
 
+    public DictationState CurrentState => _stateMachine.CurrentState;
+
     public bool IsStreamingActive => _transcriber.IsStreamingActive;
 
     public async Task StartAsync(bool streamingActive)
     {
-        _transcriber.BeginSession(streamingActive);
-
-        if (streamingActive)
+        try
         {
-            _recordingCoordinator.EnableChunking(TimeSpan.FromSeconds(8));
-            _logger.LogInformation("Streaming transcription active for this session (8s chunks)");
-        }
-        else
-        {
-            _recordingCoordinator.DisableChunking();
-        }
+            _stateMachine.TransitionTo(DictationState.Recording);
+            _transcriber.BeginSession(streamingActive);
 
-        await _recordingCoordinator.StartRecordingAsync();
+            if (streamingActive)
+            {
+                _recordingCoordinator.EnableChunking(TimeSpan.FromSeconds(8));
+                _logger.LogInformation("Streaming transcription active for this session (8s chunks)");
+            }
+            else
+            {
+                _recordingCoordinator.DisableChunking();
+            }
+
+            await _recordingCoordinator.StartRecordingAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start recording");
+            _stateMachine.TransitionTo(DictationState.Idle);
+        }
     }
 
-    public Task<byte[]> StopAsync() => _recordingCoordinator.StopRecordingAsync();
+    public async Task<byte[]?> StopAndValidateAsync()
+    {
+        var audioData = await _recordingCoordinator.StopRecordingAsync();
+
+        if (audioData.Length == 0)
+        {
+            _logger.LogWarning("No audio data recorded");
+            _stateMachine.TransitionTo(DictationState.Idle);
+            return null;
+        }
+
+        _logger.LogInformation("Recording stopped - {Bytes} bytes captured", audioData.Length);
+        _stateMachine.TransitionTo(DictationState.Transcribing);
+
+        return audioData;
+    }
 
     public Task EmergencyStopAsync() => _recordingCoordinator.EmergencyStopAsync();
 

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationRecordingSession.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationRecordingSession.cs
@@ -1,19 +1,27 @@
 using Olbrasoft.VirtualAssistant.Core.Audio;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
 
 namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 
 /// <summary>
 /// Audio-recording lifecycle lifted out of <c>DictationWorker</c> (#969
-/// god-class split). Bundles <see cref="IAudioRecordingCoordinator"/> with
-/// the streaming-session hooks on <see cref="IDictationTranscriber"/> so
-/// the worker no longer subscribes to <c>ChunkAvailable</c>, toggles
-/// chunking directly, or coordinates the transcriber's streaming state —
-/// it just tells the session start / stop / cancel / reset. State-machine
-/// transitions stay in the worker because they're cross-cutting across
-/// the transcription, typing, and cancel paths too.
+/// god-class split). Bundles <see cref="IAudioRecordingCoordinator"/>,
+/// the streaming-session hooks on <see cref="IDictationTranscriber"/>, and
+/// the dictation state-machine transitions tied to recording so the worker
+/// no longer holds a direct <c>IDictationStateMachine</c> dep or subscribes
+/// to <c>ChunkAvailable</c>. It just tells the session start / stop / cancel
+/// and reads <see cref="CurrentState"/> when it needs to guard commands.
 /// </summary>
 public interface IDictationRecordingSession
 {
+    /// <summary>
+    /// Current dictation state (Idle / Recording / Transcribing). Delegates
+    /// to the underlying <see cref="IDictationStateMachine"/> so consumers
+    /// can guard commands without taking the state machine as a dep
+    /// themselves. (#969 consolidation.)
+    /// </summary>
+    DictationState CurrentState { get; }
+
     /// <summary>
     /// True when streaming chunk transcription is active for the current
     /// session (<see cref="StartAsync"/> was called with
@@ -23,17 +31,21 @@ public interface IDictationRecordingSession
     bool IsStreamingActive { get; }
 
     /// <summary>
-    /// Start a new recording session. Opens the transcriber's streaming
-    /// session, toggles chunking on the coordinator, and starts the audio
-    /// capture. Caller owns state-machine transitions.
+    /// Start a new recording session. Transitions the state machine to
+    /// <see cref="DictationState.Recording"/>, opens the transcriber's
+    /// streaming session, toggles chunking on the coordinator, and starts
+    /// the audio capture. On failure, transitions back to Idle and logs;
+    /// caller should not re-throw.
     /// </summary>
     Task StartAsync(bool streamingActive);
 
     /// <summary>
-    /// Stop the recording and return the captured PCM buffer. Caller owns
-    /// state-machine transitions and empty-buffer handling.
+    /// Stop the recording and return the captured PCM buffer along with
+    /// the state-machine transition it deserves: <c>null</c> when the
+    /// buffer is empty (caller bails + state goes Idle), non-null when
+    /// audio is good (state goes Transcribing).
     /// </summary>
-    Task<byte[]> StopAsync();
+    Task<byte[]?> StopAndValidateAsync();
 
     /// <summary>
     /// Emergency-stop the recording (discards the buffer). Used on cancel,

--- a/src/VirtualAssistant.Service/Workers/DictationWorker.cs
+++ b/src/VirtualAssistant.Service/Workers/DictationWorker.cs
@@ -3,7 +3,6 @@ using Olbrasoft.VirtualAssistant.Core.Services;
 using Olbrasoft.VirtualAssistant.Core.Speech;
 using Olbrasoft.VirtualAssistant.Core.WindowManagement;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
-using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 using Olbrasoft.VirtualAssistant.Service.Hubs;
 using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 
@@ -18,7 +17,6 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
 {
     private readonly ILogger<DictationWorker> _logger;
     private readonly IDictationKeyHandler _keyHandler;
-    private readonly IDictationStateMachine _stateMachine;
     private readonly IDictationRecordingSession _recordingSession;
     private readonly IDictationCompletionPipeline _completionPipeline;
     private readonly IDictationCancellationCoordinator _cancellationCoordinator;
@@ -28,7 +26,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private volatile bool _streamingTranscriptionEnabled;
 
     /// <inheritdoc/>
-    public DictationState State => _stateMachine.CurrentState;
+    public DictationState State => _recordingSession.CurrentState;
 
     /// <inheritdoc/>
     public event EventHandler<string>? TranscriptionCompleted;
@@ -36,14 +34,12 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     public DictationWorker(
         ILogger<DictationWorker> logger,
         IDictationKeyHandler keyHandler,
-        IDictationStateMachine stateMachine,
         IDictationRecordingSession recordingSession,
         IDictationCompletionPipeline completionPipeline,
         IDictationCancellationCoordinator cancellationCoordinator)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _keyHandler = keyHandler ?? throw new ArgumentNullException(nameof(keyHandler));
-        _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
         _recordingSession = recordingSession ?? throw new ArgumentNullException(nameof(recordingSession));
         _completionPipeline = completionPipeline ?? throw new ArgumentNullException(nameof(completionPipeline));
         _cancellationCoordinator = cancellationCoordinator ?? throw new ArgumentNullException(nameof(cancellationCoordinator));
@@ -60,7 +56,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         _logger.LogInformation("Dictation {Status}", enabled ? "enabled" : "disabled");
 
         // If disabling and currently recording/transcribing, emergency stop
-        if (!enabled && _stateMachine.CurrentState != DictationState.Idle)
+        if (!enabled && _recordingSession.CurrentState != DictationState.Idle)
         {
             _logger.LogInformation("Dictation disabled while active - performing emergency stop");
             Task.Run(async () => await _cancellationCoordinator.EmergencyStopAsync());
@@ -85,7 +81,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             return;
         }
 
-        if (_stateMachine.CurrentState == DictationState.Idle)
+        if (_recordingSession.CurrentState == DictationState.Idle)
         {
             _quickDictationMode = false;
             await StartRecordingAsync();
@@ -101,7 +97,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             return;
         }
 
-        if (_stateMachine.CurrentState == DictationState.Idle)
+        if (_recordingSession.CurrentState == DictationState.Idle)
         {
             _quickDictationMode = true;
             await StartRecordingAsync();
@@ -111,7 +107,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     /// <inheritdoc/>
     public Task StopDictationAsync()
     {
-        if (_stateMachine.CurrentState == DictationState.Recording)
+        if (_recordingSession.CurrentState == DictationState.Recording)
         {
             _ = Task.Run(async () => await StopAndTranscribeAsync());
         }
@@ -122,7 +118,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     /// <inheritdoc/>
     public Task StopDictationAsync(bool quickMode)
     {
-        if (_stateMachine.CurrentState == DictationState.Recording)
+        if (_recordingSession.CurrentState == DictationState.Recording)
         {
             // Override the mode that was chosen at start time. This is the
             // path used by the Remote Control's unified dictation button:
@@ -185,7 +181,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
             _keyHandler.Stop();
 
             // Stop recording if active
-            if (_stateMachine.CurrentState == DictationState.Recording)
+            if (_recordingSession.CurrentState == DictationState.Recording)
             {
                 await _cancellationCoordinator.ShutdownAsync();
             }
@@ -202,7 +198,7 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     private sealed class KeyHandlerBindings(DictationWorker worker) : IDictationKeyHandlerBindings
     {
         public bool IsEnabled => worker._dictationEnabled;
-        public DictationState State => worker._stateMachine.CurrentState;
+        public DictationState State => worker._recordingSession.CurrentState;
 
         public Task StartAsync()
         {
@@ -217,23 +213,12 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         public void CancelTranscription() => worker._cancellationCoordinator.CancelTranscription();
     }
 
-    private async Task StartRecordingAsync()
-    {
-        try
-        {
-            // Transition to Recording state
-            _stateMachine.TransitionTo(DictationState.Recording);
-
-            // Freeze streaming choice for this session — toggles mid-recording have no effect.
-            // The session owns transcriber.BeginSession + chunking toggle + audio start.
-            await _recordingSession.StartAsync(_streamingTranscriptionEnabled);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to start recording");
-            _stateMachine.TransitionTo(DictationState.Idle);
-        }
-    }
+    /// <summary>
+    /// Freezes the streaming-mode choice for this session — toggles mid-
+    /// recording have no effect. Session owns the Recording → Idle fallback
+    /// state transitions internally.
+    /// </summary>
+    private Task StartRecordingAsync() => _recordingSession.StartAsync(_streamingTranscriptionEnabled);
 
     /// <summary>
     /// Orchestrates the dictation workflow: stop recording, transcribe, save, and type text.
@@ -243,7 +228,9 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
     {
         try
         {
-            var audioData = await ValidateAndPrepareAudioAsync();
+            // Session stops the recording, validates the buffer, and handles
+            // the state-machine transitions (null → Idle, non-null → Transcribing).
+            var audioData = await _recordingSession.StopAndValidateAsync();
             if (audioData == null) return;
 
             var token = _cancellationCoordinator.BeginTranscription();
@@ -277,32 +264,11 @@ public class DictationWorker : BackgroundService, IDictationControl, IDictationS
         }
     }
 
-    /// <summary>
-    /// Stops recording and validates audio data.
-    /// Returns null if audio is invalid, otherwise returns audio data.
-    /// </summary>
-    private async Task<byte[]?> ValidateAndPrepareAudioAsync()
-    {
-        var audioData = await _recordingSession.StopAsync();
-
-        if (audioData.Length == 0)
-        {
-            _logger.LogWarning("No audio data recorded");
-            _stateMachine.TransitionTo(DictationState.Idle);
-            return null;
-        }
-
-        _logger.LogInformation("Recording stopped - {Bytes} bytes captured", audioData.Length);
-        _stateMachine.TransitionTo(DictationState.Transcribing);
-
-        return audioData;
-    }
-
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Dictation worker stopping...");
 
-        if (_stateMachine.CurrentState == DictationState.Recording)
+        if (_recordingSession.CurrentState == DictationState.Recording)
         {
             await _cancellationCoordinator.ShutdownAsync();
         }

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationRecordingSessionTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationRecordingSessionTests.cs
@@ -1,33 +1,47 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using Olbrasoft.VirtualAssistant.Core.Audio;
+using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 
 namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
 
 /// <summary>
 /// Pins the recording-session façade lifted out of DictationWorker in #969:
-/// StartAsync toggles chunking (8s on/off) and opens the transcriber's
-/// streaming session before starting audio capture, EmergencyStop discards
-/// audio without side-effects, and ChunkAvailable events are forwarded
-/// internally to the transcriber so the worker never sees them.
+/// StartAsync toggles chunking (8s on/off), opens the transcriber's streaming
+/// session, and transitions the state machine to Recording; StopAndValidateAsync
+/// stops the coordinator, transitions to Transcribing on non-empty buffers or
+/// Idle on empty, and returns null on empty. Session also owns the
+/// ChunkAvailable → transcriber.ForwardChunk forwarding.
 /// </summary>
 public class DictationRecordingSessionTests
 {
     private readonly Mock<ILogger<DictationRecordingSession>> _loggerMock = new();
     private readonly Mock<IAudioRecordingCoordinator> _coordinatorMock = new();
     private readonly Mock<IDictationTranscriber> _transcriberMock = new();
+    private readonly Mock<IDictationStateMachine> _stateMachineMock = new();
 
     private DictationRecordingSession CreateSut() =>
-        new(_loggerMock.Object, _coordinatorMock.Object, _transcriberMock.Object);
+        new(_loggerMock.Object, _coordinatorMock.Object, _transcriberMock.Object, _stateMachineMock.Object);
 
     [Fact]
-    public async Task StartAsync_Streaming_EnablesChunkingAndOpensTranscriberSession()
+    public void CurrentState_DelegatesToStateMachine()
+    {
+        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
+        var sut = CreateSut();
+
+        Assert.Equal(DictationState.Transcribing, sut.CurrentState);
+    }
+
+    [Fact]
+    public async Task StartAsync_Streaming_TransitionsRecordingEnablesChunkingAndOpensSession()
     {
         var sut = CreateSut();
 
         await sut.StartAsync(streamingActive: true);
 
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
         _transcriberMock.Verify(x => x.BeginSession(true), Times.Once);
         _coordinatorMock.Verify(x => x.EnableChunking(TimeSpan.FromSeconds(8)), Times.Once);
         _coordinatorMock.Verify(x => x.DisableChunking(), Times.Never);
@@ -35,15 +49,13 @@ public class DictationRecordingSessionTests
     }
 
     [Fact]
-    public async Task StartAsync_NonStreaming_DisablesChunkingAndStillOpensTranscriberSession()
+    public async Task StartAsync_NonStreaming_TransitionsRecordingDisablesChunkingAndOpensSession()
     {
-        // Non-streaming is the default path; the transcriber still gets a
-        // BeginSession(false) so the assembler's "is active" flag is reset
-        // from any prior streaming session.
         var sut = CreateSut();
 
         await sut.StartAsync(streamingActive: false);
 
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
         _transcriberMock.Verify(x => x.BeginSession(false), Times.Once);
         _coordinatorMock.Verify(x => x.DisableChunking(), Times.Once);
         _coordinatorMock.Verify(x => x.EnableChunking(It.IsAny<TimeSpan>()), Times.Never);
@@ -51,15 +63,44 @@ public class DictationRecordingSessionTests
     }
 
     [Fact]
-    public async Task StopAsync_ReturnsCoordinatorBuffer()
+    public async Task StartAsync_StartRecordingThrows_TransitionsBackToIdle()
+    {
+        _coordinatorMock
+            .Setup(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var sut = CreateSut();
+
+        await sut.StartAsync(streamingActive: false);
+
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task StopAndValidateAsync_NonEmptyBuffer_TransitionsTranscribingAndReturnsAudio()
     {
         var buffer = new byte[] { 1, 2, 3 };
         _coordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>())).ReturnsAsync(buffer);
         var sut = CreateSut();
 
-        var result = await sut.StopAsync();
+        var result = await sut.StopAndValidateAsync();
 
         Assert.Same(buffer, result);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Transcribing), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Never);
+    }
+
+    [Fact]
+    public async Task StopAndValidateAsync_EmptyBuffer_TransitionsIdleAndReturnsNull()
+    {
+        _coordinatorMock.Setup(x => x.StopRecordingAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<byte>());
+        var sut = CreateSut();
+
+        var result = await sut.StopAndValidateAsync();
+
+        Assert.Null(result);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Transcribing), Times.Never);
     }
 
     [Fact]
@@ -96,9 +137,6 @@ public class DictationRecordingSessionTests
     [Fact]
     public void ChunkAvailable_ForwardedToTranscriber()
     {
-        // The point of pulling this into the session is that the worker never
-        // sees ChunkAvailable — the session subscribes at construction and
-        // fans out to the transcriber internally.
         var sut = CreateSut();
 
         _coordinatorMock.Raise(x => x.ChunkAvailable += null,
@@ -124,15 +162,20 @@ public class DictationRecordingSessionTests
     [Fact]
     public void Constructor_NullLogger_Throws() =>
         Assert.Throws<ArgumentNullException>(() =>
-            new DictationRecordingSession(null!, _coordinatorMock.Object, _transcriberMock.Object));
+            new DictationRecordingSession(null!, _coordinatorMock.Object, _transcriberMock.Object, _stateMachineMock.Object));
 
     [Fact]
     public void Constructor_NullCoordinator_Throws() =>
         Assert.Throws<ArgumentNullException>(() =>
-            new DictationRecordingSession(_loggerMock.Object, null!, _transcriberMock.Object));
+            new DictationRecordingSession(_loggerMock.Object, null!, _transcriberMock.Object, _stateMachineMock.Object));
 
     [Fact]
     public void Constructor_NullTranscriber_Throws() =>
         Assert.Throws<ArgumentNullException>(() =>
-            new DictationRecordingSession(_loggerMock.Object, _coordinatorMock.Object, null!));
+            new DictationRecordingSession(_loggerMock.Object, _coordinatorMock.Object, null!, _stateMachineMock.Object));
+
+    [Fact]
+    public void Constructor_NullStateMachine_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationRecordingSession(_loggerMock.Object, _coordinatorMock.Object, _transcriberMock.Object, null!));
 }

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationStateBroadcasterTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationStateBroadcasterTests.cs
@@ -34,16 +34,37 @@ public class DictationStateBroadcasterTests : IDisposable
     }
 
     /// <summary>
-    /// Starts the broadcaster and yields briefly so ExecuteAsync wires up
-    /// its event subscriptions before the test raises events.
+    /// Starts the broadcaster and waits deterministically until ExecuteAsync
+    /// has wired up its three event subscriptions. Uses SetupAdd callbacks
+    /// to decrement a counter — once all three fire, a TaskCompletionSource
+    /// flips and the test proceeds. Replaces a fragile Task.Delay(20) wait.
+    /// (Copilot review on PR #1037.)
     /// </summary>
     private async Task StartAsync()
     {
+        var subscriptionsRegistered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var remainingSubscriptions = 3;
+
+        void MarkSubscribed()
+        {
+            if (Interlocked.Decrement(ref remainingSubscriptions) == 0)
+                subscriptionsRegistered.TrySetResult();
+        }
+
+        _stateMachineMock
+            .SetupAdd(x => x.StateChanged += It.IsAny<EventHandler<DictationState>>())
+            .Callback(MarkSubscribed);
+
+        _transcriberMock
+            .SetupAdd(x => x.RawTranscriptionReady += It.IsAny<Action<string>>())
+            .Callback(MarkSubscribed);
+
+        _dictationServiceMock
+            .SetupAdd(x => x.TranscriptionCompleted += It.IsAny<EventHandler<string>>())
+            .Callback(MarkSubscribed);
+
         _ = _sut.StartAsync(_cts.Token);
-        // Yield so ExecuteAsync's event subscriptions register before the test
-        // raises an event. One Task.Yield + short delay is enough because
-        // BackgroundService kicks ExecuteAsync on the thread pool.
-        await Task.Delay(20);
+        await subscriptionsRegistered.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Fact]

--- a/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/DictationWorkerTests.cs
@@ -7,7 +7,6 @@ using Olbrasoft.VirtualAssistant.Core.Speech;
 using Olbrasoft.VirtualAssistant.Core.StateMachine;
 using Olbrasoft.VirtualAssistant.Service.Workers;
 using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
-using Olbrasoft.VirtualAssistant.Voice.StateMachine;
 
 namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers;
 
@@ -15,7 +14,6 @@ public class DictationWorkerTests : IDisposable
 {
     private readonly Mock<ILogger<DictationWorker>> _loggerMock;
     private readonly Mock<IDictationKeyHandler> _keyHandlerMock;
-    private readonly Mock<IDictationStateMachine> _stateMachineMock;
     private readonly Mock<IDictationRecordingSession> _recordingSessionMock;
     private readonly Mock<IDictationCompletionPipeline> _completionPipelineMock;
     private readonly Mock<IDictationCancellationCoordinator> _cancellationCoordinatorMock;
@@ -33,7 +31,6 @@ public class DictationWorkerTests : IDisposable
     {
         _loggerMock = new Mock<ILogger<DictationWorker>>();
         _keyHandlerMock = new Mock<IDictationKeyHandler>();
-        _stateMachineMock = new Mock<IDictationStateMachine>();
         _recordingSessionMock = new Mock<IDictationRecordingSession>();
         _completionPipelineMock = new Mock<IDictationCompletionPipeline>();
         _cancellationCoordinatorMock = new Mock<IDictationCancellationCoordinator>();
@@ -46,12 +43,11 @@ public class DictationWorkerTests : IDisposable
                 _bindingsReady.TrySetResult(b);
             });
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
 
         _sut = new DictationWorker(
             _loggerMock.Object,
             _keyHandlerMock.Object,
-            _stateMachineMock.Object,
             _recordingSessionMock.Object,
             _completionPipelineMock.Object,
             _cancellationCoordinatorMock.Object);
@@ -73,37 +69,31 @@ public class DictationWorkerTests : IDisposable
     [Fact]
     public void Constructor_NullLogger_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            null!, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            null!, _keyHandlerMock.Object, _recordingSessionMock.Object,
             _completionPipelineMock.Object, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullKeyHandler_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object, null!, _stateMachineMock.Object, _recordingSessionMock.Object,
-            _completionPipelineMock.Object, _cancellationCoordinatorMock.Object));
-
-    [Fact]
-    public void Constructor_NullStateMachine_ThrowsArgumentNullException() =>
-        Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object, _keyHandlerMock.Object, null!, _recordingSessionMock.Object,
+            _loggerMock.Object, null!, _recordingSessionMock.Object,
             _completionPipelineMock.Object, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullRecordingSession_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, null!,
+            _loggerMock.Object, _keyHandlerMock.Object, null!,
             _completionPipelineMock.Object, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullCompletionPipeline_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            _loggerMock.Object, _keyHandlerMock.Object, _recordingSessionMock.Object,
             null!, _cancellationCoordinatorMock.Object));
 
     [Fact]
     public void Constructor_NullCancellationCoordinator_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new DictationWorker(
-            _loggerMock.Object, _keyHandlerMock.Object, _stateMachineMock.Object, _recordingSessionMock.Object,
+            _loggerMock.Object, _keyHandlerMock.Object, _recordingSessionMock.Object,
             _completionPipelineMock.Object, null!));
 
     #endregion
@@ -142,7 +132,7 @@ public class DictationWorkerTests : IDisposable
         using var cts = new CancellationTokenSource();
         var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
 
         Assert.Equal(DictationState.Transcribing, bindings.State);
     }
@@ -165,12 +155,13 @@ public class DictationWorkerTests : IDisposable
         using var cts = new CancellationTokenSource();
         var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>())).Returns(Task.CompletedTask);
 
         await bindings.StartAsync();
 
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
+        // Session owns the Recording state transition internally; worker just
+        // delegates. DictationRecordingSessionTests pin the transition.
         _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Once);
     }
 
@@ -181,8 +172,8 @@ public class DictationWorkerTests : IDisposable
         var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
         var audio = new byte[] { 1, 2, 3, 4 };
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audio);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.StopAndValidateAsync()).ReturnsAsync(audio);
 
         await bindings.StopAndTranscribeAsync();
         await Task.Delay(100);
@@ -221,7 +212,7 @@ public class DictationWorkerTests : IDisposable
     [Fact]
     public void SetDictationEnabled_DisablingWhileIdle_DoesNotCallCoordinator()
     {
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
 
         _sut.SetDictationEnabled(false);
 
@@ -234,7 +225,7 @@ public class DictationWorkerTests : IDisposable
         // Deterministic wait for the fire-and-forget Task.Run inside
         // SetDictationEnabled via a TaskCompletionSource callback on the mock.
         // (Copilot review on PR #1036 — avoids flaky Task.Delay.)
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         var emergencyStopped = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _cancellationCoordinatorMock
             .Setup(x => x.EmergencyStopAsync())
@@ -250,7 +241,7 @@ public class DictationWorkerTests : IDisposable
     [Fact]
     public async Task SetDictationEnabled_DisablingWhileTranscribing_TriggersCoordinatorEmergencyStop()
     {
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Transcribing);
         var emergencyStopped = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _cancellationCoordinatorMock
             .Setup(x => x.EmergencyStopAsync())
@@ -273,8 +264,8 @@ public class DictationWorkerTests : IDisposable
         using var cts = new CancellationTokenSource();
         await StartAndAwaitBindingsAsync(cts.Token);
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(Array.Empty<byte>());
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.StopAndValidateAsync()).ReturnsAsync((byte[]?)null);
 
         await _sut.StopDictationAsync();
         await Task.Delay(200);
@@ -285,7 +276,9 @@ public class DictationWorkerTests : IDisposable
         _completionPipelineMock.Verify(
             x => x.CompleteQuickAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.AtLeastOnce);
+        // Session owns the Idle transition for the empty-audio case; worker's
+        // only responsibility is to skip the pipeline invocation.
+        _recordingSessionMock.Verify(x => x.StopAndValidateAsync(), Times.Once);
     }
 
     [SkipOnCIFact]
@@ -298,8 +291,8 @@ public class DictationWorkerTests : IDisposable
         var token = new CancellationToken();
         _cancellationCoordinatorMock.Setup(x => x.BeginTranscription()).Returns(token);
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.StopAndValidateAsync()).ReturnsAsync(audioData);
 
         await _sut.StopDictationAsync();
         await Task.Delay(200);
@@ -319,8 +312,8 @@ public class DictationWorkerTests : IDisposable
 
         var audioData = new byte[] { 1, 2, 3, 4 };
         Action<string>? capturedCallback = null;
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.StopAndValidateAsync()).ReturnsAsync(audioData);
         _completionPipelineMock
             .Setup(x => x.CompleteFullAsync(
                 It.IsAny<byte[]>(), It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()))
@@ -349,7 +342,7 @@ public class DictationWorkerTests : IDisposable
         using var cts = new CancellationTokenSource();
         await StartAndAwaitBindingsAsync(cts.Token);
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
 
         await _sut.StopAsync(CancellationToken.None);
 
@@ -362,7 +355,7 @@ public class DictationWorkerTests : IDisposable
         using var cts = new CancellationTokenSource();
         await StartAndAwaitBindingsAsync(cts.Token);
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         _cancellationCoordinatorMock.Setup(x => x.ShutdownAsync()).Returns(Task.CompletedTask);
 
         await _sut.StopAsync(CancellationToken.None);
@@ -377,11 +370,11 @@ public class DictationWorkerTests : IDisposable
     [Fact]
     public async Task StartQuickDictationAsync_SetsQuickModeAndStartsRecording()
     {
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
 
         await _sut.StartQuickDictationAsync();
 
-        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Recording), Times.Once);
+        // Session owns the Recording state transition internally.
         _recordingSessionMock.Verify(x => x.StartAsync(It.IsAny<bool>()), Times.Once);
     }
 
@@ -393,11 +386,11 @@ public class DictationWorkerTests : IDisposable
 
         var audioData = new byte[] { 1, 2, 3, 4 };
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         await _sut.StartQuickDictationAsync();
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.StopAndValidateAsync()).ReturnsAsync(audioData);
 
         await _sut.StopDictationAsync();
         await Task.Delay(200);
@@ -419,19 +412,19 @@ public class DictationWorkerTests : IDisposable
         using var cts = new CancellationTokenSource();
         var bindings = await StartAndAwaitBindingsAsync(cts.Token);
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         await _sut.StartQuickDictationAsync();
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
         ((IDictationService)_sut).CancelTranscription();
 
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Idle);
         _recordingSessionMock.Setup(x => x.StartAsync(It.IsAny<bool>())).Returns(Task.CompletedTask);
         await bindings.StartAsync();
 
         var audioData = new byte[] { 1, 2, 3 };
-        _stateMachineMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
-        _recordingSessionMock.Setup(x => x.StopAsync()).ReturnsAsync(audioData);
+        _recordingSessionMock.SetupGet(x => x.CurrentState).Returns(DictationState.Recording);
+        _recordingSessionMock.Setup(x => x.StopAndValidateAsync()).ReturnsAsync(audioData);
         await bindings.StopAndTranscribeAsync();
         await Task.Delay(200);
 


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #969 (DictationWorker god-class split). Also addresses Copilot review on merged PR #1037.

## Final #969 status

| Target | Original | Final |
|---|---|---|
| LOC | 883 | **278 ✅ (≤400)** |
| Ctor deps | 12 | **5 ✅ (≤5)** |
| Responsibilities | 11 | 1 (thin coordinator) |

**Both targets hit.**

## Summary

`IDictationRecordingSession` now absorbs the state machine:
- Exposes `CurrentState`.
- `StartAsync` transitions to Recording before starting audio; transitions back to Idle in the failure catch.
- `StopAsync` becomes `StopAndValidateAsync` — returns `null` on empty buffer (+ Idle transition), non-null on good audio (+ Transcribing transition).

Worker drops the last inline state-machine usage:
- Ctor deps 6 → 5 (drops `IDictationStateMachine`).
- `State` getter + bindings `State` + shutdown guard read `_recordingSession.CurrentState`.
- `StartRecordingAsync` collapses to a one-line delegate; `ValidateAndPrepareAudioAsync` disappears entirely.

## PR #1037 review fix (bundled)

- `DictationStateBroadcasterTests.StartAsync` replaces `Task.Delay(20)` with a 3-count `SetupAdd`-driven `TaskCompletionSource` so the test blocks deterministically until the broadcaster's three event subscriptions register.

## Tests

- `DictationRecordingSessionTests` expanded to 16 cases: state transitions on each StartAsync branch (streaming / non-streaming / failure), StopAndValidateAsync empty/non-empty, `CurrentState` delegation, chunk forwarding + Dispose, null-ctor guards.
- `DictationWorkerTests` drop `stateMachineMock`; assertions that previously verified `TransitionTo` on the worker are either removed (covered in session tests) or replaced with session-method verifications.
- Full suite: **434 Service tests pass**.

## Test plan

- [x] `dotnet build` — green.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — all Service + Voice + others pass.
- [ ] After deploy: verify dictation end-to-end (start recording, stop, confirm transcription + state transitions still land correctly).