### PR TITLE
fix(paste): exit tmux copy-mode before every paste — closes #1050

### DIFF
--- a/docs/paste-into-claude-code-issue.md
+++ b/docs/paste-into-claude-code-issue.md
@@ -1,7 +1,8 @@
 # Paste into Claude Code (inside tmux) — the recurring "No image found in clipboard" bug
 
-**Status:** Actively managed. A structural fix landed in PR #953 (2026-04-16)
-and a root-cause gdbus-parse fix landed in PR #1048 (2026-04-21, closes #1047)
+**Status:** Actively managed. Structural fix in PR #953 (2026-04-16),
+root-cause gdbus-parse fix in PR #1048 (2026-04-21 afternoon, closes #1047),
+and tmux copy-mode guard in PR #1052 (2026-04-21 evening, closes #1050)
 — but the class of bugs this document describes keeps recurring, so any future
 regression should start here instead of from scratch.
 
@@ -191,6 +192,94 @@ What is **not** covered:
 
 ---
 
+## 2026-04-21 evening: tmux copy-mode hijacks paste input (PR #1052, issue #1050)
+
+**What was broken.** With `set -g mouse on` in `~/.tmux.conf` (the user's
+setup for wheel-scroll scrollback), any mouse wheel scroll inside a Claude
+Code pane makes tmux auto-enter **copy-mode**. In copy-mode every
+keystroke — including the `Shift+Insert` paste VA emits after dictation —
+is consumed by tmux's own scroll/search bindings and **never reaches the
+program running in the pane**. User-visible signal: the pane cursor blinks
+**inverted (black/white)** instead of solid white. The bug is localised to
+whichever pane the user last scrolled in; other tmux sessions on other
+workspaces behave normally. The symptom "Claude Code paste doesn't land
+but the service log says FastPaste succeeded" is therefore a *tmux-layer*
+failure, not a clipboard / CopyQ / detection one.
+
+**Why it went undetected before.** The user confirmed: "mně se to
+nestávalo, dokud jsem nezačal používat ten T-Mux." Before tmux was in the
+stack, copy-mode did not exist and terminator handled scrollback natively
+without trapping keystrokes. The new fix from PR #1048 (which corrected
+gdbus JSON parsing and made the paste-shortcut selection work) unmasked
+this downstream tmux issue because now the shortcut DOES reach tmux — and
+tmux in copy-mode drops it.
+
+**Recovery today (before PR #1052).** User had to **double-click** inside
+the pane: single click only moved the copy-mode cursor; the drag-release
+of the double click triggered `bind -T copy-mode MouseDragEnd1Pane
+send-keys -X copy-pipe-and-cancel`, which selected a word and, crucially,
+**cancelled copy-mode**. Then the next paste landed.
+
+**Live evidence captured 2026-04-21 16:xx.**
+
+```
+$ tmux list-panes -a -F '#{session_name}:…  in_mode=#{pane_in_mode}  mode=#{pane_mode}'
+claude-VirtualAssistant-pts-8:0.0  in_mode=0  mode=
+claude-cr-pts-4:0.0                in_mode=0  mode=
+claude-jirka-pts-2:0.0             in_mode=1  mode=copy-mode       ← stuck
+claude-prehrajto-sync-pts-6:0.0    in_mode=0  mode=
+```
+
+Exactly one pane was "stuck" — the one the user had wheel-scrolled. The
+VA log for the most recent failed paste showed everything *looking*
+healthy: `Using paste shortcut: shift+insert (CLI app: Claude Code)` and
+`FastPaste: 731 chars pasted`. Bytes were emitted; tmux ate them.
+
+**Fix (service-side).** New `ITmuxCopyModeGuard` + `TmuxCopyModeGuard`:
+before every paste entry point (`FastPasteAsync`, `TypeIntoActiveWindowAsync`,
+`PasteFromClipboardAsync`) the service probes
+`tmux list-panes -a -F '#{pane_active}\t#{pane_in_mode}\t#{target}'`.
+For every pane with both `pane_active=1` and `pane_in_mode=1` it issues
+`tmux send-keys -X -t <target> cancel`. The guard is best-effort: tmux
+missing, IO error, or internal timeout are all swallowed — the paste
+pipeline is never blocked by the guard. Active-only filter is deliberate,
+touching an inactive pane would pull the user out of a scrollback they
+may be reading, and the paste wouldn't land there anyway. Wired with
+the guard running **before** PRIMARY/CLIPBOARD staging in `FastPaste`
+to keep the stage → paste race window short (Copilot review on #1052).
+
+**Fix (user-side, complementary).** The user added to `~/.tmux.conf`:
+
+```tmux
+bind -T copy-mode    MouseDown1Pane send-keys -X cancel
+bind -T copy-mode-vi MouseDown1Pane send-keys -X cancel
+```
+
+so a **single mouse click** also exits copy-mode (default behaviour
+is just to move the cursor). This matters for manual paste flows
+(Shift+Insert from the physical keyboard, Ctrl+Shift+V from the IDE
+keymap, middle-click from another window) where the service-side
+guard isn't involved.
+
+**Live-verify signals after deploy.**
+
+Healthy log during a paste into a previously-stuck pane:
+
+```
+TmuxCopyModeGuard: sent 'cancel' to pane claude-jirka-pts-2:0.0 (was in copy-mode)
+Using paste shortcut: shift+insert (CLI app: Claude Code — Ctrl+Shift+V would be hijacked)
+FastPaste: 298 chars pasted
+```
+
+If you still see the "cursor blinks inverted, paste dropped" symptom
+AFTER this fix is deployed, the class of bug has moved somewhere
+new (likely another tmux input-interception mode — search, command-
+prompt, copy-mode-emacs bindings that don't honour `cancel`). At
+that point escalate to the "not in scope" list in the parent
+`2026-04-21 afternoon` section above.
+
+---
+
 ## 2026-04-21: gdbus JSON parse regression (PR #1048, issue #1047)
 
 **What was broken.** `GdbusJsonHelper.UnescapeQuotes` (at
@@ -350,6 +439,19 @@ leaves the text in the selection.
    Presence of that line means gdbus parsing regressed again. Cross-check
    against step 1b.
 
+   **1c. Is any tmux pane stuck in copy-mode?** (added 2026-04-21 after
+   PR #1052.) Run
+   ```
+   tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index}  active=#{pane_active}  in_mode=#{pane_in_mode}  mode=#{pane_mode}'
+   ```
+   Any row with `mode=copy-mode` + `active=1` is the "cursor blinks inverted,
+   paste dropped" pane. That alone explains the symptom regardless of what the
+   VA log says about `FastPaste: N chars pasted`. Also check the service log
+   for the `TmuxCopyModeGuard: sent 'cancel' to pane <target>` line — its
+   presence means the guard is firing (good), absence when `mode=copy-mode`
+   exists means the guard is disabled / broken and paste-into-copy-mode drops
+   are back.
+
 2. What does VA detect? Hit
    `http://localhost:5055/Admin/DesktopMonitor` and check `APP NAME`,
    `CORRECTION PROMPT`. If they don't say `Claude Code` /
@@ -474,7 +576,11 @@ In rough order of complexity:
   + PRIMARY-selection staging. (2026-04-16)
 - PR #1048 (closes #1047) — `GdbusJsonHelper.UnescapeQuotes` single-vs-double
   escape fix. Single-pass scanner, regression test pinning the real gdbus
-  byte pattern. *The current state.* (2026-04-21)
+  byte pattern. (2026-04-21 afternoon)
+- PR #1052 (closes #1050) — `ITmuxCopyModeGuard` probes
+  `tmux list-panes -a` and issues `send-keys -X cancel` to every active pane
+  in copy-mode before paste. Complementary `~/.tmux.conf` bind for single-
+  click copy-mode exit. *The current state.* (2026-04-21 evening)
 
 ---
 

--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -37,6 +37,7 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
     private readonly IDotoolProcessRunner _dotoolRunner;
     private readonly ITerminalDetector _terminalDetector;
     private readonly ICliAppDetector _cliAppDetector;
+    private readonly ITmuxCopyModeGuard _copyModeGuard;
     private readonly ILogger<XDoToolKeyboardService> _logger;
 
     public XDoToolKeyboardService(
@@ -45,6 +46,7 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
         IDotoolProcessRunner dotoolRunner,
         ITerminalDetector terminalDetector,
         ICliAppDetector cliAppDetector,
+        ITmuxCopyModeGuard copyModeGuard,
         ILogger<XDoToolKeyboardService> logger)
     {
         _clipboardManager = clipboardManager ?? throw new ArgumentNullException(nameof(clipboardManager));
@@ -52,6 +54,7 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
         _dotoolRunner = dotoolRunner ?? throw new ArgumentNullException(nameof(dotoolRunner));
         _terminalDetector = terminalDetector ?? throw new ArgumentNullException(nameof(terminalDetector));
         _cliAppDetector = cliAppDetector ?? throw new ArgumentNullException(nameof(cliAppDetector));
+        _copyModeGuard = copyModeGuard ?? throw new ArgumentNullException(nameof(copyModeGuard));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -79,6 +82,12 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             var textToType = text + " ";
             var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
             var usePrimary = pasteShortcut == "shift+insert";
+
+            // #1050: if any active tmux pane is stuck in copy-mode (user wheel-
+            // scrolled earlier), the upcoming Shift+Insert would be swallowed by
+            // tmux's own bindings and never reach the CLI TUI. Exit copy-mode
+            // first so the paste actually lands.
+            await _copyModeGuard.EnsureNotInCopyModeAsync(cancellationToken);
 
             _logger.LogInformation("Simulating paste with shortcut: {Shortcut} (selection: {Selection})",
                 pasteShortcut, usePrimary ? "PRIMARY" : "CLIPBOARD");
@@ -212,6 +221,10 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
 
             await Task.Delay(30, cancellationToken);
 
+            // #1050: cancel any tmux copy-mode on the active pane so the paste
+            // keystroke below is not hijacked by tmux's scroll/search bindings.
+            await _copyModeGuard.EnsureNotInCopyModeAsync(cancellationToken);
+
             if (!await SendPasteShortcutAsync(pasteShortcut, cancellationToken))
                 return false;
 
@@ -235,6 +248,10 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
     {
         var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
         _logger.LogInformation("PasteFromClipboard: sending {Shortcut}", pasteShortcut);
+
+        // #1050: exit any lingering tmux copy-mode on the active pane so the
+        // paste below is delivered to the CLI TUI, not consumed by tmux.
+        await _copyModeGuard.EnsureNotInCopyModeAsync(cancellationToken);
 
         // Shift+Insert path (CLI agent TUIs) reads PRIMARY, not CLIPBOARD.
         // The user clicked "Paste from clipboard" intending to paste the

--- a/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
+++ b/src/VirtualAssistant.Core/Keyboard/XDoToolKeyboardService.cs
@@ -214,16 +214,21 @@ public class XDoToolKeyboardService : IKeyboardSimulationService
             var pasteShortcut = await GetPasteShortcutAsync(cancellationToken);
             var usePrimary = pasteShortcut == "shift+insert";
 
+            // #1050: cancel any tmux copy-mode on the active pane BEFORE we
+            // stage the PRIMARY/CLIPBOARD selection. The guard can take up to
+            // its internal timeout (~2 s), and if we staged first, a concurrent
+            // clipboard owner (CopyQ auto-sync, another app) could overwrite
+            // the selection during that window and our paste would emit stale
+            // text. Running the guard first keeps the stage → paste interval
+            // as short as possible.
+            await _copyModeGuard.EnsureNotInCopyModeAsync(cancellationToken);
+
             if (usePrimary)
                 await _clipboardManager.SetPrimarySelectionAsync(text, cancellationToken);
             else
                 await _clipboardManager.SetClipboardAsync(text, cancellationToken);
 
             await Task.Delay(30, cancellationToken);
-
-            // #1050: cancel any tmux copy-mode on the active pane so the paste
-            // keystroke below is not hijacked by tmux's scroll/search bindings.
-            await _copyModeGuard.EnsureNotInCopyModeAsync(cancellationToken);
 
             if (!await SendPasteShortcutAsync(pasteShortcut, cancellationToken))
                 return false;

--- a/src/VirtualAssistant.Core/WindowManagement/ITmuxCopyModeGuard.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/ITmuxCopyModeGuard.cs
@@ -1,0 +1,23 @@
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <summary>
+/// Ensures no active tmux pane is lingering in copy-mode before VirtualAssistant
+/// simulates a paste. In tmux copy-mode every keystroke — including the
+/// <c>Shift+Insert</c> paste VA emits — is consumed by tmux's own scroll/search
+/// bindings and never reaches the program running in the pane (Claude Code,
+/// OpenCode, Gemini CLI, …). With <c>mouse on</c> in the user's config tmux
+/// auto-enters copy-mode on any mouse-wheel scroll, so the bug appears "out of
+/// nowhere" and the only visual cue is the pane cursor blinking inverted
+/// (black/white) instead of solid. See #1050 in Olbrasoft/VirtualAssistant.
+/// </summary>
+public interface ITmuxCopyModeGuard
+{
+    /// <summary>
+    /// Queries <c>tmux list-panes -a</c>, finds every active pane currently in
+    /// copy-mode, and issues <c>send-keys -X cancel</c> to each so the pane's
+    /// input pipeline is live again. Silently no-ops when tmux is not installed
+    /// or reports no such pane — paste callers must not be blocked by guard
+    /// failures.
+    /// </summary>
+    Task EnsureNotInCopyModeAsync(CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Core/WindowManagement/TmuxCopyModeGuard.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TmuxCopyModeGuard.cs
@@ -41,8 +41,18 @@ public sealed class TmuxCopyModeGuard : ITmuxCopyModeGuard
                 cancellationToken);
             stuckPanes = ParseActivePanesInCopyMode(listOutput);
         }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Internal tmux-invoker timeout (not an external cancel from the
+            // caller) is a transient failure — log and skip. Rethrowing would
+            // abort the outer paste pipeline, contradicting the best-effort
+            // contract documented on the interface.
+            _logger.LogDebug("TmuxCopyModeGuard: list-panes probe timed out; skipping");
+            return;
+        }
         catch (OperationCanceledException)
         {
+            // Caller cancelled — surface it so the pipeline unwinds cleanly.
             throw;
         }
         catch (Exception ex)
@@ -67,6 +77,13 @@ public sealed class TmuxCopyModeGuard : ITmuxCopyModeGuard
                     new[] { "send-keys", "-X", "-t", target, "cancel" },
                     cancellationToken);
                 _logger.LogInformation("TmuxCopyModeGuard: sent 'cancel' to pane {Target} (was in copy-mode)", target);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Same timeout-vs-cancel distinction as above — if the tmux
+                // invoker's internal timeout fires we continue with the other
+                // stuck panes rather than aborting the whole paste.
+                _logger.LogDebug("TmuxCopyModeGuard: send-keys cancel timed out for {Target}", target);
             }
             catch (OperationCanceledException)
             {
@@ -139,11 +156,20 @@ public sealed class TmuxCopyModeGuard : ITmuxCopyModeGuard
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(TmuxTimeout);
 
+        // Drain both stdout and stderr concurrently. If stderr were redirected
+        // but not read, a chatty tmux (e.g. "unknown option" spam on a future
+        // tmux version) could fill the pipe buffer and deadlock the child —
+        // we would then only recover on the timeout. We throw the stderr text
+        // away because the exit code is the signal we actually care about.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+        var stderrTask = process.StandardError.ReadToEndAsync(timeoutCts.Token);
+
         string output;
         try
         {
-            output = await process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+            await Task.WhenAll(stdoutTask, stderrTask);
             await process.WaitForExitAsync(timeoutCts.Token);
+            output = await stdoutTask;
         }
         catch (OperationCanceledException)
         {

--- a/src/VirtualAssistant.Core/WindowManagement/TmuxCopyModeGuard.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TmuxCopyModeGuard.cs
@@ -1,0 +1,156 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <inheritdoc />
+public sealed class TmuxCopyModeGuard : ITmuxCopyModeGuard
+{
+    private static readonly TimeSpan TmuxTimeout = TimeSpan.FromSeconds(2);
+
+    // `tmux list-panes -a -F '<fmt>'` prints one record per pane. We use a
+    // literal tab (ASCII 0x09) as the field separator because it cannot
+    // appear in any of the scalar fields we emit.
+    internal const string ListFormat = "#{pane_active}\t#{pane_in_mode}\t#{session_name}:#{window_index}.#{pane_index}";
+
+    private readonly ILogger<TmuxCopyModeGuard> _logger;
+    private readonly Func<IReadOnlyList<string>, CancellationToken, Task<string?>> _tmuxInvoker;
+
+    public TmuxCopyModeGuard(ILogger<TmuxCopyModeGuard> logger)
+        : this(logger, RunTmuxProcessAsync)
+    {
+    }
+
+    // Test seam: inject a fake tmux runner so the unit test can drive the
+    // parse + cancel-dispatch logic without shelling out to a real tmux.
+    internal TmuxCopyModeGuard(
+        ILogger<TmuxCopyModeGuard> logger,
+        Func<IReadOnlyList<string>, CancellationToken, Task<string?>> tmuxInvoker)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _tmuxInvoker = tmuxInvoker ?? throw new ArgumentNullException(nameof(tmuxInvoker));
+    }
+
+    public async Task EnsureNotInCopyModeAsync(CancellationToken cancellationToken)
+    {
+        List<string> stuckPanes;
+        try
+        {
+            var listOutput = await _tmuxInvoker(
+                new[] { "list-panes", "-a", "-F", ListFormat },
+                cancellationToken);
+            stuckPanes = ParseActivePanesInCopyMode(listOutput);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // tmux not installed / not running / transient IO error — caller's
+            // paste path must still proceed. This guard is a best-effort pre-
+            // step, never a blocker.
+            _logger.LogDebug(ex, "TmuxCopyModeGuard: list-panes probe failed; skipping");
+            return;
+        }
+
+        if (stuckPanes.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var target in stuckPanes)
+        {
+            try
+            {
+                await _tmuxInvoker(
+                    new[] { "send-keys", "-X", "-t", target, "cancel" },
+                    cancellationToken);
+                _logger.LogInformation("TmuxCopyModeGuard: sent 'cancel' to pane {Target} (was in copy-mode)", target);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "TmuxCopyModeGuard: failed to cancel copy-mode on {Target}", target);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses <c>tmux list-panes -a -F</c> output and returns every active
+    /// pane that is currently in copy-mode. We only cancel active panes —
+    /// touching an inactive pane would yank the user out of a scrollback
+    /// they're reading and the paste never lands there anyway.
+    /// </summary>
+    internal static List<string> ParseActivePanesInCopyMode(string? listOutput)
+    {
+        var results = new List<string>();
+        if (string.IsNullOrEmpty(listOutput))
+        {
+            return results;
+        }
+
+        foreach (var line in listOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = line.Split('\t');
+            if (parts.Length != 3)
+            {
+                continue;
+            }
+
+            var active = parts[0].Trim();
+            var inMode = parts[1].Trim();
+            var target = parts[2].Trim();
+
+            if (active == "1" && inMode == "1" && !string.IsNullOrWhiteSpace(target))
+            {
+                results.Add(target);
+            }
+        }
+
+        return results;
+    }
+
+    private static async Task<string?> RunTmuxProcessAsync(
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "tmux",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+        foreach (var arg in arguments)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        process.Start();
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TmuxTimeout);
+
+        string output;
+        try
+        {
+            output = await process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+            await process.WaitForExitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { }
+            throw;
+        }
+
+        return process.ExitCode == 0 ? output : null;
+    }
+}

--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -220,6 +220,7 @@ public static class VoiceServicesExtensions
         services.AddSingleton<ICliAppDetector, TerminalCliAppDetector>();
         services.AddSingleton<IDotoolProcessRunner, DotoolProcessRunner>();
         services.AddSingleton<IClipboardPasteOrchestrator, ClipboardPasteOrchestrator>();
+        services.AddSingleton<ITmuxCopyModeGuard, TmuxCopyModeGuard>();
         services.AddSingleton<IKeyboardSimulationService, XDoToolKeyboardService>();
 
         services.AddSingleton<IKeyboardLedReader, LinuxKeyboardLedReader>();

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TmuxCopyModeGuardTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TmuxCopyModeGuardTests.cs
@@ -205,6 +205,52 @@ public class TmuxCopyModeGuardTests
     }
 
     [Fact]
+    public async Task EnsureNotInCopyMode_InternalTimeout_SwallowedNotPropagated()
+    {
+        // The internal tmux runner uses a linked CTS with CancelAfter(2s) and
+        // will throw OperationCanceledException when tmux hangs. That must NOT
+        // bubble up and abort the outer paste pipeline — guard's contract is
+        // best-effort. We simulate this by having the fake runner throw OCE
+        // while the caller's cancellationToken is NOT cancelled.
+        var guard = new TmuxCopyModeGuard(
+            NullLogger<TmuxCopyModeGuard>.Instance,
+            (_, _) => throw new OperationCanceledException());
+
+        // Must complete normally, no exception.
+        await guard.EnsureNotInCopyModeAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task EnsureNotInCopyMode_CancelInvocationInternalTimeout_OtherTargetsStillAttempted()
+    {
+        // Same logic for the per-pane cancel: one pane's internal timeout must
+        // not stop the guard from trying the next stuck pane.
+        var listOutput = string.Join('\n', new[]
+        {
+            "1\t1\tclaude-a:0.0",
+            "1\t1\tclaude-b:0.0",
+        });
+        var attempts = new List<string>();
+        Task<string?> Runner(IReadOnlyList<string> args, CancellationToken _)
+        {
+            if (args[0] == "list-panes")
+                return Task.FromResult<string?>(listOutput);
+
+            var target = args[3];
+            attempts.Add(target);
+            if (target == "claude-a:0.0")
+                throw new OperationCanceledException();
+            return Task.FromResult<string?>("");
+        }
+
+        var guard = new TmuxCopyModeGuard(NullLogger<TmuxCopyModeGuard>.Instance, Runner);
+
+        await guard.EnsureNotInCopyModeAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { "claude-a:0.0", "claude-b:0.0" }, attempts);
+    }
+
+    [Fact]
     public void Ctor_NullLogger_Throws() =>
         Assert.Throws<ArgumentNullException>(() => new TmuxCopyModeGuard(null!));
 

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TmuxCopyModeGuardTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TmuxCopyModeGuardTests.cs
@@ -1,0 +1,226 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
+
+/// <summary>
+/// Pins the parse + cancel-dispatch contract of <see cref="TmuxCopyModeGuard"/>.
+/// The guard's whole job is: if ANY active pane is in copy-mode before a
+/// VirtualAssistant paste, issue <c>send-keys -X cancel</c> so the upcoming
+/// Shift+Insert is not hijacked by tmux bindings (#1050). Every failure mode
+/// here — tmux not installed, list-panes empty, multiple panes stuck, inactive
+/// pane also in copy-mode — has shown up in the wild at least once.
+/// </summary>
+public class TmuxCopyModeGuardTests
+{
+    [Fact]
+    public void Parse_ActivePaneInCopyMode_Included()
+    {
+        var output = "1\t1\tclaude-ji:0.0";
+
+        var result = TmuxCopyModeGuard.ParseActivePanesInCopyMode(output);
+
+        Assert.Single(result);
+        Assert.Equal("claude-ji:0.0", result[0]);
+    }
+
+    [Fact]
+    public void Parse_InactivePaneInCopyMode_Excluded()
+    {
+        // Inactive pane is probably a scrollback another window left behind —
+        // the user may be reading it. Don't cancel it, the paste won't go there.
+        var output = "0\t1\tclaude-ji:0.0";
+
+        var result = TmuxCopyModeGuard.ParseActivePanesInCopyMode(output);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Parse_ActivePaneNotInCopyMode_Excluded()
+    {
+        var output = "1\t0\tclaude-ji:0.0";
+
+        var result = TmuxCopyModeGuard.ParseActivePanesInCopyMode(output);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Parse_MixedPanes_OnlyActiveCopyModeReturned()
+    {
+        // Real-world tmux list-panes -a on a host with several attached sessions.
+        var output = string.Join('\n', new[]
+        {
+            "1\t0\tclaude-VirtualAssistant-pts-8:0.0",
+            "1\t0\tclaude-cr-pts-4:0.0",
+            "1\t1\tclaude-jirka-pts-2:0.0",
+            "0\t1\tclaude-old-pts-99:0.0",
+            "1\t0\tclaude-prehrajto-sync-pts-6:0.0",
+        });
+
+        var result = TmuxCopyModeGuard.ParseActivePanesInCopyMode(output);
+
+        Assert.Single(result);
+        Assert.Equal("claude-jirka-pts-2:0.0", result[0]);
+    }
+
+    [Fact]
+    public void Parse_EmptyOutput_ReturnsEmpty()
+    {
+        var result = TmuxCopyModeGuard.ParseActivePanesInCopyMode(string.Empty);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Parse_NullOutput_ReturnsEmpty()
+    {
+        var result = TmuxCopyModeGuard.ParseActivePanesInCopyMode(null);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Parse_MalformedLine_Skipped()
+    {
+        // A tmux running an older format or a truncated line must not throw;
+        // guard is a best-effort step.
+        var output = string.Join('\n', new[]
+        {
+            "garbage",
+            "1\t1\tclaude-ji:0.0",
+            "1\t1",
+            "",
+        });
+
+        var result = TmuxCopyModeGuard.ParseActivePanesInCopyMode(output);
+
+        Assert.Single(result);
+        Assert.Equal("claude-ji:0.0", result[0]);
+    }
+
+    [Fact]
+    public async Task EnsureNotInCopyMode_NoStuckPanes_NoCancelSent()
+    {
+        var calls = new List<IReadOnlyList<string>>();
+        var guard = CreateGuardWithFakeTmux(calls, listOutput: "1\t0\tclaude-ji:0.0");
+
+        await guard.EnsureNotInCopyModeAsync(CancellationToken.None);
+
+        // Exactly one call — the list-panes probe. No send-keys follow-up.
+        Assert.Single(calls);
+        Assert.Equal("list-panes", calls[0][0]);
+    }
+
+    [Fact]
+    public async Task EnsureNotInCopyMode_OneStuckPane_CancelSentToThatTarget()
+    {
+        var calls = new List<IReadOnlyList<string>>();
+        var guard = CreateGuardWithFakeTmux(calls, listOutput: "1\t1\tclaude-ji:0.0");
+
+        await guard.EnsureNotInCopyModeAsync(CancellationToken.None);
+
+        Assert.Equal(2, calls.Count);
+        Assert.Equal("list-panes", calls[0][0]);
+        Assert.Equal(new[] { "send-keys", "-X", "-t", "claude-ji:0.0", "cancel" }, calls[1]);
+    }
+
+    [Fact]
+    public async Task EnsureNotInCopyMode_MultipleStuckPanes_CancelSentToEach()
+    {
+        var calls = new List<IReadOnlyList<string>>();
+        var listOutput = string.Join('\n', new[]
+        {
+            "1\t1\tclaude-a:0.0",
+            "1\t0\tclaude-b:0.0",
+            "1\t1\tclaude-c:0.0",
+        });
+        var guard = CreateGuardWithFakeTmux(calls, listOutput);
+
+        await guard.EnsureNotInCopyModeAsync(CancellationToken.None);
+
+        Assert.Equal(3, calls.Count);
+        Assert.Equal("claude-a:0.0", calls[1][3]);
+        Assert.Equal("claude-c:0.0", calls[2][3]);
+    }
+
+    [Fact]
+    public async Task EnsureNotInCopyMode_TmuxProbeThrows_Swallowed()
+    {
+        // tmux not installed / not running / transient crash must not propagate
+        // to the paste pipeline — guard is advisory only.
+        var guard = new TmuxCopyModeGuard(
+            NullLogger<TmuxCopyModeGuard>.Instance,
+            (_, _) => throw new InvalidOperationException("tmux missing"));
+
+        await guard.EnsureNotInCopyModeAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task EnsureNotInCopyMode_CancelInvocationThrows_OtherTargetsStillAttempted()
+    {
+        // First send-keys fails, second must still be attempted so a user with
+        // two stuck panes is not left with one still frozen.
+        var listOutput = string.Join('\n', new[]
+        {
+            "1\t1\tclaude-a:0.0",
+            "1\t1\tclaude-b:0.0",
+        });
+        var attempts = new List<string>();
+        Task<string?> Runner(IReadOnlyList<string> args, CancellationToken _)
+        {
+            if (args[0] == "list-panes")
+                return Task.FromResult<string?>(listOutput);
+
+            var target = args[3];
+            attempts.Add(target);
+            if (target == "claude-a:0.0")
+                throw new InvalidOperationException("tmux send-keys failed");
+            return Task.FromResult<string?>("");
+        }
+
+        var guard = new TmuxCopyModeGuard(NullLogger<TmuxCopyModeGuard>.Instance, Runner);
+
+        await guard.EnsureNotInCopyModeAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { "claude-a:0.0", "claude-b:0.0" }, attempts);
+    }
+
+    [Fact]
+    public async Task EnsureNotInCopyMode_CancellationDuringProbe_Propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var guard = new TmuxCopyModeGuard(
+            NullLogger<TmuxCopyModeGuard>.Instance,
+            (_, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult<string?>(null);
+            });
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => guard.EnsureNotInCopyModeAsync(cts.Token));
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new TmuxCopyModeGuard(null!));
+
+    [Fact]
+    public void Ctor_NullInvoker_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new TmuxCopyModeGuard(NullLogger<TmuxCopyModeGuard>.Instance, null!));
+
+    private static TmuxCopyModeGuard CreateGuardWithFakeTmux(
+        List<IReadOnlyList<string>> calls,
+        string listOutput) =>
+        new(
+            NullLogger<TmuxCopyModeGuard>.Instance,
+            (args, _) =>
+            {
+                calls.Add(args);
+                return Task.FromResult<string?>(args[0] == "list-panes" ? listOutput : "");
+            });
+}


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #1050
Refs #960 (tracking — keep open)

## Summary

- When a Claude Code pane ends up in tmux copy-mode (`mouse on` + wheel scroll = auto-enter copy-mode is the typical trigger), every keystroke including our `Shift+Insert` paste is consumed by tmux bindings. Visible signal: pane cursor blinks **inverted** (black/white) and no paste lands. User recovery today is a **double-click** because the existing `copy-pipe-and-cancel` bind fires only on drag-release.
- New `ITmuxCopyModeGuard` / `TmuxCopyModeGuard`: probes `tmux list-panes -a`, finds every active pane with `in_mode=1`, issues `send-keys -X -t <target> cancel`. Inactive panes are left alone on purpose (user may be reading scrollback there; the paste wouldn't land in them anyway).
- Wired into `XDoToolKeyboardService` at all three paste entry points: `TypeIntoActiveWindowAsync`, `FastPasteAsync`, `PasteFromClipboardAsync`. Each calls the guard before the dotool keystroke.
- Guard is **best-effort**: tmux missing, transient IO error, or a single cancel throwing cannot block the outer paste pipeline. All failures are logged at Debug level and swallowed.

## Root-cause evidence

Live `tmux list-panes -a` during the 2026-04-21 recurrence caught `claude-jirka-pts-2:0.0` with `in_mode=1 mode=copy-mode` while the other three active panes were `in_mode=0`. That exactly matches the user's report that the bug is localized to one session and "comes out of nowhere" (wheel-scroll trigger).

User-side complementary fix (not in this repo) is a `~/.tmux.conf` bind `copy-mode MouseDown1Pane send-keys -X cancel` so a single click also exits copy-mode. The VA guard still matters because **dictation fires paste without a preceding click** — so the pane stays stuck without the service-side intervention.

## Test plan

- [x] `dotnet build` — 0 errors.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 1019 tests green (Core 15 new + 12 existing, Voice 332+6 skipped, Service 450, Data.EF 115, Desktop 65, LlmChain 32).
- [ ] Post-deploy, put a Claude Code pane into copy-mode (wheel-scroll), leave focus anywhere, Quick Dictation — text must land in the Claude Code prompt, and the journal must show `TmuxCopyModeGuard: sent 'cancel' to pane <target>`.
- [ ] Control: fresh pane (no copy-mode), Quick Dictation — journal must **not** show any cancel lines and paste proceeds normally.