### PR TITLE
test(dictation): pin unwind order via callback trace

### DIFF
--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationRecordingSessionTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationRecordingSessionTests.cs
@@ -82,16 +82,25 @@ public class DictationRecordingSessionTests
         _coordinatorMock
             .Setup(x => x.StartRecordingAsync(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("boom"));
+
+        // Order matters: any observer reacting to Idle must already see the
+        // transcriber session closed + chunking off, so cleanup MUST precede
+        // the Idle transition. Callback-based trace pins the sequence.
+        var order = new List<string>();
+        _transcriberMock.Setup(x => x.EndSession()).Callback(() => order.Add("end-session"));
+        _coordinatorMock.Setup(x => x.DisableChunking()).Callback(() => order.Add("disable-chunking"));
+        _stateMachineMock.Setup(x => x.TransitionTo(DictationState.Idle)).Callback(() => order.Add("idle"));
+
         var sut = CreateSut();
 
         await sut.StartAsync(streamingActive: true);
 
         _transcriberMock.Verify(x => x.BeginSession(true), Times.Once);
         _coordinatorMock.Verify(x => x.EnableChunking(TimeSpan.FromSeconds(8)), Times.Once);
-        // Unwind: transcriber session ended and chunking disabled before flipping back to Idle.
         _transcriberMock.Verify(x => x.EndSession(), Times.Once);
         _coordinatorMock.Verify(x => x.DisableChunking(), Times.Once);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+        Assert.Equal(new[] { "end-session", "disable-chunking", "idle" }, order);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to merged PR #1039 addressing Copilot's one inline comment.

## Summary
Copilot flagged that `StartAsync_StreamingFails_UnwindsBeginSessionAndChunking` had a comment saying "before flipping back to Idle" but its `Times.Once` assertions didn't enforce ordering — so the test wouldn't have caught a regression that flipped state to Idle first and only then cleaned up chunking/transcriber.

Ordering is part of the contract: any observer reacting to Idle must already see chunking off and the transcriber session closed (otherwise a subscriber could race in mid-cleanup).

Replaced the comment with a callback-based trace that records invocation order and asserts `end-session` → `disable-chunking` → `idle` explicitly.

## Test plan
- [x] `dotnet test --filter "...StartAsync_StreamingFails"` — passes
- [x] Existing `Times.Once` assertions preserved (still guard against duplicate invocations)