### PR TITLE
docs(tests): clarify AudioPlaybackService skip comment — address Copilot post-merge review on #1054

### DIFF
--- a/tests/VirtualAssistant.Voice.Tests/Services/AudioPlaybackServiceTests.cs
+++ b/tests/VirtualAssistant.Voice.Tests/Services/AudioPlaybackServiceTests.cs
@@ -103,9 +103,14 @@ public class AudioPlaybackServiceTests : IDisposable
     // playback yet. Two sister tests (`Dispose_StopsPlayback`,
     // `PlayAsync_MonitorsSpeechLockEvery50Ms`) already carry SkipOnCIFact for
     // the same timing reason; this one slipped through and blocked the
-    // 2026-04-21 evening deploy of PR #1052. No code change is needed; the
-    // behaviour is already covered by `PlayAsync_WhenSpeechLockAcquired_
-    // StopsPlayback`, which deterministically drives the lock callback.
+    // 2026-04-21 evening deploy of PR #1052. No production code change is
+    // needed — but note that the direct-external `_sut.Stop()`-while-playing
+    // path is only exercised by this flaky local test today.
+    // `PlayAsync_WhenSpeechLockAcquired_StopsPlayback` covers an internal Stop
+    // triggered via the speech-lock callback, not an external Stop() call, so
+    // it is NOT equivalent coverage. A future deterministic rewrite (e.g.
+    // gating PlayAsync with a TaskCompletionSource the test controls) should
+    // restore reliable CI coverage for the direct-Stop path.
     public void Stop_WhenPlaying_CallsPlayerStop()
     {
         // Arrange


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Refs #1054 (already merged) — this is a post-merge follow-up so the Copilot review is addressed in tree.

## Summary

Copilot review on PR #1054 landed after the hotfix merged. Two valid comments on the inline skip-explanation:

1. The comment implied `PlayAsync_WhenSpeechLockAcquired_StopsPlayback` covers the same behaviour. It does not — that test exercises an **internal** Stop triggered via the speech-lock callback, not an external `_sut.Stop()` call. Corrected wording + flagged that the direct-Stop path now only has local (flaky) coverage until a deterministic rewrite lands.
2. The identifier `PlayAsync_WhenSpeechLockAcquired_StopsPlayback` was split across two comment lines after the trailing underscore, breaking grep. Collapsed onto one line.

Comment-only; no test behaviour affected.

## Test plan

- [x] `dotnet build` — 0 errors.
- [x] Identifier `grep -r "PlayAsync_WhenSpeechLockAcquired_StopsPlayback"` finds both the method and the comment reference.