### PR TITLE
fix(dictation): detect Claude Code via process-tree/tmux in focus router

### DIFF
--- a/src/VirtualAssistant.Core/WindowManagement/ITerminalAgentIdentifier.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/ITerminalAgentIdentifier.cs
@@ -1,0 +1,33 @@
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <summary>
+/// Identifies the known CLI agent (Claude Code, OpenCode, Gemini CLI) running
+/// inside a given terminal window. Combines the three signals that can betray
+/// an agent in a terminal:
+/// <list type="number">
+/// <item>window title markers (fast, but fails when tmux/terminator does not
+/// propagate the TUI title to the outer X11 window — e.g. terminator titled
+/// <c>/bin/bash</c> even though <c>claude</c> is running under a tmux session);</item>
+/// <item>process-tree descendants of the terminal PID (catches <c>claude</c>
+/// launched directly as a child of the terminal);</item>
+/// <item>tmux session names attached to a descendant tmux client (catches
+/// wrapper-spawned <c>claude-&lt;repo&gt;-&lt;tty&gt;</c> sessions whose server is
+/// systemd-scoped and therefore outside the terminal's descendant tree).</item>
+/// </list>
+/// Both <c>TerminalCliAppDetector</c> (focused-window detection for the
+/// notifications / civility-trim paths) and <c>DictationFocusRouter</c>
+/// (per-window scan for Quick Dictation auto-focus) share this service so the
+/// two code paths cannot drift: anywhere we decide whether a terminal hosts
+/// Claude Code, we decide the same way.
+/// </summary>
+public interface ITerminalAgentIdentifier
+{
+    /// <summary>
+    /// Returns the known agent running in the terminal whose outer window has
+    /// the given <paramref name="title"/> and PID <paramref name="terminalPid"/>,
+    /// or null if no known agent is detected. The caller is responsible for
+    /// having already confirmed that the window is a terminal (typically via
+    /// WmClass); this method makes no WmClass check of its own.
+    /// </summary>
+    Task<KnownAgent?> IdentifyAsync(string? title, int terminalPid, CancellationToken cancellationToken);
+}

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalAgentIdentifier.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalAgentIdentifier.cs
@@ -1,0 +1,174 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <inheritdoc />
+public sealed class TerminalAgentIdentifier : ITerminalAgentIdentifier
+{
+    private readonly ILogger<TerminalAgentIdentifier> _logger;
+    private readonly ITmuxCliAppMatcher _tmuxMatcher;
+
+    public TerminalAgentIdentifier(
+        ILogger<TerminalAgentIdentifier> logger,
+        ITmuxCliAppMatcher tmuxMatcher)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _tmuxMatcher = tmuxMatcher ?? throw new ArgumentNullException(nameof(tmuxMatcher));
+    }
+
+    /// <inheritdoc />
+    public async Task<KnownAgent?> IdentifyAsync(string? title, int terminalPid, CancellationToken cancellationToken)
+    {
+        // Order: process-tree → title → tmux session. Process-tree is the
+        // strongest signal (the actual process is literally running under us),
+        // title is cheapest when it works, tmux is the fallback for
+        // systemd-scoped wrapper sessions.
+        var descendantPids = await GetDescendantProcessesAsync(terminalPid, cancellationToken);
+
+        foreach (var agent in CliAgentRegistry.KnownAgents)
+        {
+            if (await IsProcessAmongPidsAsync(agent.ProcessName, descendantPids, cancellationToken))
+            {
+                _logger.LogInformation(
+                    "Detected CLI app in terminal (pid {Pid}): {AppName} (process: {ProcessName})",
+                    terminalPid, agent.AppName, agent.ProcessName);
+                return agent;
+            }
+        }
+
+        if (CliAgentRegistry.FindByTitle(title) is { } titleMatch)
+        {
+            _logger.LogInformation(
+                "Detected CLI app by terminal title: {AppName} (title: '{Title}')",
+                titleMatch.AppName, title);
+            return titleMatch;
+        }
+
+        if (await _tmuxMatcher.MatchAsync(descendantPids, cancellationToken) is { } tmuxMatch)
+        {
+            // TmuxCliAppMatcher already logs the session name — we only need
+            // to map its CliAppDetectionResult back to the KnownAgent record
+            // so callers get the same type regardless of detection path.
+            return CliAgentRegistry.KnownAgents.FirstOrDefault(a =>
+                string.Equals(a.AppName, tmuxMatch.AppName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// BFS walk of the process tree rooted at <paramref name="parentPid"/>.
+    /// Each level spawns one <c>pgrep -P</c>, so cost scales with depth, not
+    /// breadth — a terminator running a shell running tmux running claude is
+    /// typically ~4 levels.
+    /// </summary>
+    private async Task<HashSet<int>> GetDescendantProcessesAsync(int parentPid, CancellationToken cancellationToken)
+    {
+        var descendants = new HashSet<int>();
+        var toProcess = new Queue<int>();
+        toProcess.Enqueue(parentPid);
+
+        while (toProcess.Count > 0)
+        {
+            var currentPid = toProcess.Dequeue();
+            var children = await GetChildPidsAsync(currentPid, cancellationToken);
+
+            foreach (var childPid in children)
+            {
+                if (descendants.Add(childPid))
+                    toProcess.Enqueue(childPid);
+            }
+        }
+
+        return descendants;
+    }
+
+    private async Task<List<int>> GetChildPidsAsync(int parentPid, CancellationToken cancellationToken)
+    {
+        var children = new List<int>();
+
+        try
+        {
+            var output = await RunPgrepAsync($"-P {parentPid}", cancellationToken);
+            if (output is null) return children;
+
+            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (int.TryParse(line.Trim(), out var pid))
+                    children.Add(pid);
+            }
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to get child PIDs for {ParentPid}", parentPid);
+        }
+
+        return children;
+    }
+
+    private async Task<bool> IsProcessAmongPidsAsync(string processName, HashSet<int> pids, CancellationToken cancellationToken)
+    {
+        if (pids.Count == 0) return false;
+
+        try
+        {
+            var output = await RunPgrepAsync($"-x {processName}", cancellationToken);
+            if (output is null) return false;
+
+            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (int.TryParse(line.Trim(), out var pid) && pids.Contains(pid))
+                {
+                    _logger.LogDebug("Found {ProcessName} (PID: {Pid}) among terminal descendants", processName, pid);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to check if process '{ProcessName}' is among PIDs", processName);
+            return false;
+        }
+    }
+
+    // Spawns pgrep with the given arguments; returns stdout on success or null
+    // if pgrep exits non-zero (no match is exit 1, which is legitimate). Kills
+    // the child on caller cancellation before rethrowing so hotkey spam cannot
+    // accumulate short-lived pgrep processes. Mirrors the safeguard added in
+    // PR #1003 for the original in-detector helper.
+    private static async Task<string?> RunPgrepAsync(string arguments, CancellationToken cancellationToken)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "pgrep",
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+
+        process.Start();
+        string output;
+        try
+        {
+            output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { }
+            throw;
+        }
+
+        return process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output) ? output : null;
+    }
+}

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalAgentIdentifier.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalAgentIdentifier.cs
@@ -20,6 +20,11 @@ public sealed class TerminalAgentIdentifier : ITerminalAgentIdentifier
     /// <inheritdoc />
     public async Task<KnownAgent?> IdentifyAsync(string? title, int terminalPid, CancellationToken cancellationToken)
     {
+        // Fail fast if the caller has already cancelled — otherwise the
+        // helpers swallow internal failures and we could end up doing real
+        // pgrep work even when the pipeline is tearing down.
+        cancellationToken.ThrowIfCancellationRequested();
+
         // Order: process-tree → title → tmux session. Process-tree is the
         // strongest signal (the actual process is literally running under us),
         // title is cheapest when it works, tmux is the fallback for
@@ -66,11 +71,21 @@ public sealed class TerminalAgentIdentifier : ITerminalAgentIdentifier
     private async Task<HashSet<int>> GetDescendantProcessesAsync(int parentPid, CancellationToken cancellationToken)
     {
         var descendants = new HashSet<int>();
+
+        // pgrep -P 0 matches every process that has been reparented to init,
+        // i.e. a sizeable slice of the whole system. A WindowInfo with Pid 0
+        // (or negative, from a future DTO change) would make us BFS that whole
+        // tree and peg CPU during a Quick Dictation trigger — the very hot
+        // path the router wants to stay snappy.
+        if (parentPid <= 0) return descendants;
+
         var toProcess = new Queue<int>();
         toProcess.Enqueue(parentPid);
 
         while (toProcess.Count > 0)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var currentPid = toProcess.Dequeue();
             var children = await GetChildPidsAsync(currentPid, cancellationToken);
 

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalCliAppDetector.cs
@@ -1,46 +1,33 @@
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
 
 /// <summary>
 /// Detects CLI applications (Claude Code, OpenCode, Gemini CLI) running inside
-/// the currently focused terminal. The class now delegates the three detection
-/// strategies to focused collaborators:
+/// the currently focused terminal. Responsibilities are limited to the
+/// focused-window path:
 /// <list type="bullet">
 /// <item><see cref="IGdbusWindowDetector"/> — resolves the focused window via GNOME Shell.</item>
 /// <item><see cref="CliAppDetectionCache"/> — serves the last successful result during transient gdbus failures.</item>
-/// <item><see cref="ITmuxCliAppMatcher"/> — matches tmux session names when the CLI app is outside the focused terminal's descendant tree.</item>
+/// <item><see cref="ITerminalAgentIdentifier"/> — runs the three-way (process-tree / title / tmux) agent identification, shared with the dictation focus router.</item>
 /// </list>
-/// Process-tree + title-marker matching live inline — both are small and share
-/// the <see cref="CliAgentRegistry"/> shortlist used by the tmux matcher.
 /// </summary>
 public class TerminalCliAppDetector : ICliAppDetector
 {
-    /// <summary>
-    /// Terminal window classes that we know how to detect CLI apps in.
-    /// </summary>
-    private static readonly HashSet<string> TerminalClasses = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "kitty", "gnome-terminal", "gnome-terminal-server", "org.gnome.Terminal",
-        "konsole", "xfce4-terminal", "mate-terminal", "tilix", "terminator",
-        "alacritty", "wezterm", "foot", "xterm", "urxvt", "st", "terminology",
-    };
-
     private readonly ILogger<TerminalCliAppDetector> _logger;
     private readonly IGdbusWindowDetector _gdbus;
-    private readonly ITmuxCliAppMatcher _tmuxMatcher;
+    private readonly ITerminalAgentIdentifier _identifier;
     private readonly CliAppDetectionCache _cache;
 
     public TerminalCliAppDetector(
         ILogger<TerminalCliAppDetector> logger,
         IGdbusWindowDetector gdbus,
-        ITmuxCliAppMatcher tmuxMatcher,
+        ITerminalAgentIdentifier identifier,
         CliAppDetectionCache cache)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _gdbus = gdbus ?? throw new ArgumentNullException(nameof(gdbus));
-        _tmuxMatcher = tmuxMatcher ?? throw new ArgumentNullException(nameof(tmuxMatcher));
+        _identifier = identifier ?? throw new ArgumentNullException(nameof(identifier));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
     }
 
@@ -54,7 +41,7 @@ public class TerminalCliAppDetector : ICliAppDetector
                 return _cache.TryGet("gdbus probe returned no focused window info");
             }
 
-            if (!TerminalClasses.Contains(focusedWindow.Value.WmClass))
+            if (!TerminalWindowClasses.IsTerminal(focusedWindow.Value.WmClass))
             {
                 _logger.LogDebug("Focused window is not a terminal: {WmClass}", focusedWindow.Value.WmClass);
                 // Confirmed non-terminal focus: invalidate cache so a later gdbus
@@ -66,23 +53,22 @@ public class TerminalCliAppDetector : ICliAppDetector
             _logger.LogDebug("Terminal detected: {WmClass} (PID: {Pid}), checking for CLI apps...",
                 focusedWindow.Value.WmClass, focusedWindow.Value.Pid);
 
-            var descendantPids = await GetDescendantProcessesAsync(focusedWindow.Value.Pid, cancellationToken);
-            _logger.LogDebug("Found {Count} descendant processes for terminal PID {Pid}",
-                descendantPids.Count, focusedWindow.Value.Pid);
+            var agent = await _identifier.IdentifyAsync(
+                focusedWindow.Value.Title,
+                focusedWindow.Value.Pid,
+                cancellationToken);
 
-            if (await MatchByProcessTreeAsync(descendantPids, cancellationToken) is { } processMatch)
-                return CacheAndReturn(processMatch);
+            if (agent is null)
+            {
+                _logger.LogDebug("No known CLI apps detected in terminal descendants, title or tmux sessions");
+                // Confirmed terminal without any known CLI app (e.g. plain bash).
+                _cache.Clear();
+                return null;
+            }
 
-            if (MatchByTitle(focusedWindow.Value.Title) is { } titleMatch)
-                return CacheAndReturn(titleMatch);
-
-            if (await _tmuxMatcher.MatchAsync(descendantPids, cancellationToken) is { } tmuxMatch)
-                return CacheAndReturn(tmuxMatch);
-
-            _logger.LogDebug("No known CLI apps detected in terminal descendants, title or tmux sessions");
-            // Confirmed terminal without any known CLI app (e.g. plain bash).
-            _cache.Clear();
-            return null;
+            var result = new CliAppDetectionResult(agent.AppName, agent.PromptFileName);
+            _cache.Set(result);
+            return result;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -93,151 +79,5 @@ public class TerminalCliAppDetector : ICliAppDetector
             _logger.LogWarning(ex, "Error during CLI app detection");
             return _cache.TryGet("unhandled exception during detection");
         }
-    }
-
-    private CliAppDetectionResult CacheAndReturn(CliAppDetectionResult result)
-    {
-        _cache.Set(result);
-        return result;
-    }
-
-    private async Task<CliAppDetectionResult?> MatchByProcessTreeAsync(HashSet<int> descendantPids, CancellationToken cancellationToken)
-    {
-        foreach (var agent in CliAgentRegistry.KnownAgents)
-        {
-            if (await IsProcessAmongPidsAsync(agent.ProcessName, descendantPids, cancellationToken))
-            {
-                _logger.LogInformation("Detected CLI app in terminal: {AppName} (process: {ProcessName})",
-                    agent.AppName, agent.ProcessName);
-                return new CliAppDetectionResult(agent.AppName, agent.PromptFileName);
-            }
-        }
-        return null;
-    }
-
-    private CliAppDetectionResult? MatchByTitle(string? title)
-    {
-        var agent = CliAgentRegistry.FindByTitle(title);
-        if (agent is null) return null;
-
-        _logger.LogInformation(
-            "Detected CLI app by terminal title: {AppName} (title: '{Title}')",
-            agent.AppName, title);
-        return new CliAppDetectionResult(agent.AppName, agent.PromptFileName);
-    }
-
-    /// <summary>
-    /// Walks the process tree rooted at <paramref name="parentPid"/> and returns
-    /// the full descendant PID set. BFS — each iteration spawns one pgrep, so
-    /// depth scales with tree depth, not breadth.
-    /// </summary>
-    private async Task<HashSet<int>> GetDescendantProcessesAsync(int parentPid, CancellationToken cancellationToken)
-    {
-        var descendants = new HashSet<int>();
-        var toProcess = new Queue<int>();
-        toProcess.Enqueue(parentPid);
-
-        while (toProcess.Count > 0)
-        {
-            var currentPid = toProcess.Dequeue();
-            var children = await GetChildPidsAsync(currentPid, cancellationToken);
-
-            foreach (var childPid in children)
-            {
-                if (descendants.Add(childPid))
-                    toProcess.Enqueue(childPid);
-            }
-        }
-
-        return descendants;
-    }
-
-    private async Task<List<int>> GetChildPidsAsync(int parentPid, CancellationToken cancellationToken)
-    {
-        var children = new List<int>();
-
-        try
-        {
-            var output = await RunPgrepAsync($"-P {parentPid}", cancellationToken);
-            if (output is null) return children;
-
-            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-            {
-                if (int.TryParse(line.Trim(), out var pid))
-                    children.Add(pid);
-            }
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to get child PIDs for {ParentPid}", parentPid);
-        }
-
-        return children;
-    }
-
-    private async Task<bool> IsProcessAmongPidsAsync(string processName, HashSet<int> pids, CancellationToken cancellationToken)
-    {
-        if (pids.Count == 0) return false;
-
-        try
-        {
-            var output = await RunPgrepAsync($"-x {processName}", cancellationToken);
-            if (output is null) return false;
-
-            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-            {
-                if (int.TryParse(line.Trim(), out var pid) && pids.Contains(pid))
-                {
-                    _logger.LogDebug("Found {ProcessName} (PID: {Pid}) among terminal descendants", processName, pid);
-                    return true;
-                }
-            }
-
-            return false;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to check if process '{ProcessName}' is among PIDs", processName);
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Spawns pgrep with the given arguments, returns stdout on success or
-    /// null if pgrep exited non-zero (no match is exit 1). Kills the child
-    /// on caller cancellation before re-throwing so hotkey spam cannot
-    /// accumulate short-lived pgrep processes. (Copilot review on PR #1003.)
-    /// </summary>
-    private static async Task<string?> RunPgrepAsync(string arguments, CancellationToken cancellationToken)
-    {
-        using var process = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "pgrep",
-                Arguments = arguments,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            },
-        };
-
-        process.Start();
-        string output;
-        try
-        {
-            output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
-            try { process.Kill(entireProcessTree: true); } catch { }
-            throw;
-        }
-
-        return process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output) ? output : null;
     }
 }

--- a/src/VirtualAssistant.Core/WindowManagement/TerminalWindowClasses.cs
+++ b/src/VirtualAssistant.Core/WindowManagement/TerminalWindowClasses.cs
@@ -1,0 +1,29 @@
+namespace Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+/// <summary>
+/// The WM_CLASS values we recognise as terminal emulators. Shared between
+/// <see cref="TerminalCliAppDetector"/> (focused-window CLI detection) and
+/// <see cref="ITerminalAgentIdentifier"/> callers (e.g. the dictation focus
+/// router) so both paths treat the same set of windows as "terminals" and
+/// we don't have to wonder whether a given emulator is handled in one path
+/// and not the other.
+/// </summary>
+public static class TerminalWindowClasses
+{
+    /// <summary>
+    /// Case-insensitive set of known terminal WmClass values.
+    /// </summary>
+    public static IReadOnlySet<string> All { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "kitty", "gnome-terminal", "gnome-terminal-server", "org.gnome.Terminal",
+        "konsole", "xfce4-terminal", "mate-terminal", "tilix", "terminator",
+        "alacritty", "wezterm", "foot", "xterm", "urxvt", "st", "terminology",
+    };
+
+    /// <summary>
+    /// Returns true if <paramref name="wmClass"/> identifies a terminal emulator
+    /// we know how to inspect. Null or empty WmClass values return false.
+    /// </summary>
+    public static bool IsTerminal(string? wmClass) =>
+        !string.IsNullOrEmpty(wmClass) && All.Contains(wmClass);
+}

--- a/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/VoiceServicesExtensions.cs
@@ -216,6 +216,7 @@ public static class VoiceServicesExtensions
         services.AddSingleton<ITerminalDetector, WaylandTerminalDetector>();
         services.AddSingleton<IGdbusWindowDetector, GdbusWindowDetector>();
         services.AddSingleton<ITmuxCliAppMatcher, TmuxCliAppMatcher>();
+        services.AddSingleton<ITerminalAgentIdentifier, TerminalAgentIdentifier>();
         services.AddSingleton<CliAppDetectionCache>();
         services.AddSingleton<ICliAppDetector, TerminalCliAppDetector>();
         services.AddSingleton<IDotoolProcessRunner, DotoolProcessRunner>();

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationFocusRouter.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationFocusRouter.cs
@@ -21,15 +21,18 @@ public sealed class DictationFocusRouter : IDictationFocusRouter
 
     private readonly IWindowQueryService _windowQuery;
     private readonly IWindowActionService _windowAction;
+    private readonly ITerminalAgentIdentifier _terminalAgentIdentifier;
     private readonly ILogger<DictationFocusRouter> _logger;
 
     public DictationFocusRouter(
         IWindowQueryService windowQuery,
         IWindowActionService windowAction,
+        ITerminalAgentIdentifier terminalAgentIdentifier,
         ILogger<DictationFocusRouter> logger)
     {
         _windowQuery = windowQuery ?? throw new ArgumentNullException(nameof(windowQuery));
         _windowAction = windowAction ?? throw new ArgumentNullException(nameof(windowAction));
+        _terminalAgentIdentifier = terminalAgentIdentifier ?? throw new ArgumentNullException(nameof(terminalAgentIdentifier));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -69,13 +72,25 @@ public sealed class DictationFocusRouter : IDictationFocusRouter
             return false;
         }
 
-        if (IsClaudeCode(focused))
+        if (await IsClaudeCodeAsync(focused, cancellationToken))
         {
             // Already on the right target — nothing to do.
             return false;
         }
 
-        var claudeWindows = currentWorkspace.Where(IsClaudeCode).ToList();
+        // Identify Claude Code candidates on this workspace. We walk every
+        // window (not just the focused one) because the whole point of the
+        // router is to move focus TO a Claude Code window somewhere else on
+        // the workspace.
+        var claudeWindows = new List<WindowInfo>();
+        foreach (var candidate in currentWorkspace)
+        {
+            if (await IsClaudeCodeAsync(candidate, cancellationToken))
+            {
+                claudeWindows.Add(candidate);
+            }
+        }
+
         if (claudeWindows.Count != 1)
         {
             // 0 → nothing to route to; 2+ → ambiguous, leave focus alone.
@@ -114,11 +129,49 @@ public sealed class DictationFocusRouter : IDictationFocusRouter
         }
     }
 
-    private static bool IsClaudeCode(WindowInfo w) =>
-        string.Equals(
-            CliAgentRegistry.FindByTitle(w.Title)?.AppName,
-            "Claude Code",
-            StringComparison.OrdinalIgnoreCase);
+    /// <summary>
+    /// Checks whether a window is hosting Claude Code. Cheap path first
+    /// (outer title contains a Claude Code marker — works for Alacritty and
+    /// for terminators whose tmux propagates titles); if that misses and the
+    /// window is a known terminal, fall through to the full identifier so a
+    /// terminator hosting <c>tmux → claude</c> with an un-propagated
+    /// <c>/bin/bash</c> title is still recognised. Non-terminal windows that
+    /// don't match by title are rejected without any pgrep work.
+    /// </summary>
+    private async Task<bool> IsClaudeCodeAsync(WindowInfo window, CancellationToken cancellationToken)
+    {
+        if (string.Equals(
+                CliAgentRegistry.FindByTitle(window.Title)?.AppName,
+                "Claude Code",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!TerminalWindowClasses.IsTerminal(window.WmClass))
+        {
+            return false;
+        }
+
+        try
+        {
+            var agent = await _terminalAgentIdentifier.IdentifyAsync(
+                window.Title, window.Pid, cancellationToken);
+            return string.Equals(agent?.AppName, "Claude Code", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Focus router: agent identification failed for window {Id} ({WmClass}), treating as non-Claude",
+                window.Id, window.WmClass);
+            return false;
+        }
+    }
 
     private static bool IsGnomeTextEditor(WindowInfo w) =>
         string.Equals(w.WmClass, GnomeTextEditorWmClass, StringComparison.OrdinalIgnoreCase);

--- a/src/VirtualAssistant.Service/Workers/Dictation/DictationFocusRouter.cs
+++ b/src/VirtualAssistant.Service/Workers/Dictation/DictationFocusRouter.cs
@@ -78,16 +78,26 @@ public sealed class DictationFocusRouter : IDictationFocusRouter
             return false;
         }
 
-        // Identify Claude Code candidates on this workspace. We walk every
-        // window (not just the focused one) because the whole point of the
-        // router is to move focus TO a Claude Code window somewhere else on
-        // the workspace.
+        // Scan non-focused windows for Claude Code candidates. The focused
+        // window was already checked above (and we know it is not Claude),
+        // so reprobing would waste a pgrep tree walk per loop. Break as soon
+        // as a second candidate turns up — 2+ is unconditionally ambiguous
+        // below, no point probing further.
         var claudeWindows = new List<WindowInfo>();
         foreach (var candidate in currentWorkspace)
         {
+            if (candidate.Id == focused.Id)
+            {
+                continue;
+            }
+
             if (await IsClaudeCodeAsync(candidate, cancellationToken))
             {
                 claudeWindows.Add(candidate);
+                if (claudeWindows.Count > 1)
+                {
+                    break;
+                }
             }
         }
 

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalAgentIdentifierTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalAgentIdentifierTests.cs
@@ -92,6 +92,35 @@ public class TerminalAgentIdentifierTests
     }
 
     [Fact]
+    public async Task Identify_ZeroPid_TitleMatchStillWorks()
+    {
+        // A WindowInfo whose Pid is 0 (toolkit didn't expose one) must not
+        // trigger `pgrep -P 0` — that would scan every reparented init
+        // descendant and peg CPU. Title-marker fallback still runs.
+        var agent = await CreateSut().IdentifyAsync(
+            "Claude Code — ~/project",
+            terminalPid: 0,
+            CancellationToken.None);
+
+        Assert.NotNull(agent);
+        Assert.Equal("Claude Code", agent!.AppName);
+    }
+
+    [Fact]
+    public async Task Identify_NegativePid_ReturnsNullWhenNoTitleMatch()
+    {
+        // Defensive guard against a future DTO change that might hand us a
+        // negative PID. Same reasoning as pid 0: skip the BFS and fall
+        // through to the remaining (pid-free) signals.
+        var agent = await CreateSut().IdentifyAsync(
+            "/bin/bash",
+            terminalPid: -42,
+            CancellationToken.None);
+
+        Assert.Null(agent);
+    }
+
+    [Fact]
     public void Ctor_NullLogger_Throws() =>
         Assert.Throws<ArgumentNullException>(() =>
             new TerminalAgentIdentifier(null!, _tmuxMatcherMock.Object));

--- a/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalAgentIdentifierTests.cs
+++ b/tests/VirtualAssistant.Core.Tests/WindowManagement/TerminalAgentIdentifierTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
+
+namespace Olbrasoft.VirtualAssistant.Core.Tests.WindowManagement;
+
+/// <summary>
+/// Unit tests cover the non-pgrep paths of <see cref="TerminalAgentIdentifier"/>:
+/// title-marker match and null fallthrough. The process-tree path spawns
+/// <c>pgrep -P</c> against live PIDs, so we point it at a PID that is
+/// guaranteed not to exist — <c>pgrep</c> exits 1, the descendant set stays
+/// empty, and the tmux matcher short-circuits on an empty set. That lets
+/// us isolate title-match and no-match behaviour without depending on the
+/// host's process list. The full three-way fallback is exercised manually
+/// on the live system (same convention as the cache-only tests that cover
+/// <see cref="TerminalCliAppDetector"/>).
+/// </summary>
+public class TerminalAgentIdentifierTests
+{
+    // pgrep -P <huge pid> exits 1 with no output, so GetDescendantProcessesAsync
+    // returns an empty set deterministically — regardless of what the host is
+    // actually running.
+    private const int NonexistentPid = 999_999_999;
+
+    private readonly Mock<ILogger<TerminalAgentIdentifier>> _loggerMock = new();
+    private readonly Mock<ITmuxCliAppMatcher> _tmuxMatcherMock = new();
+
+    private TerminalAgentIdentifier CreateSut() =>
+        new(_loggerMock.Object, _tmuxMatcherMock.Object);
+
+    [Fact]
+    public async Task Identify_TitleContainsClaudeCode_ReturnsClaudeCodeAgent()
+    {
+        // No descendants → process-tree match fails → title path runs and
+        // matches the "Claude Code" marker. The tmux matcher is never asked
+        // because an empty descendant set already short-circuits it.
+        var agent = await CreateSut().IdentifyAsync(
+            "Claude Code — ~/project",
+            NonexistentPid,
+            CancellationToken.None);
+
+        Assert.NotNull(agent);
+        Assert.Equal("Claude Code", agent!.AppName);
+    }
+
+    [Fact]
+    public async Task Identify_TitleContainsOpenCode_ReturnsOpenCodeAgent()
+    {
+        var agent = await CreateSut().IdentifyAsync(
+            "OC | ~/project",
+            NonexistentPid,
+            CancellationToken.None);
+
+        Assert.NotNull(agent);
+        Assert.Equal("OpenCode", agent!.AppName);
+    }
+
+    [Fact]
+    public async Task Identify_TitleBash_NoTmuxMatch_ReturnsNull()
+    {
+        _tmuxMatcherMock
+            .Setup(x => x.MatchAsync(It.IsAny<IReadOnlySet<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CliAppDetectionResult?)null);
+
+        var agent = await CreateSut().IdentifyAsync(
+            "/bin/bash",
+            NonexistentPid,
+            CancellationToken.None);
+
+        Assert.Null(agent);
+    }
+
+    [Fact]
+    public async Task Identify_NullTitle_NoDescendants_ReturnsNull()
+    {
+        var agent = await CreateSut().IdentifyAsync(
+            null,
+            NonexistentPid,
+            CancellationToken.None);
+
+        Assert.Null(agent);
+    }
+
+    [Fact]
+    public async Task Identify_CancellationRequested_Propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => CreateSut().IdentifyAsync("/bin/bash", NonexistentPid, cts.Token));
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new TerminalAgentIdentifier(null!, _tmuxMatcherMock.Object));
+
+    [Fact]
+    public void Ctor_NullTmuxMatcher_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new TerminalAgentIdentifier(_loggerMock.Object, null!));
+}

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationFocusRouterTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationFocusRouterTests.cs
@@ -315,6 +315,56 @@ public class DictationFocusRouterTests
     }
 
     [Fact]
+    public async Task TryFocus_FocusedTerminatorNotClaude_IdentifierProbedOnce()
+    {
+        // Performance guard: when the focused window is a terminal (so the
+        // "already on Claude?" check calls the identifier), the subsequent
+        // candidate scan must not probe the focused window a second time —
+        // a redundant process-tree walk on the hot path.
+        var focusedTerm = MakeWindow(99, "terminator", "/bin/bash", hasFocus: true, pid: 4000);
+        var otherTerm = MakeWindow(101, "terminator", "/bin/bash", pid: 5000);
+        SetupWindows(focusedTerm, otherTerm);
+        SetupIdentifierReturns(focusedTerm.Pid, agent: null);
+        SetupIdentifierReturns(otherTerm.Pid, ClaudeCodeAgent);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.True(switched);
+        _terminalAgentIdentifierMock.Verify(
+            x => x.IdentifyAsync(It.IsAny<string?>(), focusedTerm.Pid, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _windowActionMock.Verify(
+            x => x.ActivateWindowAsync(otherTerm.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryFocus_MultipleClaudeTerminators_ShortCircuitsAfterSecond()
+    {
+        // Once two Claude candidates are found, the outcome is already
+        // "ambiguous, skip" — the loop must break before probing the rest
+        // so a workspace with many terminators stays cheap.
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true, pid: 6000);
+        var claude1 = MakeWindow(101, "terminator", "/bin/bash", pid: 5000);
+        var claude2 = MakeWindow(102, "terminator", "/bin/bash", pid: 5001);
+        var claude3 = MakeWindow(103, "terminator", "/bin/bash", pid: 5002);
+        SetupWindows(browser, claude1, claude2, claude3);
+        SetupIdentifierReturns(claude1.Pid, ClaudeCodeAgent);
+        SetupIdentifierReturns(claude2.Pid, ClaudeCodeAgent);
+        SetupIdentifierReturns(claude3.Pid, ClaudeCodeAgent);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _terminalAgentIdentifierMock.Verify(
+            x => x.IdentifyAsync(It.IsAny<string?>(), claude3.Pid, It.IsAny<CancellationToken>()),
+            Times.Never);
+        _windowActionMock.Verify(
+            x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task TryFocus_IdentifierCancelled_Propagates()
     {
         var terminator = MakeWindow(101, "terminator", "/bin/bash", pid: 5000);

--- a/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationFocusRouterTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Workers/Dictation/DictationFocusRouterTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Olbrasoft.LinuxDesktop.Core.Models;
 using Olbrasoft.LinuxDesktop.Core.Services;
+using Olbrasoft.VirtualAssistant.Core.WindowManagement;
 using Olbrasoft.VirtualAssistant.Service.Workers.Dictation;
 
 namespace Olbrasoft.VirtualAssistant.Service.Tests.Workers.Dictation;
@@ -17,17 +18,32 @@ public class DictationFocusRouterTests
 {
     private readonly Mock<IWindowQueryService> _windowQueryMock = new();
     private readonly Mock<IWindowActionService> _windowActionMock = new();
+    private readonly Mock<ITerminalAgentIdentifier> _terminalAgentIdentifierMock = new();
     private readonly Mock<ILogger<DictationFocusRouter>> _loggerMock = new();
 
     private DictationFocusRouter CreateSut() =>
-        new(_windowQueryMock.Object, _windowActionMock.Object, _loggerMock.Object);
+        new(_windowQueryMock.Object,
+            _windowActionMock.Object,
+            _terminalAgentIdentifierMock.Object,
+            _loggerMock.Object);
+
+    private static readonly KnownAgent ClaudeCodeAgent = CliAgentRegistry.KnownAgents
+        .First(a => a.AppName == "Claude Code");
+
+    private void SetupIdentifierReturns(int pid, KnownAgent? agent)
+    {
+        _terminalAgentIdentifierMock
+            .Setup(x => x.IdentifyAsync(It.IsAny<string?>(), pid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+    }
 
     private static WindowInfo MakeWindow(
         uint id,
         string wmClass,
         string title,
         bool inCurrentWorkspace = true,
-        bool hasFocus = false)
+        bool hasFocus = false,
+        int pid = 0)
     {
         // LinuxDesktop.Core.Models.WindowInfo is init-only with a sizeable
         // surface. Tests only care about the fields the router inspects, so
@@ -38,7 +54,7 @@ public class DictationFocusRouterTests
             WmClass = wmClass,
             WmClassInstance = wmClass,
             Title = title,
-            Pid = 0,
+            Pid = pid,
             InCurrentWorkspace = inCurrentWorkspace,
             HasFocus = hasFocus,
             FrameType = 0,
@@ -194,17 +210,141 @@ public class DictationFocusRouterTests
     }
 
     [Fact]
+    public async Task TryFocus_TerminatorWithShellTitleHostsClaudeInTmux_Activates()
+    {
+        // The real-world regression from #1056: terminator window shows title
+        // "/bin/bash" because tmux does not propagate the Ink TUI title, but
+        // a `claude` process (or `claude-*` tmux session) lives under its
+        // PID. Title match fails → the identifier's process-tree / tmux path
+        // must pick it up so the router still recognises Claude Code on this
+        // workspace.
+        var terminator = MakeWindow(
+            id: 101,
+            wmClass: "terminator",
+            title: "/bin/bash",
+            hasFocus: false,
+            pid: 5000);
+        var browser = MakeWindow(
+            id: 7,
+            wmClass: "Google-chrome",
+            title: "Seznam – Edge",
+            hasFocus: true,
+            pid: 6000);
+        SetupWindows(terminator, browser);
+        SetupIdentifierReturns(terminator.Pid, ClaudeCodeAgent);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.True(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(101u, It.IsAny<CancellationToken>()), Times.Once);
+        _terminalAgentIdentifierMock.Verify(
+            x => x.IdentifyAsync("/bin/bash", terminator.Pid, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task TryFocus_TerminatorShellTitle_NoClaudeProcess_Skips()
+    {
+        // A terminator showing "/bin/bash" with nothing interesting under it
+        // must NOT be treated as a Claude Code host — the identifier returns
+        // null and the router falls through.
+        var terminator = MakeWindow(101, "terminator", "/bin/bash", hasFocus: false, pid: 5000);
+        var browser = MakeWindow(7, "Google-chrome", "Seznam – Edge", hasFocus: true, pid: 6000);
+        SetupWindows(terminator, browser);
+        SetupIdentifierReturns(terminator.Pid, null);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_TitleAlreadyMatches_SkipsIdentifierProbe()
+    {
+        // Performance guard: when the terminal's outer title already contains
+        // "Claude Code" (ws=3 in the user's setup), the router must not run
+        // the pgrep-based identifier. Keeps the hot path cheap.
+        var alacritty = MakeWindow(42, "Alacritty", "Claude Code — ~/project", pid: 5000);
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true, pid: 6000);
+        SetupWindows(alacritty, browser);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.True(switched);
+        _terminalAgentIdentifierMock.Verify(
+            x => x.IdentifyAsync(It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_NonTerminalWithoutTitleMatch_SkipsIdentifierProbe()
+    {
+        // A Chrome window titled "My notes" is not a terminal and its title
+        // doesn't match — the router must reject it without calling into the
+        // process-tree code (which would waste pgrep cycles on a browser).
+        var browser1 = MakeWindow(7, "Google-chrome", "My notes", hasFocus: true, pid: 6000);
+        var browser2 = MakeWindow(8, "Google-chrome", "Another tab", pid: 6001);
+        SetupWindows(browser1, browser2);
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _terminalAgentIdentifierMock.Verify(
+            x => x.IdentifyAsync(It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_IdentifierThrows_TreatsWindowAsNonClaude()
+    {
+        // Identifier failures (pgrep missing, process disappeared mid-walk)
+        // must never kill the router. The window is logged as non-Claude and
+        // paste falls through to the currently-focused window.
+        var terminator = MakeWindow(101, "terminator", "/bin/bash", pid: 5000);
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true, pid: 6000);
+        SetupWindows(terminator, browser);
+        _terminalAgentIdentifierMock
+            .Setup(x => x.IdentifyAsync(It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("pgrep failed"));
+
+        var switched = await CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None);
+
+        Assert.False(switched);
+        _windowActionMock.Verify(x => x.ActivateWindowAsync(It.IsAny<uint>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryFocus_IdentifierCancelled_Propagates()
+    {
+        var terminator = MakeWindow(101, "terminator", "/bin/bash", pid: 5000);
+        var browser = MakeWindow(7, "Google-chrome", "Browser", hasFocus: true, pid: 6000);
+        SetupWindows(terminator, browser);
+        _terminalAgentIdentifierMock
+            .Setup(x => x.IdentifyAsync(It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => CreateSut().TryFocusClaudeCodeIfApplicableAsync(CancellationToken.None));
+    }
+
+    [Fact]
     public void Ctor_NullWindowQuery_Throws() =>
         Assert.Throws<ArgumentNullException>(() =>
-            new DictationFocusRouter(null!, _windowActionMock.Object, _loggerMock.Object));
+            new DictationFocusRouter(null!, _windowActionMock.Object, _terminalAgentIdentifierMock.Object, _loggerMock.Object));
 
     [Fact]
     public void Ctor_NullWindowAction_Throws() =>
         Assert.Throws<ArgumentNullException>(() =>
-            new DictationFocusRouter(_windowQueryMock.Object, null!, _loggerMock.Object));
+            new DictationFocusRouter(_windowQueryMock.Object, null!, _terminalAgentIdentifierMock.Object, _loggerMock.Object));
+
+    [Fact]
+    public void Ctor_NullTerminalAgentIdentifier_Throws() =>
+        Assert.Throws<ArgumentNullException>(() =>
+            new DictationFocusRouter(_windowQueryMock.Object, _windowActionMock.Object, null!, _loggerMock.Object));
 
     [Fact]
     public void Ctor_NullLogger_Throws() =>
         Assert.Throws<ArgumentNullException>(() =>
-            new DictationFocusRouter(_windowQueryMock.Object, _windowActionMock.Object, null!));
+            new DictationFocusRouter(_windowQueryMock.Object, _windowActionMock.Object, _terminalAgentIdentifierMock.Object, null!));
 }


### PR DESCRIPTION
<!-- claude-session: 22068916-af2d-49da-8017-609ff548e677 -->

Refs #1056

## Summary

Quick Dictation auto-focus (PR #1046) missed every terminator window whose tmux wrapper didn't propagate the Ink TUI title, so `terminator "/bin/bash"` with `claude` running under tmux never triggered the focus switch. This PR makes the router use the same three-signal (process-tree + title + tmux session) detection already used by the notifications path.

## Root cause

`DictationFocusRouter.IsClaudeCode` relied solely on `CliAgentRegistry.FindByTitle(w.Title)`. On the user's machine several terminators show title `/bin/bash` (no title propagation from tmux → terminator), so `claudeWindows.Count == 0` and the router silently skipped.

## Change

1. New `ITerminalAgentIdentifier` in `VirtualAssistant.Core.WindowManagement` that, given `(title, terminalPid)`, runs the process-tree → title → tmux-session cascade and returns the `KnownAgent` (or null).
2. `TerminalCliAppDetector` refactored to delegate to the identifier (keeps its focused-window + cache role).
3. `DictationFocusRouter` uses the identifier per terminal window on the current workspace. Non-terminal windows and windows whose outer title already matches stay pgrep-free.
4. Shared `TerminalWindowClasses` so the two paths agree on what counts as a terminal.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test --filter 'FullyQualifiedName!~IntegrationTests'` → all green (185 Core incl. 7 new identifier tests, 457 Service incl. 7 new router tests, 338 Voice)
- [ ] Post-deploy live check: press Remote Control → Diktovat → Rychle while focused on Edge on a workspace that contains exactly one terminator running `tmux → claude` (title `/bin/bash`). Expect the terminator to receive focus and the prompt to land in Claude Code.
- [ ] Confirm 0-Claude, 2+ Claude, and focus-on-Text-Editor cases still skip the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)