### PR TITLE
refactor(dictation): address PR #1038 Copilot review

### DIFF
--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationRecordingSession.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationRecordingSession.cs
@@ -54,6 +54,11 @@ public sealed class DictationRecordingSession : IDictationRecordingSession, IDis
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to start recording");
+            // BeginSession + EnableChunking may already have fired before the
+            // throw; unwind them before flipping state back to Idle so a
+            // failed start doesn't leave the transcriber's streaming session
+            // or coordinator chunking stuck on.
+            EndSession();
             _stateMachine.TransitionTo(DictationState.Idle);
         }
     }
@@ -69,7 +74,8 @@ public sealed class DictationRecordingSession : IDictationRecordingSession, IDis
             return null;
         }
 
-        _logger.LogInformation("Recording stopped - {Bytes} bytes captured", audioData.Length);
+        // AudioRecordingCoordinator.StopRecordingAsync already logs the byte
+        // count at Information — don't duplicate it here.
         _stateMachine.TransitionTo(DictationState.Transcribing);
 
         return audioData;

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationRecordingSession.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationRecordingSession.cs
@@ -34,8 +34,9 @@ public interface IDictationRecordingSession
     /// Start a new recording session. Transitions the state machine to
     /// <see cref="DictationState.Recording"/>, opens the transcriber's
     /// streaming session, toggles chunking on the coordinator, and starts
-    /// the audio capture. On failure, transitions back to Idle and logs;
-    /// caller should not re-throw.
+    /// the audio capture. Failures are caught and logged internally — the
+    /// session cleans up any partial side-effects and transitions back to
+    /// Idle, so this method does not throw.
     /// </summary>
     Task StartAsync(bool streamingActive);
 

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationRecordingSessionTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationRecordingSessionTests.cs
@@ -77,6 +77,24 @@ public class DictationRecordingSessionTests
     }
 
     [Fact]
+    public async Task StartAsync_StreamingFails_UnwindsBeginSessionAndChunking()
+    {
+        _coordinatorMock
+            .Setup(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var sut = CreateSut();
+
+        await sut.StartAsync(streamingActive: true);
+
+        _transcriberMock.Verify(x => x.BeginSession(true), Times.Once);
+        _coordinatorMock.Verify(x => x.EnableChunking(TimeSpan.FromSeconds(8)), Times.Once);
+        // Unwind: transcriber session ended and chunking disabled before flipping back to Idle.
+        _transcriberMock.Verify(x => x.EndSession(), Times.Once);
+        _coordinatorMock.Verify(x => x.DisableChunking(), Times.Once);
+        _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
     public async Task StopAndValidateAsync_NonEmptyBuffer_TransitionsTranscribingAndReturnsAudio()
     {
         var buffer = new byte[] { 1, 2, 3 };


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to merged PR #1038. Three small fixes on `DictationRecordingSession`:

## Summary
- **StartAsync cleanup on failure** — if `StartRecordingAsync` throws after `BeginSession` / `EnableChunking` already fired, the catch path now calls `EndSession()` to disable chunking and end the transcriber's streaming session before flipping state back to Idle. Previously these side-effects could leak.
- **Remove duplicate stop log** — `AudioRecordingCoordinator.StopRecordingAsync` already logs `"Recording stopped - {Bytes} bytes captured"` at Information level, so the session's own copy was noise.
- **Clarify XML doc** — `IDictationRecordingSession.StartAsync` docstring reworded from the confusing "caller should not re-throw" to spell out that failures are handled internally and the method does not throw.

Adds `StartAsync_StreamingFails_UnwindsBeginSessionAndChunking` to pin the new cleanup contract.

## Test plan
- [x] `dotnet test` — 435 Service tests green (16/16 on `DictationRecordingSessionTests`)
- [x] `dotnet build` — no new warnings