### PR TITLE
docs(paste-into-claude-code): record 2026-04-21 gdbus root-cause + byte-format probe

### DIFF
--- a/docs/paste-into-claude-code-issue.md
+++ b/docs/paste-into-claude-code-issue.md
@@ -5,12 +5,12 @@ and a root-cause gdbus-parse fix landed in PR #1048 (2026-04-21, closes #1047)
 — but the class of bugs this document describes keeps recurring, so any future
 regression should start here instead of from scratch.
 
-> **⚠️ Service-restart fallacy.** Right after a `systemctl --user restart
-> virtual-assistant.service` (or an auto-deploy) the system *always* looks
-> healthy for a few minutes — the test environment is reset, caches are
-> cold, the first few interactions go through the happy path. That tells
-> you nothing about whether the underlying regression is gone. Trust the
-> log signals in the debug checklist, not the post-restart vibe check.
+> **⚠️ Service-restart fallacy.** Right after a `systemctl --user restart virtual-assistant.service`
+> (or an auto-deploy) the system *always* looks healthy for a few minutes —
+> the test environment is reset, caches are cold, the first few interactions
+> go through the happy path. That tells you nothing about whether the
+> underlying regression is gone. Trust the log signals in the debug
+> checklist, not the post-restart vibe check.
 
 ---
 

--- a/docs/paste-into-claude-code-issue.md
+++ b/docs/paste-into-claude-code-issue.md
@@ -1,8 +1,16 @@
 # Paste into Claude Code (inside tmux) — the recurring "No image found in clipboard" bug
 
 **Status:** Actively managed. A structural fix landed in PR #953 (2026-04-16)
-but the class of bugs this document describes keeps recurring, so any future
+and a root-cause gdbus-parse fix landed in PR #1048 (2026-04-21, closes #1047)
+— but the class of bugs this document describes keeps recurring, so any future
 regression should start here instead of from scratch.
+
+> **⚠️ Service-restart fallacy.** Right after a `systemctl --user restart
+> virtual-assistant.service` (or an auto-deploy) the system *always* looks
+> healthy for a few minutes — the test environment is reset, caches are
+> cold, the first few interactions go through the happy path. That tells
+> you nothing about whether the underlying regression is gone. Trust the
+> log signals in the debug checklist, not the post-restart vibe check.
 
 ---
 
@@ -159,8 +167,11 @@ helped the common case but did not remove the class of bugs.
    so we had to stage text in `PRIMARY` too — and CopyQ's auto-sync defeated
    our initial attempt to do this via `CLIPBOARD`.
 5. Stage text directly in `PRIMARY` via `wl-copy --primary`, restore
-   `PRIMARY` after 300 ms. **This is the current state (PR #953).** It
-   covers the off-by-one and the `No image found` cases on the happy path.
+   `PRIMARY` after 300 ms. PR #953 (2026-04-16). Covers the off-by-one
+   and the `No image found` cases *as long as CLI-app detection works*.
+6. **Fix `GdbusJsonHelper.UnescapeQuotes` to match the real gdbus wire
+   format.** PR #1048 / issue #1047 (2026-04-21 ~16:20 CEST). See the
+   dedicated section below.
 
 What is **not** covered:
 
@@ -172,6 +183,99 @@ What is **not** covered:
   "Store selection changes" ON vs OFF — currently unknown / not audited).
 - What happens if the focused window changes between the moment we detect
   the CLI app and the moment dotool fires.
+- A future gdbus / glib version that emits a *different* escape format
+  (e.g. single-quote wrap with no escape, or extra layers). The 2026-04-21
+  fix added a unit test pinning the current byte sequence; if that test
+  ever regresses on a host upgrade, this document's "Debug checklist
+  step 1b" is how to re-capture the new format.
+
+---
+
+## 2026-04-21: gdbus JSON parse regression (PR #1048, issue #1047)
+
+**What was broken.** `GdbusJsonHelper.UnescapeQuotes` (at
+`src/VirtualAssistant.Core/WindowManagement/GdbusJsonHelper.cs`) was
+searching for *double-escaped* quotes (`\\"` on the wire — three bytes:
+backslash, backslash, quote) and rewriting them to JSON-escaped quotes
+(`\"`). The comment in the file claimed gdbus emits that format. It
+doesn't — at least not on this host.
+
+**Actual gdbus wire format (verified by `od -c` on live output):**
+
+```
+( " [ { \ " i n _ c u r r e n t _ w o r k s p a c e \ " : f a l s e
+```
+
+Positions 4–5 are `\` and `"` — **two** distinct bytes, i.e. the string
+is **single-escape**, wrapped in outer double-quotes. The old `Replace`
+never matched, `UnescapeQuotes` returned the escaped string unchanged,
+and `System.Text.Json.JsonSerializer` threw on the very first property
+name:
+
+```
+System.Text.Json.JsonException: '\' is an invalid start of a property name.
+  Expected a '"'. Path: $ | LineNumber: 0 | BytePositionInLine: 2.
+  at GdbusWindowDetector.cs:line 65
+```
+
+**Propagation.** The exception was swallowed, every gdbus-based detector
+returned null, and the downstream consequences fanned out:
+
+| Consumer | Degradation |
+| --- | --- |
+| `GdbusWindowDetector.GetFocusedWindowInfoAsync` | returns `null` |
+| `TerminalCliAppDetector.DetectCliAppAsync` | never sees Claude Code |
+| `WaylandTerminalDetector.IsTerminalActiveAsync` | returns `false` |
+| `XDoToolKeyboardService.GetPasteShortcutAsync` | falls through to `ctrl+v` |
+| Claude Code TUI | hijacks `ctrl+v` → red `No image found in clipboard` toast |
+| `DesktopMonitorBroadcastWorker` | never broadcasts `CliAppChanged` |
+| Remote Control web UI | shows the monolithic **Diktovat** button instead of the split **Pokračuj / Diktovat** |
+| Desktop Monitor dashboard | correction prompt stays `DefaultCorrection` instead of `ClaudeCodeCorrection` |
+
+**Fix.** Rewrite `UnescapeQuotes` as a single-pass `StringBuilder` scan
+that recognises only `\\` → `\` and `\"` → `"`, leaving every other
+`\x` sequence (including genuine JSON escapes like `\n`, `\t`, `\uXXXX`
+and lone trailing backslashes) intact. Signature widened to
+`string? UnescapeQuotes(string?)` with
+`[return: NotNullIfNotNull(nameof(json))]` so callers that pass a
+non-null string still see a non-null return.
+
+New regression test (`GdbusJsonHelperTests.UnescapeQuotes_RealGdbusWireFormat_ProducesValidJson`)
+feeds the helper the exact byte pattern captured via `od -c` from live
+`gdbus call ... Windows.List`, and asserts that System.Text.Json
+deserializes it and that the focused window resolves to
+`wm_class="terminator"`, `title="/bin/bash"`, `pid=322375`.
+
+**Live-verify signal after deploy.**
+
+```
+journalctl --user -u virtual-assistant.service --since "5 min ago" \
+  | grep -E "paste shortcut|Focused window|Failed to parse"
+```
+
+A **healthy** log shows both halves of the pair:
+
+```
+Focused window: terminator "Claude Code" (PID: 6508)
+Using paste shortcut: shift+insert (CLI app: Claude Code — Ctrl+Shift+V would be hijacked)
+```
+
+A **regressed** log shows:
+
+```
+Failed to parse D-Bus JSON response
+System.Text.Json.JsonException: '\' is an invalid start of a property name.
+…
+Using paste shortcut: ctrl+v (terminal: False)
+```
+
+**If this document is open because the bug is back:** do **not** assume
+the 2026-04-21 fix is still doing its job. First step is always to run
+the `od -c` probe in the Debug checklist "step 1b" below and compare
+the byte pattern of `\` vs `"` against what `GdbusJsonHelper.UnescapeQuotes`
+expects *today*. A host upgrade (glib / gdbus / libxml) could shift the
+format again, and the unit test pinning the 2026-04-21 bytes will still
+pass locally while prod behaves differently.
 
 ---
 
@@ -221,6 +325,30 @@ leaves the text in the selection.
    ```
    Look for `"focus": true` and read the `title` field. Does it contain
    "Claude Code"?
+
+   **1b. What is the exact gdbus escape format?** (added 2026-04-21 after
+   PR #1048.) Run
+   ```
+   gdbus call --session --dest org.gnome.Shell \
+     --object-path /org/gnome/Shell/Extensions/Windows \
+     --method org.gnome.Shell.Extensions.Windows.List | od -c | head
+   ```
+   Look at bytes 4–5 of the first record (`\` + `"` = two bytes =
+   single-escape, which is what `GdbusJsonHelper.UnescapeQuotes` handles
+   today). If you see `\ \ "` (three bytes) or some other shape, the
+   gdbus / glib stack has changed escape rules on this host and the
+   helper's regression test
+   (`GdbusJsonHelperTests.UnescapeQuotes_RealGdbusWireFormat_ProducesValidJson`)
+   will need an update to match — don't paper over it by re-restarting
+   the service.
+
+   Also tail the service log for the deterministic signal:
+   ```
+   journalctl --user -u virtual-assistant.service --since "5 min ago" \
+     | grep -E "Failed to parse D-Bus JSON response"
+   ```
+   Presence of that line means gdbus parsing regressed again. Cross-check
+   against step 1b.
 
 2. What does VA detect? Hit
    `http://localhost:5055/Admin/DesktopMonitor` and check `APP NAME`,
@@ -343,7 +471,10 @@ In rough order of complexity:
 ## Related PRs
 
 - PR #953 — Pokračuj button + CliAppChanged broadcast + Shift+Insert paste
-  + PRIMARY-selection staging. *The current state.*
+  + PRIMARY-selection staging. (2026-04-16)
+- PR #1048 (closes #1047) — `GdbusJsonHelper.UnescapeQuotes` single-vs-double
+  escape fix. Single-pass scanner, regression test pinning the real gdbus
+  byte pattern. *The current state.* (2026-04-21)
 
 ---
 


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Refs #960 (tracking — keep open)
Refs #1047 (already merged via PR #1048)

## Summary

- Append a new `2026-04-21: gdbus JSON parse regression (PR #1048, issue #1047)` section with: wire-format `od -c` evidence, the propagation table (which consumer degrades how), the live-verify signal after deploy, and an explicit warning that a host upgrade could shift the escape format and silently regress while the existing unit test still passes locally.
- Add a service-restart fallacy callout at the top of the doc: every time we restart `virtual-assistant.service` the symptom goes away for a few minutes on its own, so the post-restart vibe check proves nothing. Trust the log signals, not the visual.
- Extend the debug checklist with a new **step 1b**: re-capture the gdbus byte pattern via `od -c` and cross-check against what `GdbusJsonHelper.UnescapeQuotes` expects today. Plus a deterministic log grep (`Failed to parse D-Bus JSON response`) that says gdbus parsing regressed again.
- Link PR #1048 in the \"Related PRs\" section.

Note on commit message: the commit says `Closes #960 (documentation portion)` but #960 is a long-lived tracking issue — it stays open. This PR just fleshes out the knowledge base the tracking issue guards.

## Test plan

- [x] Docs-only change — renders correctly in GitHub Markdown preview.
- [x] No code paths touched, no test impact. Build + test suite still green from PR #1048 run.