### PR TITLE
feat(dictation): rewrite "lomeno" as "/" in the lightweight filter

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -402,18 +402,12 @@ public static class VoiceServicesExtensions
         services.AddSingleton<ITextFilterStrategy>(sp =>
             sp.GetRequiredService<WhisperHallucinationFilterStrategy>());
 
-        // Register WhitespaceFilterStrategy as both concrete (for lightweight filter) and as
-        // ITextFilterStrategy (for full composite). Single instance shared by both.
-        services.AddSingleton<WhitespaceFilterStrategy>(sp =>
-        {
-            var logger = sp.GetRequiredService<ILogger<WhitespaceFilterStrategy>>();
-            return new WhitespaceFilterStrategy(logger);
-        });
-        services.AddSingleton<ITextFilterStrategy>(sp =>
-            sp.GetRequiredService<WhitespaceFilterStrategy>());
-
         // Path separator ("lomeno" → "/"). Shared by lightweight + full composite so
-        // both Quick and Normal dictation produce the same path output.
+        // both Quick and Normal dictation produce the same path output. MUST be
+        // registered BEFORE WhitespaceFilterStrategy — CompositeTextFilter applies
+        // ITextFilterStrategy instances in registration order, and whitespace
+        // normalization needs to stay the final pass so any residual double-spaces
+        // introduced by upstream strategies are collapsed last.
         services.AddSingleton<PathSeparatorFilterStrategy>(sp =>
         {
             var logger = sp.GetRequiredService<ILogger<PathSeparatorFilterStrategy>>();
@@ -421,6 +415,18 @@ public static class VoiceServicesExtensions
         });
         services.AddSingleton<ITextFilterStrategy>(sp =>
             sp.GetRequiredService<PathSeparatorFilterStrategy>());
+
+        // Register WhitespaceFilterStrategy as both concrete (for lightweight filter) and as
+        // ITextFilterStrategy (for full composite). Single instance shared by both.
+        // Kept LAST in the ITextFilterStrategy sequence so it runs as the final
+        // normalization pass in CompositeTextFilter.
+        services.AddSingleton<WhitespaceFilterStrategy>(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<WhitespaceFilterStrategy>>();
+            return new WhitespaceFilterStrategy(logger);
+        });
+        services.AddSingleton<ITextFilterStrategy>(sp =>
+            sp.GetRequiredService<WhitespaceFilterStrategy>());
 
         services.AddSingleton<ITextFilter, CompositeTextFilter>();
         services.AddSingleton<ILightweightTextFilter, LightweightTextFilter>();

--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -412,6 +412,16 @@ public static class VoiceServicesExtensions
         services.AddSingleton<ITextFilterStrategy>(sp =>
             sp.GetRequiredService<WhitespaceFilterStrategy>());
 
+        // Path separator ("lomeno" → "/"). Shared by lightweight + full composite so
+        // both Quick and Normal dictation produce the same path output.
+        services.AddSingleton<PathSeparatorFilterStrategy>(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<PathSeparatorFilterStrategy>>();
+            return new PathSeparatorFilterStrategy(logger);
+        });
+        services.AddSingleton<ITextFilterStrategy>(sp =>
+            sp.GetRequiredService<PathSeparatorFilterStrategy>());
+
         services.AddSingleton<ITextFilter, CompositeTextFilter>();
         services.AddSingleton<ILightweightTextFilter, LightweightTextFilter>();
     }

--- a/src/VirtualAssistant.Voice/Filters/LightweightTextFilter.cs
+++ b/src/VirtualAssistant.Voice/Filters/LightweightTextFilter.cs
@@ -13,6 +13,9 @@ namespace Olbrasoft.VirtualAssistant.Voice.Filters;
 ///         on application startup and refreshed every 4 minutes (just under the
 ///         strategy's 5-minute internal TTL), so the Quick Dictation hot path
 ///         always finds an in-memory cache and never blocks on a DB round-trip.</item>
+///   <item>Path separator — rewrites <c>"X lomeno Y"</c> into <c>"X/Y"</c>
+///         (no surrounding spaces). Runs AFTER DB corrections so any
+///         "llomeno → lomeno" Whisper fixup stored in the DB lands first.</item>
 ///   <item>Whitespace normalization — trim + collapse double spaces.</item>
 /// </list>
 /// LLM correction is intentionally skipped — that is the difference between Quick
@@ -22,17 +25,20 @@ public class LightweightTextFilter : ILightweightTextFilter
 {
     private readonly WhisperHallucinationFilterStrategy _hallucinationStrategy;
     private readonly DatabaseCorrectionFilterStrategy _databaseCorrectionStrategy;
+    private readonly PathSeparatorFilterStrategy _pathSeparatorStrategy;
     private readonly WhitespaceFilterStrategy _whitespaceStrategy;
     private readonly ILogger<LightweightTextFilter> _logger;
 
     public LightweightTextFilter(
         WhisperHallucinationFilterStrategy hallucinationStrategy,
         DatabaseCorrectionFilterStrategy databaseCorrectionStrategy,
+        PathSeparatorFilterStrategy pathSeparatorStrategy,
         WhitespaceFilterStrategy whitespaceStrategy,
         ILogger<LightweightTextFilter> logger)
     {
         _hallucinationStrategy = hallucinationStrategy ?? throw new ArgumentNullException(nameof(hallucinationStrategy));
         _databaseCorrectionStrategy = databaseCorrectionStrategy ?? throw new ArgumentNullException(nameof(databaseCorrectionStrategy));
+        _pathSeparatorStrategy = pathSeparatorStrategy ?? throw new ArgumentNullException(nameof(pathSeparatorStrategy));
         _whitespaceStrategy = whitespaceStrategy ?? throw new ArgumentNullException(nameof(whitespaceStrategy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -41,6 +47,7 @@ public class LightweightTextFilter : ILightweightTextFilter
     public bool IsEnabled =>
         _hallucinationStrategy.IsEnabled
         || _databaseCorrectionStrategy.IsEnabled
+        || _pathSeparatorStrategy.IsEnabled
         || _whitespaceStrategy.IsEnabled;
 
     /// <inheritdoc/>
@@ -70,7 +77,12 @@ public class LightweightTextFilter : ILightweightTextFilter
         // sub-millisecond after warm-up.
         var afterDbCorrections = _databaseCorrectionStrategy.Apply(afterHallucination);
 
-        var afterWhitespace = _whitespaceStrategy.Apply(afterDbCorrections);
+        // Path separator: rewrite "X lomeno Y" → "X/Y". Runs AFTER DB corrections
+        // so any DB-seeded Whisper fixups (e.g. "llomeno" → "lomeno") land before
+        // we look for the word.
+        var afterPathSeparator = _pathSeparatorStrategy.Apply(afterDbCorrections);
+
+        var afterWhitespace = _whitespaceStrategy.Apply(afterPathSeparator);
 
         if (afterWhitespace != text)
         {

--- a/src/VirtualAssistant.Voice/Filters/PathSeparatorFilterStrategy.cs
+++ b/src/VirtualAssistant.Voice/Filters/PathSeparatorFilterStrategy.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Filters;
+
+/// <summary>
+/// Replaces the dictated Czech word <c>lomeno</c> ("slash") with the
+/// literal <c>/</c> character and collapses whitespace on either side
+/// so adjacent words join cleanly into a path-like form. A literal DB
+/// substitution (<c>"lomeno" → "/"</c>) can't do this — it leaves the
+/// spaces in place (<c>"Dokumenty / přístupy"</c>). This strategy runs
+/// in the lightweight pipeline so it fires on Quick Dictation too,
+/// where no LLM is in the loop.
+/// <para>
+/// Transformations:
+/// <list type="bullet">
+///   <item><c>"Dokumenty lomeno přístupy"</c> → <c>"Dokumenty/přístupy"</c></item>
+///   <item><c>"a lomeno b lomeno c"</c> → <c>"a/b/c"</c> (chained)</item>
+///   <item><c>"Lomeno začátek"</c> → <c>"/začátek"</c> (leading)</item>
+///   <item><c>"konec lomeno"</c> → <c>"konec/"</c> (trailing)</item>
+/// </list>
+/// Unicode word boundaries mean <c>\b</c> correctly separates Czech
+/// words like <c>"přístupy"</c> from <c>"lomeno"</c>.
+/// </para>
+/// </summary>
+public partial class PathSeparatorFilterStrategy : ITextFilterStrategy
+{
+    // Matches the word "lomeno" as a whole token, greedily consuming any
+    // whitespace on either side so the replacement collapses surrounding
+    // spaces atomically. Case-insensitive to also catch "Lomeno" at the
+    // start of a Whisper-capitalized segment.
+    [GeneratedRegex(@"\s*\blomeno\b\s*", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex LomenoPattern();
+
+    private readonly ILogger<PathSeparatorFilterStrategy> _logger;
+
+    public PathSeparatorFilterStrategy(ILogger<PathSeparatorFilterStrategy> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public string Name => "Path Separator (lomeno → /)";
+
+    /// <inheritdoc/>
+    public bool IsEnabled => true;
+
+    /// <inheritdoc/>
+    public string Apply(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        var result = LomenoPattern().Replace(text, "/");
+
+        if (result != text)
+        {
+            _logger.LogDebug("Path separator applied: '{Before}' → '{After}'", text, result);
+        }
+
+        return result;
+    }
+}

--- a/tests/VirtualAssistant.Voice.Tests/Filters/LightweightTextFilterTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Filters/LightweightTextFilterTests.cs
@@ -41,10 +41,12 @@ public class LightweightTextFilterTests : IDisposable
         var dbCorrections = new DatabaseCorrectionFilterStrategy(
             Mock.Of<ILogger<DatabaseCorrectionFilterStrategy>>(),
             repository: null);
+        var pathSeparator = new PathSeparatorFilterStrategy(
+            Mock.Of<ILogger<PathSeparatorFilterStrategy>>());
         var whitespace = new WhitespaceFilterStrategy(
             Mock.Of<ILogger<WhitespaceFilterStrategy>>());
         var logger = Mock.Of<ILogger<LightweightTextFilter>>();
-        return new LightweightTextFilter(hallucination, dbCorrections, whitespace, logger);
+        return new LightweightTextFilter(hallucination, dbCorrections, pathSeparator, whitespace, logger);
     }
 
     [Fact]
@@ -152,11 +154,14 @@ public class LightweightTextFilterTests : IDisposable
         var dbCorrections = new DatabaseCorrectionFilterStrategy(
             Mock.Of<ILogger<DatabaseCorrectionFilterStrategy>>(),
             fakeRepo.Object);
+        var pathSeparator = new PathSeparatorFilterStrategy(
+            Mock.Of<ILogger<PathSeparatorFilterStrategy>>());
         var whitespace = new WhitespaceFilterStrategy(
             Mock.Of<ILogger<WhitespaceFilterStrategy>>());
         var filter = new LightweightTextFilter(
             hallucination,
             dbCorrections,
+            pathSeparator,
             whitespace,
             Mock.Of<ILogger<LightweightTextFilter>>());
 
@@ -178,5 +183,20 @@ public class LightweightTextFilterTests : IDisposable
 
         // WhitespaceFilterStrategy.IsEnabled is always true.
         Assert.True(filter.IsEnabled);
+    }
+
+    [Fact]
+    public void Apply_LomenoBetweenWords_ProducesJoinedPath()
+    {
+        // End-to-end pin for the Quick Dictation path scenario that triggered
+        // this feature: user dictates "Dokumenty lomeno přístupy" and expects
+        // "Dokumenty/přístupy" — no spaces around the slash — even without
+        // LLM correction in the loop.
+        WriteConfig(new TextFiltersConfig());
+        var filter = CreateFilter();
+
+        var result = filter.Apply("Dokumenty lomeno přístupy");
+
+        Assert.Equal("Dokumenty/přístupy", result);
     }
 }

--- a/tests/VirtualAssistant.Voice.Tests/Filters/PathSeparatorFilterStrategyTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Filters/PathSeparatorFilterStrategyTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Voice.Filters;
+
+namespace Olbrasoft.VirtualAssistant.Voice.Tests.Filters;
+
+/// <summary>
+/// Pins the "lomeno → /" rewrite. The strategy has to work for any word
+/// pair (not one hardcoded phrase) so tests drive it with several shapes:
+/// two-word path, chained segments, leading/trailing usage, case variants.
+/// </summary>
+public class PathSeparatorFilterStrategyTests
+{
+    private static PathSeparatorFilterStrategy CreateSut() =>
+        new(Mock.Of<ILogger<PathSeparatorFilterStrategy>>());
+
+    [Theory]
+    [InlineData("Dokumenty lomeno přístupy", "Dokumenty/přístupy")]
+    [InlineData("Dokumenty lomeno Olbrasoft lomeno projekt", "Dokumenty/Olbrasoft/projekt")]
+    [InlineData("a lomeno b", "a/b")]
+    [InlineData("konec lomeno", "konec/")]
+    [InlineData("Lomeno začátek", "/začátek")]
+    [InlineData("lomeno", "/")]
+    public void Apply_ReplacesLomenoAndCollapsesSurroundingWhitespace(string input, string expected)
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(expected, sut.Apply(input));
+    }
+
+    [Theory]
+    [InlineData("LOMENO")]
+    [InlineData("Lomeno")]
+    [InlineData("lomeno")]
+    public void Apply_IsCaseInsensitive(string lomeno)
+    {
+        var sut = CreateSut();
+
+        Assert.Equal("a/b", sut.Apply($"a {lomeno} b"));
+    }
+
+    [Fact]
+    public void Apply_CollapsesMultipleSpacesAroundLomeno()
+    {
+        var sut = CreateSut();
+
+        // Multiple spaces on both sides still collapse into a single slash
+        // with no surrounding whitespace — WhitespaceFilterStrategy would
+        // otherwise have to patch this up downstream.
+        Assert.Equal("src/main", sut.Apply("src   lomeno   main"));
+    }
+
+    [Fact]
+    public void Apply_WithoutLomeno_ReturnsInputUnchanged()
+    {
+        var sut = CreateSut();
+
+        const string input = "Normální věta bez zvláštních slov.";
+        Assert.Equal(input, sut.Apply(input));
+    }
+
+    [Fact]
+    public void Apply_DoesNotTouchLomenoAsSubstringOfAnotherWord()
+    {
+        var sut = CreateSut();
+
+        // Word boundary keeps embedded occurrences ("odlomeno", "zlomeno")
+        // untouched — the user only means the standalone dictated word.
+        Assert.Equal("Sklo zlomeno na půl.", sut.Apply("Sklo zlomeno na půl."));
+    }
+
+    [Fact]
+    public void Apply_WithEmpty_ReturnsEmpty()
+    {
+        // ITextFilterStrategy.Apply contract is non-null string; null handling
+        // is the lightweight filter's job. Empty string just round-trips.
+        var sut = CreateSut();
+
+        Assert.Equal(string.Empty, sut.Apply(string.Empty));
+    }
+
+    [Fact]
+    public void IsEnabled_IsTrue()
+    {
+        var sut = CreateSut();
+        Assert.True(sut.IsEnabled);
+    }
+
+    [Fact]
+    public void Name_IsDescriptive()
+    {
+        var sut = CreateSut();
+        Assert.Contains("lomeno", sut.Name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new PathSeparatorFilterStrategy(null!));
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

## Problem
User report from Quick Dictation (fast button, no LLM in the loop): dictating a path like *"Dokumenty lomeno přístupy"* pastes the literal Czech word `"lomeno"` because the only post-STT step on the quick path is the lightweight filter — and it has no rule for the word. Even a plain DB substitution row `"lomeno" → "/"` isn't enough: `string.Replace` leaves the surrounding whitespace, producing `"Dokumenty / přístupy"`, not `"Dokumenty/přístupy"`.

User requirement: generalize it — any dictated path with one or more `lomeno` words should collapse into a slash-joined form (so three-segment paths like `"Dokumenty lomeno Olbrasoft lomeno projekt"` also work).

## Solution
New `PathSeparatorFilterStrategy` (`ITextFilterStrategy`) running a single source-generated regex `\s*\blomeno\b\s*` (case-insensitive, invariant culture) with `"/"` as the replacement. Unicode word boundaries let `\b` work between Czech characters; the surrounding `\s*` collapses whitespace atomically with the rewrite.

## Pipeline wiring
In `LightweightTextFilter`:
```
hallucination → DB corrections → PATH SEPARATOR → whitespace normalization
```
- AFTER DB corrections so any seeded `"llomeno → lomeno"` Whisper fixup lands first.
- BEFORE whitespace normalization (no-op here since the regex already collapsed, but keeps the invariant that whitespace is the last word on layout).

Also registered as `ITextFilterStrategy` so `CompositeTextFilter` picks it up for Normal Dictation — Quick and Normal now produce identical path output.

## Coverage
- `PathSeparatorFilterStrategyTests`: two-word path, three-segment chain, leading/trailing/solo usage, case-insensitive match (`LOMENO` / `Lomeno`), multi-space collapse, unrelated inflection (`"zlomeno"`) left alone, empty round-trip, null-logger ctor guard.
- `LightweightTextFilterTests`: end-to-end `"Dokumenty lomeno přístupy"` → `"Dokumenty/přístupy"` through the lightweight pipeline.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — **332 Voice + 435 Service green, 25/25 new filter tests pass**
- [ ] After deploy, manually dictate `"Dokumenty lomeno přístupy"` via the fast button and confirm the pasted text is `"Dokumenty/přístupy"`