### PR TITLE
fix: Address Copilot review on #1063 - XSS hardening + controller tests

### DIFF
--- a/src/VirtualAssistant.Service/Controllers/TtsController.cs
+++ b/src/VirtualAssistant.Service/Controllers/TtsController.cs
@@ -16,12 +16,15 @@ public class TtsController : ControllerBase
 {
     private readonly ILogger<TtsController> _logger;
     private readonly string _piperModelPath;
+    private readonly IKeysUsageReporter _keysUsageReporter;
 
     public TtsController(
         ILogger<TtsController> logger,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        IKeysUsageReporter keysUsageReporter)
     {
         _logger = logger;
+        _keysUsageReporter = keysUsageReporter;
 
         // Piper model path - resolve relative path
         var piperPath = configuration["TTS:Piper:ModelPath"] ?? "piper-voices/cs/cs_CZ-jirka-medium.onnx";
@@ -39,10 +42,9 @@ public class TtsController : ControllerBase
     /// failure counts). Used by the /Admin/Tts dashboard for live polling.
     /// </summary>
     [HttpGet("keys-usage")]
-    public ActionResult<IReadOnlyList<TtsKeyUsageDto>> GetKeysUsage(
-        [FromServices] IKeysUsageReporter reporter)
+    public ActionResult<IReadOnlyList<TtsKeyUsageDto>> GetKeysUsage()
     {
-        var snapshots = reporter.GetKeysUsage();
+        var snapshots = _keysUsageReporter.GetKeysUsage();
         var dtos = snapshots.Select(s => new TtsKeyUsageDto
         {
             Index = s.Index,

--- a/src/VirtualAssistant.Service/Controllers/TtsController.cs
+++ b/src/VirtualAssistant.Service/Controllers/TtsController.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
-using Olbrasoft.TextToSpeech.Providers.GoogleCloud;
+using Olbrasoft.VirtualAssistant.Service.Infrastructure;
 
 namespace Olbrasoft.VirtualAssistant.Service.Controllers;
 
@@ -40,9 +40,9 @@ public class TtsController : ControllerBase
     /// </summary>
     [HttpGet("keys-usage")]
     public ActionResult<IReadOnlyList<TtsKeyUsageDto>> GetKeysUsage(
-        [FromServices] GoogleCloudMultiKeyTtsProvider provider)
+        [FromServices] IKeysUsageReporter reporter)
     {
-        var snapshots = provider.GetKeysUsage();
+        var snapshots = reporter.GetKeysUsage();
         var dtos = snapshots.Select(s => new TtsKeyUsageDto
         {
             Index = s.Index,

--- a/src/VirtualAssistant.Service/Extensions/TtsServicesExtensions.cs
+++ b/src/VirtualAssistant.Service/Extensions/TtsServicesExtensions.cs
@@ -74,6 +74,7 @@ public static class TtsServicesExtensions
 
         services.AddSingleton<GoogleCloudMultiKeyTtsProvider>();
         services.AddSingleton<ITtsProvider>(sp => sp.GetRequiredService<GoogleCloudMultiKeyTtsProvider>());
+        services.AddSingleton<IKeysUsageReporter, GoogleCloudKeysUsageReporter>();
 
         // Register Piper provider (separate package)
         services.AddPiperTts(configuration);

--- a/src/VirtualAssistant.Service/Infrastructure/GoogleCloudKeysUsageReporter.cs
+++ b/src/VirtualAssistant.Service/Infrastructure/GoogleCloudKeysUsageReporter.cs
@@ -1,0 +1,14 @@
+using Olbrasoft.TextToSpeech.Providers.GoogleCloud;
+
+namespace Olbrasoft.VirtualAssistant.Service.Infrastructure;
+
+/// <summary>
+/// Default <see cref="IKeysUsageReporter"/> implementation that delegates to
+/// the registered <see cref="GoogleCloudMultiKeyTtsProvider"/> singleton.
+/// </summary>
+public sealed class GoogleCloudKeysUsageReporter : IKeysUsageReporter
+{
+    private readonly GoogleCloudMultiKeyTtsProvider _provider;
+    public GoogleCloudKeysUsageReporter(GoogleCloudMultiKeyTtsProvider provider) => _provider = provider;
+    public IReadOnlyList<ApiKeyUsageSnapshot> GetKeysUsage() => _provider.GetKeysUsage();
+}

--- a/src/VirtualAssistant.Service/Infrastructure/IKeysUsageReporter.cs
+++ b/src/VirtualAssistant.Service/Infrastructure/IKeysUsageReporter.cs
@@ -11,14 +11,3 @@ public interface IKeysUsageReporter
 {
     IReadOnlyList<ApiKeyUsageSnapshot> GetKeysUsage();
 }
-
-/// <summary>
-/// Default implementation that delegates to the registered
-/// <see cref="GoogleCloudMultiKeyTtsProvider"/> singleton.
-/// </summary>
-public sealed class GoogleCloudKeysUsageReporter : IKeysUsageReporter
-{
-    private readonly GoogleCloudMultiKeyTtsProvider _provider;
-    public GoogleCloudKeysUsageReporter(GoogleCloudMultiKeyTtsProvider provider) => _provider = provider;
-    public IReadOnlyList<ApiKeyUsageSnapshot> GetKeysUsage() => _provider.GetKeysUsage();
-}

--- a/src/VirtualAssistant.Service/Infrastructure/IKeysUsageReporter.cs
+++ b/src/VirtualAssistant.Service/Infrastructure/IKeysUsageReporter.cs
@@ -1,0 +1,24 @@
+using Olbrasoft.TextToSpeech.Providers.GoogleCloud;
+
+namespace Olbrasoft.VirtualAssistant.Service.Infrastructure;
+
+/// <summary>
+/// Thin abstraction over <see cref="GoogleCloudMultiKeyTtsProvider.GetKeysUsage"/>
+/// so controllers / pages can be unit-tested without instantiating the concrete
+/// (sealed) provider type.
+/// </summary>
+public interface IKeysUsageReporter
+{
+    IReadOnlyList<ApiKeyUsageSnapshot> GetKeysUsage();
+}
+
+/// <summary>
+/// Default implementation that delegates to the registered
+/// <see cref="GoogleCloudMultiKeyTtsProvider"/> singleton.
+/// </summary>
+public sealed class GoogleCloudKeysUsageReporter : IKeysUsageReporter
+{
+    private readonly GoogleCloudMultiKeyTtsProvider _provider;
+    public GoogleCloudKeysUsageReporter(GoogleCloudMultiKeyTtsProvider provider) => _provider = provider;
+    public IReadOnlyList<ApiKeyUsageSnapshot> GetKeysUsage() => _provider.GetKeysUsage();
+}

--- a/src/VirtualAssistant.Service/Pages/Admin/Tts.cshtml
+++ b/src/VirtualAssistant.Service/Pages/Admin/Tts.cshtml
@@ -148,6 +148,7 @@
     .state-MonthlyLimitExceeded { background: rgba(206, 145, 120, 0.18); color: #ce9178; }
     .state-TemporaryError { background: rgba(220, 220, 0, 0.15); color: #d7ba7d; }
     .state-Invalid       { background: rgba(244, 135, 113, 0.18); color: #f48771; }
+    .state-Unknown       { background: rgba(120, 120, 120, 0.18); color: #b0b0b0; }
 
     .meter {
         position: relative;
@@ -250,6 +251,14 @@
         document.getElementById('summary-cap').textContent = cap > 0 ? fmtNum(cap) : 'unlimited';
     }
 
+    // Whitelist of states the server can return. Anything else falls back
+    // to a generic "Unknown" class so an unexpected value can't poison the
+    // CSS class name (defense-in-depth; today the API enum guarantees the set).
+    const KNOWN_STATES = new Set([
+        'Available', 'RateLimited', 'QuotaExceeded',
+        'Invalid', 'TemporaryError', 'MonthlyLimitExceeded'
+    ]);
+
     function renderTable(keys) {
         const tbody = document.getElementById('keys-tbody');
         if (!keys.length) {
@@ -260,27 +269,33 @@
             const failClass = k.consecutiveFailures >= 5 ? 'bad'
                             : k.consecutiveFailures >= 2 ? 'warn'
                             : '';
+            const stateRaw = String(k.state || '');
+            const stateClass = KNOWN_STATES.has(stateRaw) ? stateRaw : 'Unknown';
+            const stateLabel = escapeHtml(stateRaw);
+            const errReason = escapeHtml(k.lastErrorReason || '');
+            const errTime = fmtTime(k.lastErrorUtc); // already a safe formatted string
             const lastErr = k.lastErrorReason
-                ? `<span title="${fmtTime(k.lastErrorUtc)}">${k.lastErrorReason} · ${fmtTime(k.lastErrorUtc)}</span>`
+                ? `<span title="${escapeAttr(errTime)}">${errReason} · ${escapeHtml(errTime)}</span>`
                 : '<span class="muted">—</span>';
             return `
                 <tr>
-                    <td class="muted">#${k.index}</td>
+                    <td class="muted">#${k.index | 0}</td>
                     <td>${escapeHtml(k.name)}</td>
-                    <td><span class="state-badge state-${k.state}">${k.state}</span></td>
+                    <td><span class="state-badge state-${stateClass}">${stateLabel}</span></td>
                     <td>${meterCell(k.monthlyCharacterCount, k.monthlyCharacterLimit)}</td>
                     <td>${fmtNum(k.totalSuccesses)}</td>
                     <td>${fmtNum(k.totalFailures)}</td>
-                    <td class="fail ${failClass}">${k.consecutiveFailures}</td>
-                    <td class="muted">${fmtTime(k.lastSuccessUtc)}</td>
+                    <td class="fail ${failClass}">${k.consecutiveFailures | 0}</td>
+                    <td class="muted">${escapeHtml(fmtTime(k.lastSuccessUtc))}</td>
                     <td>${lastErr}</td>
                 </tr>`;
         }).join('');
     }
 
     function escapeHtml(s) {
-        return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+        return String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
     }
+    function escapeAttr(s) { return escapeHtml(s); }
 
     function start() {
         if (pollingTimer) return;

--- a/tests/VirtualAssistant.Service.Tests/Controllers/TtsControllerKeysUsageTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Controllers/TtsControllerKeysUsageTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.TextToSpeech.Providers.GoogleCloud;
+using Olbrasoft.VirtualAssistant.Service.Controllers;
+using Olbrasoft.VirtualAssistant.Service.Infrastructure;
+
+namespace Olbrasoft.VirtualAssistant.Service.Tests.Controllers;
+
+public class TtsControllerKeysUsageTests
+{
+    private static TtsController CreateController()
+    {
+        var logger = new Mock<ILogger<TtsController>>();
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        return new TtsController(logger.Object, config);
+    }
+
+    [Fact]
+    public void GetKeysUsage_ReturnsOkWithMappedDtos()
+    {
+        var snapshot = new ApiKeyUsageSnapshot
+        {
+            Index = 0,
+            Name = "primary",
+            State = ApiKeyState.Available,
+            CooldownUntilUtc = null,
+            MonthlyCharacterCount = 12_345,
+            MonthlyCharacterLimit = 1_000_000,
+            TotalSuccesses = 100,
+            TotalFailures = 2,
+            ConsecutiveFailures = 0,
+            LastSuccessUtc = new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc),
+            LastErrorUtc = null,
+            LastErrorReason = null
+        };
+        var reporter = new Mock<IKeysUsageReporter>();
+        reporter.Setup(r => r.GetKeysUsage()).Returns(new[] { snapshot });
+
+        var controller = CreateController();
+
+        var result = controller.GetKeysUsage(reporter.Object);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dtos = Assert.IsAssignableFrom<IReadOnlyList<TtsKeyUsageDto>>(ok.Value);
+        var dto = Assert.Single(dtos);
+        Assert.Equal(0, dto.Index);
+        Assert.Equal("primary", dto.Name);
+        Assert.Equal("Available", dto.State);
+        Assert.Equal(12_345, dto.MonthlyCharacterCount);
+        Assert.Equal(1_000_000, dto.MonthlyCharacterLimit);
+        Assert.Equal(100, dto.TotalSuccesses);
+        Assert.Equal(2, dto.TotalFailures);
+        Assert.Equal(0, dto.ConsecutiveFailures);
+        Assert.Equal(snapshot.LastSuccessUtc, dto.LastSuccessUtc);
+        Assert.Null(dto.LastErrorUtc);
+        Assert.Null(dto.LastErrorReason);
+    }
+
+    [Fact]
+    public void GetKeysUsage_RendersAllStateValuesAsString()
+    {
+        var snapshots = new[]
+        {
+            new ApiKeyUsageSnapshot { Index = 0, Name = "k1", State = ApiKeyState.RateLimited },
+            new ApiKeyUsageSnapshot { Index = 1, Name = "k2", State = ApiKeyState.QuotaExceeded },
+            new ApiKeyUsageSnapshot { Index = 2, Name = "k3", State = ApiKeyState.Invalid },
+            new ApiKeyUsageSnapshot { Index = 3, Name = "k4", State = ApiKeyState.MonthlyLimitExceeded }
+        };
+        var reporter = new Mock<IKeysUsageReporter>();
+        reporter.Setup(r => r.GetKeysUsage()).Returns(snapshots);
+
+        var controller = CreateController();
+        var result = controller.GetKeysUsage(reporter.Object);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dtos = Assert.IsAssignableFrom<IReadOnlyList<TtsKeyUsageDto>>(ok.Value);
+        Assert.Collection(dtos,
+            d => Assert.Equal("RateLimited", d.State),
+            d => Assert.Equal("QuotaExceeded", d.State),
+            d => Assert.Equal("Invalid", d.State),
+            d => Assert.Equal("MonthlyLimitExceeded", d.State));
+    }
+
+    [Fact]
+    public void GetKeysUsage_EmptyKeyList_ReturnsEmptyDtoList()
+    {
+        var reporter = new Mock<IKeysUsageReporter>();
+        reporter.Setup(r => r.GetKeysUsage()).Returns(Array.Empty<ApiKeyUsageSnapshot>());
+
+        var controller = CreateController();
+        var result = controller.GetKeysUsage(reporter.Object);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dtos = Assert.IsAssignableFrom<IReadOnlyList<TtsKeyUsageDto>>(ok.Value);
+        Assert.Empty(dtos);
+    }
+}

--- a/tests/VirtualAssistant.Service.Tests/Controllers/TtsControllerKeysUsageTests.cs
+++ b/tests/VirtualAssistant.Service.Tests/Controllers/TtsControllerKeysUsageTests.cs
@@ -10,11 +10,11 @@ namespace Olbrasoft.VirtualAssistant.Service.Tests.Controllers;
 
 public class TtsControllerKeysUsageTests
 {
-    private static TtsController CreateController()
+    private static TtsController CreateController(IKeysUsageReporter reporter)
     {
         var logger = new Mock<ILogger<TtsController>>();
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        return new TtsController(logger.Object, config);
+        return new TtsController(logger.Object, config, reporter);
     }
 
     [Fact]
@@ -38,9 +38,9 @@ public class TtsControllerKeysUsageTests
         var reporter = new Mock<IKeysUsageReporter>();
         reporter.Setup(r => r.GetKeysUsage()).Returns(new[] { snapshot });
 
-        var controller = CreateController();
+        var controller = CreateController(reporter.Object);
 
-        var result = controller.GetKeysUsage(reporter.Object);
+        var result = controller.GetKeysUsage();
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var dtos = Assert.IsAssignableFrom<IReadOnlyList<TtsKeyUsageDto>>(ok.Value);
@@ -71,8 +71,8 @@ public class TtsControllerKeysUsageTests
         var reporter = new Mock<IKeysUsageReporter>();
         reporter.Setup(r => r.GetKeysUsage()).Returns(snapshots);
 
-        var controller = CreateController();
-        var result = controller.GetKeysUsage(reporter.Object);
+        var controller = CreateController(reporter.Object);
+        var result = controller.GetKeysUsage();
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var dtos = Assert.IsAssignableFrom<IReadOnlyList<TtsKeyUsageDto>>(ok.Value);
@@ -89,8 +89,8 @@ public class TtsControllerKeysUsageTests
         var reporter = new Mock<IKeysUsageReporter>();
         reporter.Setup(r => r.GetKeysUsage()).Returns(Array.Empty<ApiKeyUsageSnapshot>());
 
-        var controller = CreateController();
-        var result = controller.GetKeysUsage(reporter.Object);
+        var controller = CreateController(reporter.Object);
+        var result = controller.GetKeysUsage();
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var dtos = Assert.IsAssignableFrom<IReadOnlyList<TtsKeyUsageDto>>(ok.Value);


### PR DESCRIPTION
<!-- claude-session: ec307da9-6b00-4e2f-8f17-c5e21d3d09c6 -->

Follows up #1063. All three Copilot comments addressed.

## Summary
- **XSS hardening in Tts.cshtml** — every server-controlled string (`lastErrorReason`, time strings injected into a `title` attribute) now flows through `escapeHtml`. Numeric fields (`index`, `consecutiveFailures`) coerced via `| 0`.
- **State whitelist** — the `state-${...}` CSS class is constrained to a 6-value whitelist (`Available`, `RateLimited`, `QuotaExceeded`, `Invalid`, `TemporaryError`, `MonthlyLimitExceeded`); anything else falls back to `state-Unknown`. Defense-in-depth against schema drift.
- **Testable controller** — introduced `IKeysUsageReporter` abstraction (default `GoogleCloudKeysUsageReporter` delegates to `GoogleCloudMultiKeyTtsProvider.GetKeysUsage()`). `TtsController` now depends on the interface, registered as singleton in DI.
- **3 new controller tests** — DTO mapping, all parked-state values render to string, empty-key list returns empty DTO list.

## Test plan
- [x] `dotnet build` green
- [x] 3/3 new tests pass (`TtsControllerKeysUsageTests`)
- [x] All non-integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)