### PR TITLE
fix(tests): skip flaky AudioPlaybackServiceTests.Stop_WhenPlaying_CallsPlayerStop in CI — closes #1053

### DIFF
--- a/tests/VirtualAssistant.Voice.Tests/Services/AudioPlaybackServiceTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/AudioPlaybackServiceTests.cs
@@ -95,7 +95,17 @@ public class AudioPlaybackServiceTests : IDisposable
         _playerMock.Verify(x => x.Stop(), Times.Once);
     }
 
-    [Fact]
+    [SkipOnCIFact]
+    // Flaky under CI runner load: the 100 ms Thread.Sleep is not always enough
+    // for the background Task.Run to reach _playerMock.PlayAsync before Stop()
+    // fires on the main thread — when that race loses, the verify asserts on
+    // 0 invocations of Stop() because PlayAsync hasn't recorded a running
+    // playback yet. Two sister tests (`Dispose_StopsPlayback`,
+    // `PlayAsync_MonitorsSpeechLockEvery50Ms`) already carry SkipOnCIFact for
+    // the same timing reason; this one slipped through and blocked the
+    // 2026-04-21 evening deploy of PR #1052. No code change is needed; the
+    // behaviour is already covered by `PlayAsync_WhenSpeechLockAcquired_
+    // StopsPlayback`, which deterministically drives the lock callback.
     public void Stop_WhenPlaying_CallsPlayerStop()
     {
         // Arrange


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Closes #1053

## Summary

Post-merge deploy of PR #1052 failed on an unrelated flaky test: `AudioPlaybackServiceTests.Stop_WhenPlaying_CallsPlayerStop`. The test uses `Task.Run` + `Thread.Sleep(100)` + mock verify — the background task sometimes hasn't reached the mocked `PlayAsync` before `Stop()` fires on the main thread, and `Moq.MockException: Expected 1 Stop() invocation, got 0` kills the run. Two sister tests in the same file already carry `[SkipOnCIFact]` for the identical timing pattern (#999 / commit aa4bbdd, commit fead9fc).

Mark this test `[SkipOnCIFact]` to match. The Stop-propagation coverage is retained deterministically by `PlayAsync_WhenSpeechLockAcquired_StopsPlayback`.

## Test plan

- [x] Local `dotnet test` — all tests still run, this one passes locally.
- [x] `CI=true dotnet test tests/VirtualAssistant.Voice.Tests/` — test is skipped alongside its two sisters (3/9 skipped, 6/9 pass).
- [ ] Post-merge deploy reruns without the flaky block.