### PR TITLE
docs(core-tests): clarify equality scope in ModelRecordsTests summary

### DIFF
--- a/tests/VirtualAssistant.Core.Tests/Models/ModelRecordsTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/Models/ModelRecordsTests.cs
@@ -6,12 +6,17 @@ namespace Olbrasoft.VirtualAssistant.Core.Tests.Models;
 /// Coverage pass for the plain data records under
 /// <c>src/VirtualAssistant.Core/Models</c>: properties assign verbatim,
 /// optional params have the documented defaults, and record value-
-/// equality holds across every record in the namespace. These models
-/// cross every service boundary (desktop context, LLM results, TTS
-/// results, notification routing) so pinning their shape + equality
-/// semantics in one place catches accidental required/optional flips
-/// AND any future record→class refactor that would silently lose
-/// value-equality. Part of #979 Phase C.
+/// equality is pinned for the records where equality is meaningful
+/// (<see cref="DesktopContext"/>, <see cref="LlmCorrectionResult"/>,
+/// <see cref="TtsResult"/>, <see cref="NotificationContext"/>).
+/// <c>RacingResult</c> is intentionally skipped — it holds a
+/// <c>Task&lt;T&gt;</c> whose reference-equality defeats the point —
+/// and <c>AgentNotification</c> is a plain class, not a record.
+/// These models cross every service boundary (desktop context, LLM
+/// results, TTS results, notification routing) so pinning their
+/// shape catches accidental required/optional flips, and the
+/// equality asserts guard against a future record→class refactor
+/// silently losing value-equality. Part of #979 Phase C.
 /// </summary>
 public class ModelRecordsTests
 {


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Follow-up to merged PR #1042. Addresses Copilot's remaining comment.

## Summary
XML summary claimed record equality holds "across every record in the namespace", but `RacingResult` has no equality assert and `AgentNotification` is a class. Rewrote the summary to:

- Enumerate the four records where equality is pinned (`DesktopContext`, `LlmCorrectionResult`, `TtsResult`, `NotificationContext`) via `<see cref>`
- Explain why `RacingResult` is skipped (holds `Task<T>` reference — value-equality meaningless)
- Note that `AgentNotification` is a plain class, not a record

Doc-only change, no behavior change.

## Test plan
- [x] `dotnet test --filter "ModelRecordsTests"` — 22/22 still green