### PR TITLE
chore(deploy): pass --commit to ghnotify send

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,9 +208,15 @@ jobs:
             # different naming convention (e.g. `claude-<user>-<tty>`).
             # That failure mode lost the wake for run #456 on
             # 2026-05-02 even though the deploy itself succeeded.
+            #
+            # Use the full $GITHUB_SHA, NOT the short $COMMIT_SHA
+            # (defined above as ${GITHUB_SHA:0:7} for filenames/log
+            # display). The commits/SHA/pulls endpoint is unreliable
+            # with abbreviated SHAs — short SHAs can be ambiguous
+            # across the repo's history.
             ghnotify send \
               --repo "$GITHUB_REPOSITORY" \
-              --commit "$COMMIT_SHA" \
+              --commit "$GITHUB_SHA" \
               --prompt "$WAKE_PROMPT" || \
               echo "ghnotify send failed; wake not delivered" >&2
           else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,7 +200,18 @@ jobs:
           # non-interactive runners) is the robust approach.
           export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
           if command -v ghnotify > /dev/null 2>&1; then
-            ghnotify send --repo "$GITHUB_REPOSITORY" --prompt "$WAKE_PROMPT" || \
+            # Pass --commit so ghnotify can resolve the PR-author UUID
+            # via `gh api commits/SHA/pulls` and route to the session
+            # that opened the PR. Without it, ghnotify falls back to
+            # repo-name routing (`claude-VirtualAssistant-*`), which
+            # silently fails on machines whose tmux sessions follow a
+            # different naming convention (e.g. `claude-<user>-<tty>`).
+            # That failure mode lost the wake for run #456 on
+            # 2026-05-02 even though the deploy itself succeeded.
+            ghnotify send \
+              --repo "$GITHUB_REPOSITORY" \
+              --commit "$COMMIT_SHA" \
+              --prompt "$WAKE_PROMPT" || \
               echo "ghnotify send failed; wake not delivered" >&2
           else
             echo "ghnotify CLI not found on PATH (looked in: $PATH) — install via 'cargo install --path /home/jirka/Olbrasoft/ghnotify'" >&2


### PR DESCRIPTION
<!-- claude-session: e143e465-2e2a-41b6-9e08-4a4e73434d7e -->

## Summary

Add `--commit \"$COMMIT_SHA\"` to the deploy.yml `ghnotify send` invocation so post-deploy wakes route via the PR-author UUID instead of repo name.

## Why

Run #456 on 2026-05-02 deployed successfully but the wake never reached the user's Claude session. Deploy step stderr:

```
no tmux session for repo 'Olbrasoft/VirtualAssistant'
(looked for 'claude-VirtualAssistant' or 'claude-VirtualAssistant-*').
ghnotify send failed; wake not delivered
```

The user's actual VA session is `claude-jirka-pts-9` (per-tty `claude-<user>-<tty>` naming), so repo-name routing can't find it. With `--commit` ghnotify does the same `commits/SHA/pulls` PR-body lookup the webhook side already uses to extract the `<!-- claude-session: UUID -->` marker and route to the PR author.

## Dependency / merge order

This PR depends on **Olbrasoft/ghnotify#22** (adds `--commit` flag). DO NOT MERGE until:
1. ghnotify#22 is merged.
2. The self-hosted runner's `ghnotify` binary is rebuilt from main: `cargo install --path .`.

Otherwise the next deploy fails on the unknown `--commit` flag.

## Test plan

- [ ] Merge ghnotify#22 first.
- [ ] Rebuild ghnotify binary on the runner.
- [ ] Merge this PR.
- [ ] Next push to main triggers deploy → confirm wake lands on the PR-author session, not on whichever `claude-VirtualAssistant-*` happens to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)