### PR TITLE
feat(dictation): auto-focus single Claude Code on workspace for Quick Dictation

### DIFF
--- a/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/WorkerServicesExtensions.cs
@@ -78,6 +78,8 @@ public static class WorkerServicesExtensions
                 sp.GetRequiredService<ILogger<ClaudeCodeCivilityTrimmer>>(),
                 sp.GetRequiredService<ICliAppDetector>()));
 
+        services.AddSingleton<IDictationFocusRouter, DictationFocusRouter>();
+
         services.AddSingleton<IDictationCompletionPipeline, DictationCompletionPipeline>();
 
         services.AddSingleton<IDictationKeyHandler, DictationKeyHandler>();

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationCompletionPipeline.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationCompletionPipeline.cs
@@ -15,6 +15,7 @@ public sealed class DictationCompletionPipeline : IDictationCompletionPipeline
     private readonly IDictationOutputChannel _outputChannel;
     private readonly IDictationTranscriptionPersister _persister;
     private readonly IClaudeCodeCivilityTrimmer _civilityTrimmer;
+    private readonly IDictationFocusRouter _focusRouter;
 
     public DictationCompletionPipeline(
         ILogger<DictationCompletionPipeline> logger,
@@ -22,7 +23,8 @@ public sealed class DictationCompletionPipeline : IDictationCompletionPipeline
         IDictationTranscriber transcriber,
         IDictationOutputChannel outputChannel,
         IDictationTranscriptionPersister persister,
-        IClaudeCodeCivilityTrimmer civilityTrimmer)
+        IClaudeCodeCivilityTrimmer civilityTrimmer,
+        IDictationFocusRouter focusRouter)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _stateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
@@ -30,6 +32,7 @@ public sealed class DictationCompletionPipeline : IDictationCompletionPipeline
         _outputChannel = outputChannel ?? throw new ArgumentNullException(nameof(outputChannel));
         _persister = persister ?? throw new ArgumentNullException(nameof(persister));
         _civilityTrimmer = civilityTrimmer ?? throw new ArgumentNullException(nameof(civilityTrimmer));
+        _focusRouter = focusRouter ?? throw new ArgumentNullException(nameof(focusRouter));
     }
 
     public async Task CompleteQuickAsync(byte[] audio, CancellationToken cancellationToken)
@@ -50,6 +53,13 @@ public sealed class DictationCompletionPipeline : IDictationCompletionPipeline
             _logger.LogInformation("Quick transcription: '{Text}'", result.Text);
 
             await _persister.SaveAsync(audio, result, cancellationToken);
+
+            // Auto-focus Claude Code if the user pressed fast from a non-Claude
+            // non-TextEditor surface and there's exactly one Claude on the
+            // current workspace. Runs BEFORE civility trim so the trimmer's
+            // "am I in Claude Code?" check sees the post-focus state and
+            // correctly applies the trim.
+            await _focusRouter.TryFocusClaudeCodeIfApplicableAsync(cancellationToken);
 
             // Strip trailing civility ("… Děkuji.", "… Ahoj.", Whisper hallucinated
             // sign-offs) when pasting into a CLI agent that reads the text as a

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationFocusRouter.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationFocusRouter.cs
@@ -13,10 +13,10 @@ public sealed class DictationFocusRouter : IDictationFocusRouter
     // ".desktop" suffix and returns "org.gnome.TextEditor" in WmClass.
     private const string GnomeTextEditorWmClass = "org.gnome.TextEditor";
 
-    // Empirical delay: below ~150 ms xdotool occasionally keystrokes
-    // into the outgoing window because GNOME hasn't activated the
-    // target yet. 200 ms keeps the hot path snappy while still winning
-    // the race reliably on this hardware.
+    // Empirical delay: below ~150 ms the keyboard paste occasionally
+    // keystrokes into the outgoing window because GNOME hasn't activated
+    // the target yet. 200 ms keeps the hot path snappy while still
+    // winning the race reliably on this hardware.
     private static readonly TimeSpan FocusSettleDelay = TimeSpan.FromMilliseconds(200);
 
     private readonly IWindowQueryService _windowQuery;
@@ -40,6 +40,12 @@ public sealed class DictationFocusRouter : IDictationFocusRouter
         try
         {
             windows = await _windowQuery.GetWindowsAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Never swallow cancellation — the pipeline's finally block needs
+            // to unwind state-machine + feedback even if we get clipped here.
+            throw;
         }
         catch (Exception ex)
         {
@@ -84,16 +90,35 @@ public sealed class DictationFocusRouter : IDictationFocusRouter
             "Focus router: activating Claude Code '{Title}' (id {Id}) from '{FromClass}'",
             target.Title, target.Id, focused.WmClass);
 
-        await _windowAction.ActivateWindowAsync(target.Id, cancellationToken);
-        await Task.Delay(FocusSettleDelay, cancellationToken);
-        return true;
+        try
+        {
+            await _windowAction.ActivateWindowAsync(target.Id, cancellationToken);
+            await Task.Delay(FocusSettleDelay, cancellationToken);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Activation failures (D-Bus error, window closed mid-call, etc.)
+            // mirror the enumeration failure path: log + fall through to paste
+            // against the currently-focused window. Quick Dictation must
+            // never be killed by a flaky window-calls extension.
+            _logger.LogWarning(
+                ex,
+                "Focus router: failed to activate Claude Code window {Id}, skipping focus switch",
+                target.Id);
+            return false;
+        }
     }
 
     private static bool IsClaudeCode(WindowInfo w) =>
         string.Equals(
             CliAgentRegistry.FindByTitle(w.Title)?.AppName,
             "Claude Code",
-            StringComparison.Ordinal);
+            StringComparison.OrdinalIgnoreCase);
 
     private static bool IsGnomeTextEditor(WindowInfo w) =>
         string.Equals(w.WmClass, GnomeTextEditorWmClass, StringComparison.OrdinalIgnoreCase);

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationFocusRouter.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationFocusRouter.cs
@@ -1,0 +1,100 @@
+using Olbrasoft.LinuxDesktop.Core.Models;
+using Olbrasoft.LinuxDesktop.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <inheritdoc />
+public sealed class DictationFocusRouter : IDictationFocusRouter
+{
+    // WmClass string GNOME reports for the official GNOME Text Editor
+    // (the user's dictation scratchpad). The focus-change signal uses
+    // "org.gnome.TextEditor.desktop"; window-calls `List` strips the
+    // ".desktop" suffix and returns "org.gnome.TextEditor" in WmClass.
+    private const string GnomeTextEditorWmClass = "org.gnome.TextEditor";
+
+    // Empirical delay: below ~150 ms xdotool occasionally keystrokes
+    // into the outgoing window because GNOME hasn't activated the
+    // target yet. 200 ms keeps the hot path snappy while still winning
+    // the race reliably on this hardware.
+    private static readonly TimeSpan FocusSettleDelay = TimeSpan.FromMilliseconds(200);
+
+    private readonly IWindowQueryService _windowQuery;
+    private readonly IWindowActionService _windowAction;
+    private readonly ILogger<DictationFocusRouter> _logger;
+
+    public DictationFocusRouter(
+        IWindowQueryService windowQuery,
+        IWindowActionService windowAction,
+        ILogger<DictationFocusRouter> logger)
+    {
+        _windowQuery = windowQuery ?? throw new ArgumentNullException(nameof(windowQuery));
+        _windowAction = windowAction ?? throw new ArgumentNullException(nameof(windowAction));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryFocusClaudeCodeIfApplicableAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<WindowInfo> windows;
+        try
+        {
+            windows = await _windowQuery.GetWindowsAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // D-Bus / extension failure is non-fatal — we simply skip the
+            // focus-switch heuristic and let the caller paste where it is.
+            _logger.LogDebug(ex, "Focus router: window enumeration failed, skipping");
+            return false;
+        }
+
+        var currentWorkspace = windows.Where(w => w.InCurrentWorkspace).ToList();
+        var focused = currentWorkspace.FirstOrDefault(w => w.HasFocus);
+        if (focused is null)
+        {
+            _logger.LogDebug("Focus router: no focused window on current workspace, skipping");
+            return false;
+        }
+
+        if (IsGnomeTextEditor(focused))
+        {
+            _logger.LogDebug("Focus router: focused window is Text Editor scratchpad, skipping");
+            return false;
+        }
+
+        if (IsClaudeCode(focused))
+        {
+            // Already on the right target — nothing to do.
+            return false;
+        }
+
+        var claudeWindows = currentWorkspace.Where(IsClaudeCode).ToList();
+        if (claudeWindows.Count != 1)
+        {
+            // 0 → nothing to route to; 2+ → ambiguous, leave focus alone.
+            _logger.LogDebug(
+                "Focus router: {Count} Claude Code windows on current workspace, skipping",
+                claudeWindows.Count);
+            return false;
+        }
+
+        var target = claudeWindows[0];
+        _logger.LogInformation(
+            "Focus router: activating Claude Code '{Title}' (id {Id}) from '{FromClass}'",
+            target.Title, target.Id, focused.WmClass);
+
+        await _windowAction.ActivateWindowAsync(target.Id, cancellationToken);
+        await Task.Delay(FocusSettleDelay, cancellationToken);
+        return true;
+    }
+
+    private static bool IsClaudeCode(WindowInfo w) =>
+        string.Equals(
+            CliAgentRegistry.FindByTitle(w.Title)?.AppName,
+            "Claude Code",
+            StringComparison.Ordinal);
+
+    private static bool IsGnomeTextEditor(WindowInfo w) =>
+        string.Equals(w.WmClass, GnomeTextEditorWmClass, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationFocusRouter.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationFocusRouter.cs
@@ -15,7 +15,7 @@ public interface IDictationFocusRouter
     /// <summary>
     /// Inspects the current workspace and, if the conditions above hold,
     /// activates the single Claude Code window and waits briefly for
-    /// GNOME to settle focus so the subsequent xdotool paste lands in
+    /// GNOME to settle focus so the subsequent keyboard paste lands in
     /// the new target instead of the outgoing window. Returns true when
     /// a switch happened.
     /// </summary>

--- a/src/VirtualAssistant.Service/Workers/Dictation/IDictationFocusRouter.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/IDictationFocusRouter.cs
@@ -1,0 +1,23 @@
+namespace Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+/// <summary>
+/// Quick-Dictation-only: if the current workspace has exactly one Claude
+/// Code window and the user's current focus is somewhere else (browser,
+/// non-Claude terminal, desktop), switch focus to that Claude Code window
+/// before the paste. Keeps the "user pressed fast from anywhere → text
+/// lands in Claude Code" assumption alive even when the user left focus
+/// on a non-editable surface (e.g. the Remote Control web UI).
+/// Gnome Text Editor is an explicit exception: it's a dictation scratchpad
+/// and must never be hijacked.
+/// </summary>
+public interface IDictationFocusRouter
+{
+    /// <summary>
+    /// Inspects the current workspace and, if the conditions above hold,
+    /// activates the single Claude Code window and waits briefly for
+    /// GNOME to settle focus so the subsequent xdotool paste lands in
+    /// the new target instead of the outgoing window. Returns true when
+    /// a switch happened.
+    /// </summary>
+    Task<bool> TryFocusClaudeCodeIfApplicableAsync(CancellationToken cancellationToken);
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationCompletionPipelineTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationCompletionPipelineTests.cs
@@ -23,6 +23,7 @@ public class DictationCompletionPipelineTests
     private readonly Mock<IDictationOutputChannel> _outputChannelMock = new();
     private readonly Mock<IDictationTranscriptionPersister> _persisterMock = new();
     private readonly Mock<IClaudeCodeCivilityTrimmer> _civilityTrimmerMock = new();
+    private readonly Mock<IDictationFocusRouter> _focusRouterMock = new();
 
     public DictationCompletionPipelineTests()
     {
@@ -31,11 +32,18 @@ public class DictationCompletionPipelineTests
         _civilityTrimmerMock
             .Setup(x => x.TrimIfClaudeCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns<string, CancellationToken>((text, _) => Task.FromResult(text));
+
+        // Default focus router: no-op (no switch). Individual tests override
+        // when they need to assert the router was consulted / fired.
+        _focusRouterMock
+            .Setup(x => x.TryFocusClaudeCodeIfApplicableAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
     }
 
     private DictationCompletionPipeline CreateSut() =>
         new(_loggerMock.Object, _stateMachineMock.Object, _transcriberMock.Object,
-            _outputChannelMock.Object, _persisterMock.Object, _civilityTrimmerMock.Object);
+            _outputChannelMock.Object, _persisterMock.Object, _civilityTrimmerMock.Object,
+            _focusRouterMock.Object);
 
     [Fact]
     public async Task CompleteQuickAsync_Success_PastesAndBroadcasts()
@@ -97,6 +105,53 @@ public class DictationCompletionPipelineTests
             x => x.BroadcastEventAsync(It.IsAny<DictationEventType>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _stateMachineMock.Verify(x => x.TransitionTo(DictationState.Idle), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteQuickAsync_ConsultsFocusRouterBeforeCivilityTrim()
+    {
+        // Ordering contract: focus router runs BEFORE civility trim so the
+        // trimmer's "am I in Claude Code?" heuristic sees the post-focus
+        // state. If we trimmed first, then focus-switched into Claude Code,
+        // the civility "Děkuji." sign-off could leak into the prompt.
+        var audio = new byte[] { 1 };
+        _transcriberMock.Setup(x => x.TranscribeRawAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("quick text", 0.9f));
+        _outputChannelMock.Setup(x => x.FastPasteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var order = new List<string>();
+        _focusRouterMock
+            .Setup(x => x.TryFocusClaudeCodeIfApplicableAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("focus"))
+            .ReturnsAsync(false);
+        _civilityTrimmerMock
+            .Setup(x => x.TrimIfClaudeCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((_, _) => order.Add("trim"))
+            .Returns<string, CancellationToken>((text, _) => Task.FromResult(text));
+
+        await CreateSut().CompleteQuickAsync(audio, CancellationToken.None);
+
+        _focusRouterMock.Verify(x => x.TryFocusClaudeCodeIfApplicableAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal(new[] { "focus", "trim" }, order);
+    }
+
+    [Fact]
+    public async Task CompleteFullAsync_DoesNotConsultFocusRouter()
+    {
+        // Normal Dictation keeps today's behavior: it types into the active
+        // window as-is, with no auto-focus switching. The router is Quick-only.
+        var audio = new byte[] { 1 };
+        _transcriberMock.Setup(x => x.TranscribeFullAsync(audio, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranscriptionResult("full text", 0.9f));
+        _outputChannelMock.Setup(x => x.TypeIntoActiveWindowAsync("full text", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await CreateSut().CompleteFullAsync(audio, _ => { }, CancellationToken.None);
+
+        _focusRouterMock.Verify(
+            x => x.TryFocusClaudeCodeIfApplicableAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationFocusRouterTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationFocusRouterTests.cs
@@ -149,17 +149,62 @@ public class DictationFocusRouterTests
     }
 
     [Fact]
-    public async Task Ctor_NullWindowQuery_Throws() =>
-        await Task.Run(() => Assert.Throws<ArgumentNullException>(() =>
-            new DictationFocusRouter(null!, _windowActionMock.Object, _loggerMock.Object)));
+    public async Task TryFocus_WindowQueryCancelled_Propagates()
+    {
+        // Cancellation is a control-flow signal, not an error — pass it up so
+        // the pipeline's finally block can unwind state-machine + feedback.
+        _windowQueryMock
+            .Setup(x => x.GetWindowsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None));
+    }
 
     [Fact]
-    public async Task Ctor_NullWindowAction_Throws() =>
-        await Task.Run(() => Assert.Throws<ArgumentNullException>(() =>
-            new DictationFocusRouter(_windowQueryMock.Object, null!, _loggerMock.Object)));
+    public async Task TryFocus_ActivateWindowThrows_SkipsSilently()
+    {
+        // Activation failures (window closed mid-call, transient D-Bus error)
+        // fall through same as query failures — Quick Dictation must keep
+        // working against the currently-focused window.
+        var claude = MakeWindow(42, "Alacritty", "Claude Code — ~/project");
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true);
+        SetupWindows(claude, browser);
+        _windowActionMock
+            .Setup(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("window gone"));
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+    }
 
     [Fact]
-    public async Task Ctor_NullLogger_Throws() =>
-        await Task.Run(() => Assert.Throws<ArgumentNullException>(() =>
-            new DictationFocusRouter(_windowQueryMock.Object, _windowActionMock.Object, null!)));
+    public async Task TryFocus_ActivateCancelled_Propagates()
+    {
+        var claude = MakeWindow(42, "Alacritty", "Claude Code — ~/project");
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true);
+        SetupWindows(claude, browser);
+        _windowActionMock
+            .Setup(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public void Ctor_NullWindowQuery_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationFocusRouter(null!, _windowActionMock.Object, _loggerMock.Object));
+
+    [Fact]
+    public void Ctor_NullWindowAction_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationFocusRouter(_windowQueryMock.Object, null!, _loggerMock.Object));
+
+    [Fact]
+    public void Ctor_NullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationFocusRouter(_windowQueryMock.Object, _windowActionMock.Object, null!));
 }

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationFocusRouterTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationFocusRouterTests.cs
@@ -1,0 +1,165 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.LinuxDesktop.Core.Models;
+using Olbrasoft.LinuxDesktop.Core.Services;
+using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
+
+/// <summary>
+/// Pins the "press fast from anywhere → text lands in the single Claude
+/// Code window on this workspace" heuristic. The router's whole value is
+/// knowing when NOT to switch focus — Text Editor scratchpad, ambiguous
+/// multi-Claude layouts, and the already-on-target case must all fall
+/// through silently so downstream paste continues unchanged.
+/// </summary>
+public class DictationFocusRouterTests
+{
+    private readonly Mock<IWindowQueryService> _windowQueryMock = new();
+    private readonly Mock<IWindowActionService> _windowActionMock = new();
+    private readonly Mock<ILogger<DictationFocusRouter>> _loggerMock = new();
+
+    private DictationFocusRouter CreateSut() =>
+        new(_windowQueryMock.Object, _windowActionMock.Object, _loggerMock.Object);
+
+    private static WindowInfo MakeWindow(
+        uint id,
+        string wmClass,
+        string title,
+        bool inCurrentWorkspace = true,
+        bool hasFocus = false)
+    {
+        // LinuxDesktop.Core.Models.WindowInfo is init-only with a sizeable
+        // surface. Tests only care about the fields the router inspects, so
+        // we build it via object initializer and leave the rest at defaults.
+        return new WindowInfo
+        {
+            Id = id,
+            WmClass = wmClass,
+            WmClassInstance = wmClass,
+            Title = title,
+            Pid = 0,
+            InCurrentWorkspace = inCurrentWorkspace,
+            HasFocus = hasFocus,
+            FrameType = 0,
+            WindowType = 0
+        };
+    }
+
+    private void SetupWindows(params WindowInfo[] windows)
+    {
+        _windowQueryMock
+            .Setup(x => x.GetWindowsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(windows);
+    }
+
+    [Fact]
+    public async Task TryFocus_OneClaudeOnWorkspace_FocusedOnBrowser_Activates()
+    {
+        var claude = MakeWindow(42, "Alacritty", "Claude Code — ~/project", hasFocus: false);
+        var browser = MakeWindow(7, "Google-chrome", "Desktop Monitor", hasFocus: true);
+        SetupWindows(claude, browser);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.True(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(42u, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TryFocus_FocusedOnTextEditor_SkipsEvenWithClaudeAvailable()
+    {
+        var claude = MakeWindow(42, "Alacritty", "Claude Code — ~/project");
+        var textEditor = MakeWindow(9, "org.gnome.TextEditor", "Note (Koncept) – Textový editor", hasFocus: true);
+        SetupWindows(claude, textEditor);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_AlreadyFocusedOnClaude_DoesNotReactivate()
+    {
+        var claude = MakeWindow(42, "Alacritty", "Claude Code — ~/project", hasFocus: true);
+        SetupWindows(claude);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_NoClaudeOnWorkspace_Skips()
+    {
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true);
+        SetupWindows(browser);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_MultipleClaudeOnWorkspace_SkipsAsAmbiguous()
+    {
+        var claudeA = MakeWindow(42, "Alacritty", "Claude Code — ~/project-a");
+        var claudeB = MakeWindow(43, "Alacritty", "Claude Code — ~/project-b");
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true);
+        SetupWindows(claudeA, claudeB, browser);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_ClaudeOnOtherWorkspace_Skips()
+    {
+        // Claude Code exists but NOT on the current workspace — we must not
+        // teleport the user to another workspace to paste.
+        var claude = MakeWindow(42, "Alacritty", "Claude Code — ~/project", inCurrentWorkspace: false);
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true);
+        SetupWindows(claude, browser);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_WindowQueryThrows_SkipsSilently()
+    {
+        // D-Bus / window-calls extension missing or crashed is not fatal
+        // for dictation — the caller should still paste, just without the
+        // focus-switch boost.
+        _windowQueryMock
+            .Setup(x => x.GetWindowsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("D-Bus unavailable"));
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Ctor_NullWindowQuery_Throws() =>
+        await Task.Run(() => Assert.Throws<ArgumentNullException>(() =>
+            new DictationFocusRouter(null!, _windowActionMock.Object, _loggerMock.Object)));
+
+    [Fact]
+    public async Task Ctor_NullWindowAction_Throws() =>
+        await Task.Run(() => Assert.Throws<ArgumentNullException>(() =>
+            new DictationFocusRouter(_windowQueryMock.Object, null!, _loggerMock.Object)));
+
+    [Fact]
+    public async Task Ctor_NullLogger_Throws() =>
+        await Task.Run(() => Assert.Throws<ArgumentNullException>(() =>
+            new DictationFocusRouter(_windowQueryMock.Object, _windowActionMock.Object, null!)));
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #1045

## Problem
User report: pressing the **fast** dictation button from a browser or any non-editable surface silently drops the dictated text, because `FastPasteAsync` types into the currently-focused window. In 99 % of those cases the intent was "put the text in my Claude Code session on this workspace" — but the user happens to have Remote Control / Desktop Monitor / Chromium focused instead of alt-tabbing first.

## Solution
New `IDictationFocusRouter` consulted by `DictationCompletionPipeline.CompleteQuickAsync` **before** the civility trim. On the Quick path only:

1. Enumerate windows on the **current workspace** (`IWindowQueryService.GetWindowsAsync()` filtered by `InCurrentWorkspace`).
2. If exactly ONE Claude Code window exists (match via `CliAgentRegistry.FindByTitle`), AND the focused window is neither that Claude Code nor the GNOME Text Editor scratchpad exception → activate Claude Code (`IWindowActionService.ActivateWindowAsync`), wait 200 ms for GNOME to settle focus, then proceed with the paste.
3. Otherwise (0 Claude, 2+ Claude, already on Claude, or focused on Text Editor) → no-op, paste where we are.

**Ordering contract**: focus router runs BEFORE civility trim so `IClaudeCodeCivilityTrimmer`'s "am I in Claude Code?" heuristic sees the post-focus state and correctly applies the trim when we just switched into Claude Code.

**Exception — GNOME Text Editor** (`WmClass = org.gnome.TextEditor`): user uses this as a dictation scratchpad; auto-switch must not hijack it.

**Resilience**: D-Bus / `window-calls` extension failures are caught and treated as a no-op, so a missing GNOME extension can't break Quick Dictation — the paste still runs against the currently-focused window.

## Test plan
- [x] 10 router tests (all paths: switch, no-switch, ambiguous, cross-workspace, D-Bus failure, ctor guards)
- [x] 2 new pipeline tests pinning the router is consulted on Quick (before civility trim, in order) and NOT consulted on Normal Dictation
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — **447 Service + 332 Voice tests green**
- [ ] After deploy, manually dictate from browser with one Claude Code on workspace → text pastes into Claude Code
- [ ] After deploy, manually dictate from Text Editor with Claude Code also open → text pastes into Text Editor